### PR TITLE
fix: console.log → console.error in tool layer (MCP stdio corruption)

### DIFF
--- a/src/tools/UnifiedSearchTool.ts
+++ b/src/tools/UnifiedSearchTool.ts
@@ -7,6 +7,8 @@ import { KnowledgeQuery } from '../types/index.js'
 import { FACTCache } from '../cache/FACTCache.js'
 import { MongoDBStorage, Neo4jStorage, Mem0Storage } from '../storage/index.js'
 
+const debug = (...args: unknown[]) => { if (process.env.KMS_DEBUG) console.error(...args) }
+
 export class UnifiedSearchTool {
   private storage: {
     mongodb: MongoDBStorage
@@ -68,10 +70,10 @@ export class UnifiedSearchTool {
   }> {
     const startTime = Date.now()
     
-    console.error(`\n🔍 UNIFIED SEARCH Starting...`)
-    console.error(`📝 Query: "${args.query}"`)
-    console.error(`🎯 Filters: ${JSON.stringify(args.filters || {})}`)
-    console.error(`⚙️  Options: ${JSON.stringify(args.options || {})}`)
+    debug(`\n🔍 UNIFIED SEARCH Starting...`)
+    debug(`📝 Query: "${args.query}"`)
+    debug(`🎯 Filters: ${JSON.stringify(args.filters || {})}`)
+    debug(`⚙️  Options: ${JSON.stringify(args.options || {})}`)
 
     const defaultUserId = process.env.KMS_DEFAULT_USER_ID || 'personal'
     const enforceUserId = (filters?: typeof args.filters) => {
@@ -101,7 +103,7 @@ export class UnifiedSearchTool {
     const cacheCheckTime = Date.now() - cacheCheckStart
     
     if (cached && query.options?.cacheStrategy !== 'realtime') {
-      console.error(`⚡ CACHE HIT - Returning cached results`)
+      debug(`⚡ CACHE HIT - Returning cached results`)
       
       return {
         query: query.query,
@@ -119,7 +121,7 @@ export class UnifiedSearchTool {
       }
     }
 
-    console.error(`💾 Cache miss - Searching all systems...`)
+    debug(`💾 Cache miss - Searching all systems...`)
 
     // Step 2: Search across all systems in parallel
     const searchStart = Date.now()
@@ -141,10 +143,10 @@ export class UnifiedSearchTool {
       mongodb: mongoResults.status === 'fulfilled' ? mongoResults.value : []
     }
 
-    console.error(`📊 Results found:`)
-    console.error(`   Mem0: ${processedResults.mem0.length}`)
-    console.error(`   Neo4j: ${processedResults.neo4j.length}`)
-    console.error(`   MongoDB: ${processedResults.mongodb.length}`)
+    debug(`📊 Results found:`)
+    debug(`   Mem0: ${processedResults.mem0.length}`)
+    debug(`   Neo4j: ${processedResults.neo4j.length}`)
+    debug(`   MongoDB: ${processedResults.mongodb.length}`)
 
     // Merge all results
     const allResults = [
@@ -208,14 +210,14 @@ export class UnifiedSearchTool {
     if (this.cache && query.options?.cacheStrategy !== 'realtime') {
       const ttl = this.getCacheTTL(query.options?.cacheStrategy || 'conservative')
       await this.cache.set(cacheKey, result, ttl)
-      console.error(`💾 Results cached for ${Math.round(ttl/1000)}s`)
+      debug(`💾 Results cached for ${Math.round(ttl/1000)}s`)
     }
 
-    console.error(`\n✅ UNIFIED SEARCH COMPLETE`)
-    console.error(`   Found: ${sortedResults.length} unique results`)
-    console.error(`   Entities: ${Object.keys(entity_context).length}`)
-    console.error(`   Triggered: ${triggered_actions.length}`)
-    console.error(`   Total Time: ${result.searchTime}ms`)
+    debug(`\n✅ UNIFIED SEARCH COMPLETE`)
+    debug(`   Found: ${sortedResults.length} unique results`)
+    debug(`   Entities: ${Object.keys(entity_context).length}`)
+    debug(`   Triggered: ${triggered_actions.length}`)
+    debug(`   Total Time: ${result.searchTime}ms`)
 
     return result
   }
@@ -323,7 +325,7 @@ export class UnifiedSearchTool {
     system: 'mem0' | 'neo4j' | 'mongodb',
     query: KnowledgeQuery
   ): Promise<any[]> {
-    console.error(`🔍 Searching ${system} only...`)
+    debug(`🔍 Searching ${system} only...`)
     
     switch (system) {
       case 'mem0':

--- a/src/tools/UnifiedStoreTool.ts
+++ b/src/tools/UnifiedStoreTool.ts
@@ -11,6 +11,8 @@ import { FACTCache } from '../cache/FACTCache.js'
 import { MongoDBStorage, Neo4jStorage, Mem0Storage } from '../storage/index.js'
 import { ContentInference } from '../inference/ContentInference.js'
 
+const debug = (...args: unknown[]) => { if (process.env.KMS_DEBUG) console.error(...args) }
+
 export class UnifiedStoreTool {
   private router: IntelligentStorageRouter
   private storage: {
@@ -65,8 +67,8 @@ export class UnifiedStoreTool {
   }> {
     const startTime = Date.now()
 
-    console.error(`\n🚀 UNIFIED STORE Starting...`)
-    console.error(`📝 Content: "${args.content.slice(0, 100)}${args.content.length > 100 ? '...' : ''}"`)
+    debug(`\n🚀 UNIFIED STORE Starting...`)
+    debug(`📝 Content: "${args.content.slice(0, 100)}${args.content.length > 100 ? '...' : ''}"`)
 
     // Apply smart inference if needed
     let enrichedArgs = { ...args }
@@ -75,7 +77,7 @@ export class UnifiedStoreTool {
     // Use inference to fill in missing parameters
     if (!args.contentType) {
       enrichedArgs.contentType = inference.contentType
-      console.error(`🧠 Inferred content type: ${inference.contentType} (confidence: ${inference.confidence})`)
+      debug(`🧠 Inferred content type: ${inference.contentType} (confidence: ${inference.confidence})`)
     }
 
     if (!args.source) {
@@ -87,7 +89,7 @@ export class UnifiedStoreTool {
       } else {
         enrichedArgs.source = 'cross_domain'
       }
-      console.error(`🧠 Inferred source: ${enrichedArgs.source}`)
+      debug(`🧠 Inferred source: ${enrichedArgs.source}`)
     }
 
     // Enhance metadata with inference
@@ -103,13 +105,13 @@ export class UnifiedStoreTool {
     if (!args.relationships || args.relationships.length === 0) {
       const suggestedRelationships = ContentInference.suggestRelationships(args.content)
       if (suggestedRelationships.length > 0) {
-        console.error(`💡 Suggested relationships: ${suggestedRelationships.map(r => r.type).join(', ')}`)
+        debug(`💡 Suggested relationships: ${suggestedRelationships.map(r => r.type).join(', ')}`)
       }
     }
 
-    console.error(`🏷️  Type: ${enrichedArgs.contentType}, Source: ${enrichedArgs.source}`)
-    console.error(`👤 User: ${enrichedArgs.userId || 'auto'}, Context: ${inference.detectedProject || 'general'}`)
-    console.error(`🏷️  Tags: ${enhancedMetadata.tags?.join(', ') || 'none'}`)
+    debug(`🏷️  Type: ${enrichedArgs.contentType}, Source: ${enrichedArgs.source}`)
+    debug(`👤 User: ${enrichedArgs.userId || 'auto'}, Context: ${inference.detectedProject || 'general'}`)
+    debug(`🏷️  Tags: ${enhancedMetadata.tags?.join(', ') || 'none'}`)
 
     const defaultUserId = process.env.KMS_DEFAULT_USER_ID || 'personal'
     const resolvedUserId = enrichedArgs.userId || defaultUserId
@@ -164,11 +166,11 @@ export class UnifiedStoreTool {
 
     const routingTime = Date.now() - routingStartTime
 
-    console.error(`\n🧠 STORAGE DECISION:`)
-    console.error(`   Primary: ${decision.primary}`)
-    console.error(`   Secondary: ${decision.secondary?.join(', ') || 'none'}`)
-    console.error(`   Cache Strategy: ${decision.cacheStrategy}`)
-    console.error(`   Reasoning: ${decision.reasoning}`)
+    debug(`\n🧠 STORAGE DECISION:`)
+    debug(`   Primary: ${decision.primary}`)
+    debug(`   Secondary: ${decision.secondary?.join(', ') || 'none'}`)
+    debug(`   Cache Strategy: ${decision.cacheStrategy}`)
+    debug(`   Reasoning: ${decision.reasoning}`)
 
     // Step 2: Store in systems
     const storageStartTime = Date.now()
@@ -179,12 +181,12 @@ export class UnifiedStoreTool {
 
       // Store in secondary systems (for cross-linking)
       if (secondarySystems.length > 0) {
-        console.error(`\n🔗 Cross-linking to secondary systems...`)
+        debug(`\n🔗 Cross-linking to secondary systems...`)
         await Promise.all(
           secondarySystems.map(async (system) => {
             try {
               await this.storeInSystem(knowledge, system)
-              console.error(`✅ Cross-stored in ${system}`)
+              debug(`✅ Cross-stored in ${system}`)
             } catch (error) {
               console.warn(`⚠️ Failed to cross-store in ${system}:`, error instanceof Error ? error.message : String(error))
             }
@@ -213,16 +215,16 @@ export class UnifiedStoreTool {
           await this.cache.set(cacheKey, knowledge, ttl)
           cached = true
           
-          console.error(`💾 Cached with ${decision.cacheStrategy} strategy (TTL: ${Math.round(ttl/1000)}s)`)
+          debug(`💾 Cached with ${decision.cacheStrategy} strategy (TTL: ${Math.round(ttl/1000)}s)`)
         }
       }
 
       const totalTime = Date.now() - startTime
 
-      console.error(`\n✅ UNIFIED STORE COMPLETE`)
-      console.error(`   ID: ${knowledge.id}`)
-      console.error(`   Total Time: ${totalTime}ms`)
-      console.error(`   Systems: ${[decision.primary, ...(decision.secondary || [])].join(', ')}`)
+      debug(`\n✅ UNIFIED STORE COMPLETE`)
+      debug(`   ID: ${knowledge.id}`)
+      debug(`   Total Time: ${totalTime}ms`)
+      debug(`   Systems: ${[decision.primary, ...(decision.secondary || [])].join(', ')}`)
 
       return {
         success: true,
@@ -257,7 +259,7 @@ export class UnifiedStoreTool {
    * Store knowledge in a specific system
    */
   private async storeInSystem(knowledge: UnifiedKnowledge, system: SystemName): Promise<void> {
-    console.error(`📊 Storing in ${system}...`)
+    debug(`📊 Storing in ${system}...`)
     
     switch (system) {
       case 'mem0':
@@ -273,7 +275,7 @@ export class UnifiedStoreTool {
         throw new Error(`Unknown storage system: ${system}`)
     }
     
-    console.error(`✅ Successfully stored in ${system}`)
+    debug(`✅ Successfully stored in ${system}`)
   }
 
   /**
@@ -297,9 +299,9 @@ export class UnifiedStoreTool {
     contentType?: string
     metadata?: Record<string, any>
   }): StorageDecision {
-    console.error(`\n🤔 STORAGE RECOMMENDATION REQUEST`)
-    console.error(`📝 Content: "${args.content.slice(0, 100)}..."`)
-    console.error(`🏷️  Type: ${args.contentType || 'auto-detect'}`)
+    debug(`\n🤔 STORAGE RECOMMENDATION REQUEST`)
+    debug(`📝 Content: "${args.content.slice(0, 100)}..."`)
+    debug(`🏷️  Type: ${args.contentType || 'auto-detect'}`)
 
     const decision = this.router.determineStorage({
       content: args.content,
@@ -307,11 +309,11 @@ export class UnifiedStoreTool {
       metadata: args.metadata
     })
 
-    console.error(`\n💡 RECOMMENDATION:`)
-    console.error(`   Primary: ${decision.primary}`)
-    console.error(`   Secondary: ${decision.secondary?.join(', ') || 'none'}`)
-    console.error(`   Cache: ${decision.cacheStrategy}`)
-    console.error(`   Why: ${decision.reasoning}`)
+    debug(`\n💡 RECOMMENDATION:`)
+    debug(`   Primary: ${decision.primary}`)
+    debug(`   Secondary: ${decision.secondary?.join(', ') || 'none'}`)
+    debug(`   Cache: ${decision.cacheStrategy}`)
+    debug(`   Why: ${decision.reasoning}`)
 
     return decision
   }
@@ -326,7 +328,7 @@ export class UnifiedStoreTool {
       decision: StorageDecision
     }>
   }> {
-    console.error(`\n🧪 TESTING ROUTING LOGIC`)
+    debug(`\n🧪 TESTING ROUTING LOGIC`)
 
     const testCases = [
       {
@@ -357,9 +359,9 @@ export class UnifiedStoreTool {
         contentType: test.contentType as any
       })
 
-      console.error(`\n📝 "${test.content.slice(0, 50)}..."`)
-      console.error(`   Type: ${test.contentType} → ${decision.primary}`)
-      console.error(`   Reasoning: ${decision.reasoning}`)
+      debug(`\n📝 "${test.content.slice(0, 50)}..."`)
+      debug(`   Type: ${test.contentType} → ${decision.primary}`)
+      debug(`   Reasoning: ${decision.reasoning}`)
 
       return {
         content: test.content,


### PR DESCRIPTION
## **User description**
## Summary
- Changed all `console.log` to `console.error` in `UnifiedStoreTool` and `UnifiedSearchTool`
- `console.log` writes to stdout, which corrupts JSON-RPC framing in MCP stdio mode
- `console.error` writes to stderr — safe for MCP

## Files changed
- `src/tools/UnifiedStoreTool.ts` — 30 console.log → console.error
- `src/tools/UnifiedSearchTool.ts` — 21 console.log → console.error

## Test plan
- [x] `npm run build` clean
- [ ] Verify MCP client receives clean JSON-RPC responses when store/search triggered

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep MCP responses clean during store and search actions**

### What Changed
- Store and search activity messages now go to error output instead of standard output
- This prevents MCP JSON-RPC responses from being mixed with log text when users run search, store, or recommendation actions
- Status messages still appear in logs, but no longer interfere with tool responses

### Impact
`✅ Clean MCP responses`
`✅ Fewer broken store and search calls in stdio mode`
`✅ More reliable tool output for MCP clients`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
