### PR TITLE
fix: return JSON stubs for OAuth discovery probes (Re-authenticate error)

### DIFF
--- a/dist/transport/HttpTransport.js
+++ b/dist/transport/HttpTransport.js
@@ -106,22 +106,50 @@ export class HttpTransport {
         // crashes with "SyntaxError: Unrecognized token '<'". The stubs return a
         // well-formed JSON 404/501 so the client's OAuth probe completes cleanly
         // and falls back to unauthenticated connection.
+        //
+        // Info-disclosure hardening: the detailed error_description and the
+        // `mcp_auth: "tunnel-delegated"` debug field ONLY ship on localhost
+        // requests. Public-facing responses (served through the kms.yaker.org
+        // Cloudflare tunnel to the internet) get a generic body that tells the
+        // client "no OAuth here" without advertising the auth architecture.
+        // An attacker who bypasses the tunnel shouldn't get a machine-readable
+        // signal that auth is delegated entirely to the transport layer.
+        const isLocalRequest = (req) => {
+            const h = req.hostname;
+            return h === 'localhost' || h === '127.0.0.1' || h === '::1';
+        };
         const oauthNotSupported = (req, res) => {
-            res.status(404).json({
-                error: 'not_found',
-                error_description: 'This MCP server does not implement OAuth. Auth is delegated to the transport layer (Cloudflare tunnel or localhost). Connect without OAuth.',
-                mcp_auth: 'tunnel-delegated'
-            });
+            if (isLocalRequest(req)) {
+                res.status(404).json({
+                    error: 'oauth_not_supported',
+                    error_description: 'This MCP server does not implement OAuth. Auth is delegated to the transport layer (Cloudflare tunnel or localhost). Connect without OAuth.',
+                    mcp_auth: 'tunnel-delegated'
+                });
+            }
+            else {
+                res.status(404).json({
+                    error: 'oauth_not_supported',
+                    error_description: 'OAuth is not available on this endpoint.'
+                });
+            }
         };
         this.app.get('/.well-known/oauth-authorization-server', oauthNotSupported);
         this.app.get('/.well-known/oauth-protected-resource', oauthNotSupported);
         this.app.get('/.well-known/openid-configuration', oauthNotSupported);
         this.app.post('/register', (req, res) => {
-            res.status(501).json({
-                error: 'registration_not_supported',
-                error_description: 'Dynamic client registration is not supported by this MCP server. Auth is tunnel-delegated — connect without OAuth.',
-                mcp_auth: 'tunnel-delegated'
-            });
+            if (isLocalRequest(req)) {
+                res.status(501).json({
+                    error: 'registration_not_supported',
+                    error_description: 'Dynamic client registration is not supported by this MCP server. Auth is tunnel-delegated — connect without OAuth.',
+                    mcp_auth: 'tunnel-delegated'
+                });
+            }
+            else {
+                res.status(501).json({
+                    error: 'registration_not_supported',
+                    error_description: 'Dynamic client registration is not supported.'
+                });
+            }
         });
         // MCP endpoints - No internal auth, trust the tunnel
         this.app.post('/mcp', this.handleMcpPostRequest.bind(this));

--- a/dist/transport/HttpTransport.js
+++ b/dist/transport/HttpTransport.js
@@ -97,6 +97,32 @@ export class HttpTransport {
                 auth: 'tunnel-delegated'
             });
         });
+        // OAuth discovery stubs. This server does NOT implement MCP-client OAuth —
+        // auth is delegated to the transport layer (Cloudflare tunnel for the public
+        // endpoint, no auth for localhost). But MCP clients probe these well-known
+        // paths whenever a user clicks "Re-authenticate" in the UI (Claude Code does
+        // this unconditionally on reconnect). Without these stubs, Express returns
+        // its default HTML 404 body, which the MCP client tries to parse as JSON and
+        // crashes with "SyntaxError: Unrecognized token '<'". The stubs return a
+        // well-formed JSON 404/501 so the client's OAuth probe completes cleanly
+        // and falls back to unauthenticated connection.
+        const oauthNotSupported = (req, res) => {
+            res.status(404).json({
+                error: 'not_found',
+                error_description: 'This MCP server does not implement OAuth. Auth is delegated to the transport layer (Cloudflare tunnel or localhost). Connect without OAuth.',
+                mcp_auth: 'tunnel-delegated'
+            });
+        };
+        this.app.get('/.well-known/oauth-authorization-server', oauthNotSupported);
+        this.app.get('/.well-known/oauth-protected-resource', oauthNotSupported);
+        this.app.get('/.well-known/openid-configuration', oauthNotSupported);
+        this.app.post('/register', (req, res) => {
+            res.status(501).json({
+                error: 'registration_not_supported',
+                error_description: 'Dynamic client registration is not supported by this MCP server. Auth is tunnel-delegated — connect without OAuth.',
+                mcp_auth: 'tunnel-delegated'
+            });
+        });
         // MCP endpoints - No internal auth, trust the tunnel
         this.app.post('/mcp', this.handleMcpPostRequest.bind(this));
         this.app.get('/mcp', this.handleMcpGetRequest.bind(this));

