### PR TITLE
fix: length penalty in Neo4j fulltext score normalization

### DIFF
--- a/dist/storage/Neo4jStorage.js
+++ b/dist/storage/Neo4jStorage.js
@@ -257,7 +257,17 @@ export class Neo4jStorage {
                 return {
                     id: node.id || node.name,
                     content,
-                    confidence: Math.min(score / 5, 1), // normalize fulltext score to 0-1
+                    // Normalize fulltext score with a document-length penalty.
+                    // Long documents (archive articles, full texts) match many query terms and
+                    // generate inflated scores, pushing out precise short facts. Penalize content
+                    // >500 chars so large documents can't dominate context injection results.
+                    // A 4000-char article gets ~0.60× penalty; a 200-char fact gets no penalty.
+                    confidence: (() => {
+                        const raw = Math.min(score / 5, 1);
+                        const len = content.length;
+                        const lengthPenalty = len <= 500 ? 1.0 : Math.pow(500 / len, 0.25);
+                        return raw * lengthPenalty;
+                    })(),
                     metadata: (() => {
                         if (!node.metadata)
                             return node;

--- a/src/storage/Neo4jStorage.ts
+++ b/src/storage/Neo4jStorage.ts
@@ -282,7 +282,17 @@ export class Neo4jStorage implements GraphStorage {
         return {
           id: node.id || node.name,
           content,
-          confidence: Math.min(score / 5, 1), // normalize fulltext score to 0-1
+          // Normalize fulltext score with a document-length penalty.
+          // Long documents (archive articles, full texts) match many query terms and
+          // generate inflated scores, pushing out precise short facts. Penalize content
+          // >500 chars so large documents can't dominate context injection results.
+          // A 4000-char article gets ~0.60× penalty; a 200-char fact gets no penalty.
+          confidence: (() => {
+            const raw = Math.min(score / 5, 1)
+            const len = content.length
+            const lengthPenalty = len <= 500 ? 1.0 : Math.pow(500 / len, 0.25)
+            return raw * lengthPenalty
+          })(),
           metadata: (() => {
             if (!node.metadata) return node
             try { return JSON.parse(node.metadata) } catch { return node }


### PR DESCRIPTION
## Problem

Large documents (archive articles, full texts) were getting `confidence=1.0` against virtually any query, flooding context injection results. A 4000-char NYT article about Richard Yaker's early startup (ShareiTunes) was appearing at the top of every `unified_search` call regardless of query.

**Root cause:** `Math.min(score / 5, 1)` — the fulltext confidence normalization ignores document length. Neo4j/Lucene fulltext scores scale with term frequency × document coverage, so long documents with many matching terms systematically outrank precise short facts.

## Fix

Apply a document-length penalty for content > 500 chars:
```
penalty = (500 / contentLength)^0.25
confidence = Math.min(score / 5, 1) × penalty
```

**Effect:**
| Content length | Penalty | Max confidence |
|---|---|---|
| ≤ 500 chars | 1.00 | 1.00 (unchanged) |
| 1000 chars | 0.84 | 0.84 |
| 2000 chars | 0.71 | 0.71 |
| 4000 chars | 0.60 | **0.60** (below 0.70 injection threshold) |

Short facts and precise memories are unaffected. Full-text archive documents can no longer dominate context injection.

## Test plan

- [ ] Context injection hook (`kms-context-inject.sh`) no longer returns the NYT article for unrelated queries
- [ ] Short facts (< 500 chars) still surface with same confidence as before
- [ ] Legitimate long procedures/notes (1000-2000 chars) still pass the 0.70 threshold when genuinely relevant

🤖 Generated with [Claude Code](https://claude.com/claude-code)