### PR TITLE
perf: batch SparrowDB findRelated — O(N×D) → O(D) queries per depth

### DIFF
--- a/src/storage/SparrowDBStorage.ts
+++ b/src/storage/SparrowDBStorage.ts
@@ -469,13 +469,13 @@ export class SparrowDBStorage implements StorageSystem {
             `MATCH (a:Knowledge)-[:RELATED_TO]->(b:Knowledge) WHERE a.id IN [${idList}] RETURN b.id`
           )
           neighbourRows.push(...out.rows)
-        } catch { /* ignore */ }
+        } catch (e) { console.warn('⚠️ SparrowDB findRelated outgoing query failed at depth', depth, e) }
         try {
           const inc = this.db.execute(
             `MATCH (b:Knowledge)-[:RELATED_TO]->(a:Knowledge) WHERE a.id IN [${idList}] RETURN b.id`
           )
           neighbourRows.push(...inc.rows)
-        } catch { /* ignore */ }
+        } catch (e) { console.warn('⚠️ SparrowDB findRelated incoming query failed at depth', depth, e) }
 
         const next: string[] = []
         for (const row of neighbourRows) {


### PR DESCRIPTION
## **User description**
## Summary
SparrowDB \`findRelated\` was firing 2 queries per node per depth level. For a frontier of N nodes at depth D: **2×N×D total queries**.

Replaced with 2 batched queries per depth using \`WHERE a.id IN [id1, id2, ...]\` covering the entire frontier. Now **exactly 2 queries per depth** regardless of frontier size.

## Before
\`\`\`
depth=1: 2 × frontier_size queries
depth=2: 2 × new_frontier_size queries
\`\`\`

## After
\`\`\`
depth=1: 2 queries (batch out + in for entire frontier)
depth=2: 2 queries (batch out + in for entire next frontier)
\`\`\`

## Files changed
- \`src/storage/SparrowDBStorage.ts\` — \`findRelated\` only

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized the batch processing of graph traversal queries when retrieving related knowledge items. The underlying storage layer now processes frontier nodes more efficiently, reducing the number of individual query executions and improving response times for related knowledge discovery. Frontier termination logic has also been refined for better control flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Speed up related-item lookup in SparrowDB**

### What Changed
- Related-item lookup now checks each depth level in a single batch instead of running one query per item, so results return with fewer database round trips.
- It stops searching as soon as there are no more related items to follow, avoiding extra work on empty levels.
- Existing related-item matching and result handling stay the same, including support for shortened IDs.

### Impact
`✅ Faster related-item results`
`✅ Fewer slowdowns on large result sets`
`✅ Lower database load during graph lookup`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