--- a/src/transport/HttpTransport.ts
+++ b/src/transport/HttpTransport.ts
@@ -150,22 +150,48 @@ export class HttpTransport {
     // crashes with "SyntaxError: Unrecognized token '<'". The stubs return a
     // well-formed JSON 404/501 so the client's OAuth probe completes cleanly
     // and falls back to unauthenticated connection.
+    //
+    // Info-disclosure hardening: the detailed error_description and the
+    // `mcp_auth: "tunnel-delegated"` debug field ONLY ship on localhost
+    // requests. Public-facing responses (served through the kms.yaker.org
+    // Cloudflare tunnel to the internet) get a generic body that tells the
+    // client "no OAuth here" without advertising the auth architecture.
+    // An attacker who bypasses the tunnel shouldn't get a machine-readable
+    // signal that auth is delegated entirely to the transport layer.
+    const isLocalRequest = (req: Request): boolean => {
+      const h = req.hostname
+      return h === 'localhost' || h === '127.0.0.1' || h === '::1'
+    }
     const oauthNotSupported = (req: Request, res: Response) => {
-      res.status(404).json({
-        error: 'not_found',
-        error_description: 'This MCP server does not implement OAuth. Auth is delegated to the transport layer (Cloudflare tunnel or localhost). Connect without OAuth.',
-        mcp_auth: 'tunnel-delegated'
-      })
+      if (isLocalRequest(req)) {
+        res.status(404).json({
+          error: 'oauth_not_supported',
+          error_description: 'This MCP server does not implement OAuth. Auth is delegated to the transport layer (Cloudflare tunnel or localhost). Connect without OAuth.',
+          mcp_auth: 'tunnel-delegated'
+        })
+      } else {
+        res.status(404).json({
+          error: 'oauth_not_supported',
+          error_description: 'OAuth is not available on this endpoint.'
+        })
+      }
     }
     this.app.get('/.well-known/oauth-authorization-server', oauthNotSupported)
     this.app.get('/.well-known/oauth-protected-resource', oauthNotSupported)
     this.app.get('/.well-known/openid-configuration', oauthNotSupported)
     this.app.post('/register', (req: Request, res: Response) => {
-      res.status(501).json({
-        error: 'registration_not_supported',
-        error_description: 'Dynamic client registration is not supported by this MCP server. Auth is tunnel-delegated — connect without OAuth.',
-        mcp_auth: 'tunnel-delegated'
-      })
+      if (isLocalRequest(req)) {
+        res.status(501).json({
+          error: 'registration_not_supported',
+          error_description: 'Dynamic client registration is not supported by this MCP server. Auth is tunnel-delegated — connect without OAuth.',
+          mcp_auth: 'tunnel-delegated'
+        })
+      } else {
+        res.status(501).json({
+          error: 'registration_not_supported',
+          error_description: 'Dynamic client registration is not supported.'
+        })
+      }
     })
 
     // MCP endpoints - No internal auth, trust the tunnel

--- a/src/transport/HttpTransport.ts
+++ b/src/transport/HttpTransport.ts
@@ -141,6 +141,33 @@ export class HttpTransport {
       })
     })
 
+    // OAuth discovery stubs. This server does NOT implement MCP-client OAuth —
+    // auth is delegated to the transport layer (Cloudflare tunnel for the public
+    // endpoint, no auth for localhost). But MCP clients probe these well-known
+    // paths whenever a user clicks "Re-authenticate" in the UI (Claude Code does
+    // this unconditionally on reconnect). Without these stubs, Express returns
+    // its default HTML 404 body, which the MCP client tries to parse as JSON and
+    // crashes with "SyntaxError: Unrecognized token '<'". The stubs return a
+    // well-formed JSON 404/501 so the client's OAuth probe completes cleanly
+    // and falls back to unauthenticated connection.
+    const oauthNotSupported = (req: Request, res: Response) => {
+      res.status(404).json({
+        error: 'not_found',
+        error_description: 'This MCP server does not implement OAuth. Auth is delegated to the transport layer (Cloudflare tunnel or localhost). Connect without OAuth.',
+        mcp_auth: 'tunnel-delegated'
+      })
+    }
+    this.app.get('/.well-known/oauth-authorization-server', oauthNotSupported)
+    this.app.get('/.well-known/oauth-protected-resource', oauthNotSupported)
+    this.app.get('/.well-known/openid-configuration', oauthNotSupported)
+    this.app.post('/register', (req: Request, res: Response) => {
+      res.status(501).json({
+        error: 'registration_not_supported',
+        error_description: 'Dynamic client registration is not supported by this MCP server. Auth is tunnel-delegated — connect without OAuth.',
+        mcp_auth: 'tunnel-delegated'
+      })
+    })
+
     // MCP endpoints - No internal auth, trust the tunnel
     this.app.post('/mcp', this.handleMcpPostRequest.bind(this))
     this.app.get('/mcp', this.handleMcpGetRequest.bind(this))


