### PR TITLE
feat: edge strength properties on RELATED_TO and ABOUT (closes #13)

### DIFF
--- a/src/storage/SparrowDBStorage.ts
+++ b/src/storage/SparrowDBStorage.ts
@@ -246,10 +246,10 @@ export class SparrowDBStorage implements StorageSystem {
     this.contentIndex.set(knowledge.id, entry)
     this._saveSidecar()
 
-    // Create explicit relationships (no properties on edges — SparrowDB limitation).
+    // Create explicit relationships with optional strength property.
     if (knowledge.relationships && knowledge.relationships.length > 0) {
       for (const rel of knowledge.relationships) {
-        await this._createRelationship(knowledge.id, rel.targetId, rel.type)
+        await this._createRelationship(knowledge.id, rel.targetId, rel.type, rel.strength)
       }
     }
 
@@ -467,13 +467,13 @@ export class SparrowDBStorage implements StorageSystem {
         const neighbourRows: Array<Record<string, unknown>> = []
         try {
           const out = this.db.execute(
-            `MATCH (a:Knowledge)-[:RELATED_TO]->(b:Knowledge) WHERE a.id IN [${idList}] RETURN b.id`
+            `MATCH (a:Knowledge)-[r:RELATED_TO]->(b:Knowledge) WHERE a.id IN [${idList}] RETURN b.id, r.strength`
           )
           neighbourRows.push(...out.rows)
         } catch (e) { console.warn('⚠️ SparrowDB findRelated outgoing query failed at depth', depth, e) }
         try {
           const inc = this.db.execute(
-            `MATCH (b:Knowledge)-[:RELATED_TO]->(a:Knowledge) WHERE a.id IN [${idList}] RETURN b.id`
+            `MATCH (b:Knowledge)-[r:RELATED_TO]->(a:Knowledge) WHERE a.id IN [${idList}] RETURN b.id, r.strength`
           )
           neighbourRows.push(...inc.rows)
         } catch (e) { console.warn('⚠️ SparrowDB findRelated incoming query failed at depth', depth, e) }
@@ -481,6 +481,11 @@ export class SparrowDBStorage implements StorageSystem {
         const next: string[] = []
         for (const row of neighbourRows) {
           const rawId = String(row['b.id'] ?? '')
+          // Stored as integer × 100 — divide back to 0.0–1.0 float (SparrowDB#229 workaround).
+          const rawStrength = row['r.strength']
+          const edgeStrength = rawStrength !== undefined && rawStrength !== null
+            ? Math.round(parseFloatSafe(rawStrength)) / 100
+            : undefined
           // rawId may be truncated to 7 chars — use prefix search to
           // resolve all matching sidecar entries.
           const matches = this._findAllEntriesByPrefix(rawId)
@@ -499,6 +504,7 @@ export class SparrowDBStorage implements StorageSystem {
               content: fullEntry.content,
               confidence: fullEntry.confidence,
               distance: depth,
+              ...(edgeStrength !== undefined && { strength: edgeStrength }),
               pathTypes: ['RELATED_TO'],
               sourceSystem: 'sparrowdb'
             })
@@ -678,7 +684,7 @@ export class SparrowDBStorage implements StorageSystem {
         this.db.execute(
           `MATCH (k:Knowledge {id: ${cypherStr(sourceId)}}), ` +
           `(e {id: ${cypherStr(targetId)}}) ` +
-          `CREATE (k)-[:ABOUT]->(e)`
+          `CREATE (k)-[:ABOUT {strength: 100}]->(e)`
         )
       } catch (error) {
         logger.warn(`⚠️ SparrowDB createAboutRelationships ${sourceId} → ${targetId}:`, error)
@@ -730,14 +736,20 @@ export class SparrowDBStorage implements StorageSystem {
   private async _createRelationship(
     sourceId: string,
     targetId: string,
-    relationshipType: string
+    relationshipType: string,
+    strength?: number
   ): Promise<void> {
     try {
       const safeRelType = relationshipType.toUpperCase().replace(/[^A-Z0-9_]/g, '_')
+      // SparrowDB edge props only support integers (SparrowDB#229: float panics).
+      // Store strength × 100 as integer (0–100); divide by 100 on read.
+      const props = (strength !== undefined && strength >= 0 && strength <= 1)
+        ? ` {strength: ${Math.round(strength * 100)}}`
+        : ''
       this.db.execute(
         `MATCH (a:Knowledge {id: ${cypherStr(sourceId)}}), ` +
         `(b:Knowledge {id: ${cypherStr(targetId)}}) ` +
-        `CREATE (a)-[:${safeRelType}]->(b)`
+        `CREATE (a)-[:${safeRelType}${props}]->(b)`
       )
     } catch (error) {
       logger.warn(`⚠️ SparrowDB createRelationship ${relationshipType}:`, error)

--- a/src/storage/SparrowDBStorage.ts
+++ b/src/storage/SparrowDBStorage.ts
@@ -483,7 +483,7 @@ export class SparrowDBStorage implements StorageSystem {
           const rawId = String(row['b.id'] ?? '')
           // Stored as integer × 100 — divide back to 0.0–1.0 float (SparrowDB#229 workaround).
           const rawStrength = row['r.strength']
-          const edgeStrength = rawStrength !== undefined && rawStrength !== null
+          const edgeStrength = rawStrength != null
             ? Math.round(parseFloatSafe(rawStrength)) / 100
             : undefined
           // rawId may be truncated to 7 chars — use prefix search to
@@ -743,9 +743,14 @@ export class SparrowDBStorage implements StorageSystem {
       const safeRelType = relationshipType.toUpperCase().replace(/[^A-Z0-9_]/g, '_')
       // SparrowDB edge props only support integers (SparrowDB#229: float panics).
       // Store strength × 100 as integer (0–100); divide by 100 on read.
-      const props = (strength !== undefined && strength >= 0 && strength <= 1)
-        ? ` {strength: ${Math.round(strength * 100)}}`
-        : ''
+      let props = ''
+      if (strength !== undefined) {
+        if (strength >= 0 && strength <= 1) {
+          props = ` {strength: ${Math.round(strength * 100)}}`
+        } else {
+          logger.warn(`⚠️ Invalid strength value for relationship ${relationshipType}: ${strength}. Must be between 0 and 1. Ignoring strength property.`)
+        }
+      }
       this.db.execute(
         `MATCH (a:Knowledge {id: ${cypherStr(sourceId)}}), ` +
         `(b:Knowledge {id: ${cypherStr(targetId)}}) ` +


### PR DESCRIPTION
## **User description**
## Summary
- `unified_store` with explicit `relationships: [{targetId, type, strength: 0.9}]` now persists strength on the graph edge
- `ABOUT` edges (EntityLinker auto-links) get `strength: 1.0`
- `findRelated()` BFS returns `strength` on each result node

## Storage encoding
SparrowDB edge properties currently only support integers (SparrowDB#229 — float literals panic in `node_store.rs`). Strength is stored as `integer × 100` (e.g. `0.85 → 85`) and decoded on read. Comment in code tracks the upstream issue.

## Verified
```
Raw from DB: [{"a.id":"node-a","b.id":"node-b","r.strength":85}]
Decoded strength: 0.85
```

## Closes
- #13 (relationship strength property)

## References
- SparrowDB PR #227 (edge property support)
- SparrowDB issue #229 (float edge prop panic — workaround in place)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Relationships now support optional strength values (0–1 scale) for quantifying relationship intensity

* **Refactor**
  * Improved relationship storage and retrieval to handle strength properties consistently
  * Enhanced relationship traversal logic for proper read and conversion of strength values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Store and return relationship strength on graph links**

### What Changed
- Explicit relationships now keep their strength when saved, instead of dropping that information
- `ABOUT` links are created with full strength, so auto-linked entities are treated as direct matches
- Related-item results now include strength when available, so callers can show or rank by link confidence

### Impact
`✅ Clearer relationship confidence`
`✅ More useful related-item results`
`✅ Stronger auto-linked entity matches`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