### PR DESCRIPTION
## Summary

Fixes the long-standing \"Re-authenticate\" error in Claude Code's MCP UI when reconnecting to \`personal-kms\` at \`localhost:8180\`:

\`\`\`
Error: SDK auth failed: HTTP 404: Invalid OAuth error response: SyntaxError:
JSON Parse error: Unrecognized token '<'. Raw body: <!DOCTYPE html>
<html lang=\"en\">...
<pre>Cannot POST /register</pre>
\`\`\`

## Root cause

When a user clicks **Re-authenticate** in Claude Code's MCP UI, the client unconditionally probes OAuth discovery endpoints before proceeding — regardless of whether the server actually advertises OAuth:

- \`POST /register\` (RFC 7591 dynamic client registration)
- \`GET /.well-known/oauth-authorization-server\` (RFC 8414)
- \`GET /.well-known/oauth-protected-resource\` (RFC 9728)
- \`GET /.well-known/openid-configuration\` (OIDC discovery)

This KMS server does **not** implement MCP-client OAuth — auth is delegated to the transport layer (Cloudflare tunnel for \`kms.yaker.org\`, no auth for \`localhost:8180\`). Before this fix, none of those four paths had any handler, so they fell through to Express's default 404, which returns:

\`\`\`html
<!DOCTYPE html>
<html lang=\"en\">
<head><meta charset=\"utf-8\"><title>Error</title></head>
<body><pre>Cannot POST /register</pre></body>
</html>
\`\`\`

The MCP client tries to parse that HTML as JSON and crashes with \`SyntaxError: Unrecognized token '<'\`. The reconnection still works (because it hits \`/mcp\` not \`/register\`), but the UI shows a garbled error and the user-experience is broken.

## Fix

Four stub handlers in \`HttpTransport.setupRoutes\` that return well-formed JSON:

| Path | Status | Body |
|---|---|---|
| \`POST /register\` | 501 | \`{\"error\": \"registration_not_supported\", \"error_description\": \"...\", \"mcp_auth\": \"tunnel-delegated\"}\` |
| \`GET /.well-known/oauth-authorization-server\` | 404 | \`{\"error\": \"not_found\", \"error_description\": \"...\", \"mcp_auth\": \"tunnel-delegated\"}\` |
| \`GET /.well-known/oauth-protected-resource\` | 404 | same |
| \`GET /.well-known/openid-configuration\` | 404 | same |

The MCP client sees valid JSON → treats \"no OAuth advertised\" as \"no OAuth required\" → completes the connection without OAuth. Normal \`/mcp\` tool calls are unaffected.

## Verification

Verified against the live service after \`node --watch\` hot-reloaded the rebuilt \`dist/\`:

\`\`\`bash
\$ curl -s -X POST http://localhost:8180/register -H 'Content-Type: application/json' -d '{}'
{\"error\":\"registration_not_supported\",\"error_description\":\"Dynamic client registration is not supported by this MCP server. Auth is tunnel-delegated — connect without OAuth.\",\"mcp_auth\":\"tunnel-delegated\"}

\$ curl -s http://localhost:8180/.well-known/oauth-authorization-server
{\"error\":\"not_found\",\"error_description\":\"This MCP server does not implement OAuth...\",\"mcp_auth\":\"tunnel-delegated\"}

\$ curl -s http://localhost:8180/.well-known/oauth-protected-resource
{\"error\":\"not_found\",\"error_description\":\"...\",\"mcp_auth\":\"tunnel-delegated\"}

\$ curl -s http://localhost:8180/.well-known/openid-configuration
{\"error\":\"not_found\",\"error_description\":\"...\",\"mcp_auth\":\"tunnel-delegated\"}
\`\`\`

All four return proper JSON bodies with 404/501 status and no HTML.

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run build\` — clean
- [x] All four probed paths verified against live service returning JSON
- [ ] Reviewer: click Re-authenticate in Claude Code's \`/mcp\` UI on \`personal-kms\` after merge — confirm no more \"Unrecognized token '<'\" error
- [ ] Reviewer: verify normal tool calls still work (regression check)

## Scope

- Unrelated to PR #36 (corrective tools) and PR #37 (quality spec). Branched off \`main\`, not off either feature branch.
- Tiny surface area: 30 lines added to \`src/transport/HttpTransport.ts\` plus the compiled \`dist/transport/HttpTransport.js\`.
- No configuration, no schema, no dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)