### PR TITLE
fix(build): repair broken-on-darwin sparrowdb consumption + regen TS surface

### DIFF
--- a/scripts/build-sparrowdb-node.sh
+++ b/scripts/build-sparrowdb-node.sh
@@ -38,7 +38,7 @@ if [[ ! -x "$NAPI_BIN" ]]; then
 fi
 
 echo "🦀 Building sparrowdb-node (cargo + .d.ts) from: $SPARROW_DIR"
-(cd "$SPARROW_DIR/npm/sparrowdb" && \
+(cd "$SPARROW_DIR/npm/sparrowdb" && rm -f index.*.node && \
   ./node_modules/.bin/napi build --release --platform \
     --dts index.d.ts --js false \
     --cargo-cwd ../../crates/sparrowdb-node \
@@ -58,7 +58,7 @@ cp "$SPARROW_DIR/npm/sparrowdb/index.d.ts"     "$KMSMCP_NODE_MODULES/index.d.ts"
 
 SIZE=$(ls -lh "$SPARROW_DIR/npm/sparrowdb/sparrowdb.node" | awk '{print $5}')
 DTS_LINES=$(wc -l < "$SPARROW_DIR/npm/sparrowdb/index.d.ts" | tr -d ' ')
-NEW_API_REFS=$(grep -c 'hybridSearch\|vectorSearch\|fulltextSearch' "$KMSMCP_NODE_MODULES/index.d.ts")
+NEW_API_REFS=$(grep -c 'hybridSearch\|vectorSearch\|fulltextSearch' "$KMSMCP_NODE_MODULES/index.d.ts" || true)
 echo "✅ Done."
 echo "   sparrowdb.node: $SIZE  (also copied to KMSmcp)"
 echo "   index.d.ts: $DTS_LINES lines  (also copied to KMSmcp)"

--- a/scripts/build-sparrowdb-node.sh
+++ b/scripts/build-sparrowdb-node.sh
@@ -1,9 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
-# Build sparrowdb-node NAPI binary and copy to npm/sparrowdb/sparrowdb.node
+# Build sparrowdb-node NAPI binary + regenerate TypeScript surface, then propagate
+# both into KMSmcp's node_modules/sparrowdb/.
+#
+# Why both targets matter:
+#   - SparrowDB's npm/sparrowdb/sparrowdb.node is the source-of-truth for any
+#     downstream that uses `file:../SparrowDB/npm/sparrowdb` as a dep.
+#   - KMSmcp currently consumes `sparrowdb@^0.1.20` from npm. The published
+#     tarball ships a Linux-ELF sparrowdb.node that fails to load on darwin-arm64,
+#     so we overwrite node_modules/sparrowdb/sparrowdb.node directly.
+#
+# napi-cli (declared in SparrowDB's npm/sparrowdb/devDependencies) does the
+# cargo build AND the .d.ts gen in one invocation; output is named
+# index.<platform>.node, which we then copy as sparrowdb.node.
+#
 # Usage: bash scripts/build-sparrowdb-node.sh [path-to-SparrowDB-repo]
 
 SPARROW_DIR="${1:-${SPARROWDB_DIR:-$HOME/Dev/SparrowDB}}"
+KMSMCP_NODE_MODULES="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/node_modules/sparrowdb"
 
 if [[ ! -d "$SPARROW_DIR" ]]; then
   echo "❌ SparrowDB repo not found at: $SPARROW_DIR"
@@ -11,20 +25,41 @@ if [[ ! -d "$SPARROW_DIR" ]]; then
   exit 1
 fi
 
-echo "🦀 Building sparrowdb-node from: $SPARROW_DIR"
-cd "$SPARROW_DIR"
-cargo build --release -p sparrowdb-node
-
-# macOS: .dylib → .node
-if [[ -f target/release/libsparrowdb_node.dylib ]]; then
-  cp target/release/libsparrowdb_node.dylib npm/sparrowdb/sparrowdb.node
-elif [[ -f target/release/sparrowdb_node.dll ]]; then
-  cp target/release/sparrowdb_node.dll npm/sparrowdb/sparrowdb.node
-else
-  # Linux .so
-  cp target/release/libsparrowdb_node.so npm/sparrowdb/sparrowdb.node
+if [[ ! -d "$KMSMCP_NODE_MODULES" ]]; then
+  echo "❌ KMSmcp's sparrowdb is not installed at: $KMSMCP_NODE_MODULES"
+  echo "   Run 'npm install' in KMSmcp first."
+  exit 1
 fi
 
-SIZE=$(ls -lh npm/sparrowdb/sparrowdb.node | awk '{print $5}')
-echo "✅ sparrowdb.node rebuilt: $SIZE"
-echo "   Path: $SPARROW_DIR/npm/sparrowdb/sparrowdb.node"
+NAPI_BIN="$SPARROW_DIR/npm/sparrowdb/node_modules/.bin/napi"
+if [[ ! -x "$NAPI_BIN" ]]; then
+  echo "🔧 @napi-rs/cli not installed in SparrowDB. Installing once…"
+  (cd "$SPARROW_DIR/npm/sparrowdb" && npm install)
+fi
+
+echo "🦀 Building sparrowdb-node (cargo + .d.ts) from: $SPARROW_DIR"
+(cd "$SPARROW_DIR/npm/sparrowdb" && \
+  ./node_modules/.bin/napi build --release --platform \
+    --dts index.d.ts --js false \
+    --cargo-cwd ../../crates/sparrowdb-node \
+    --cargo-name sparrowdb_node)
+
+# napi emits index.<platform>.node — find it and normalize to sparrowdb.node.
+NATIVE_OUT=$(ls "$SPARROW_DIR/npm/sparrowdb/"index.*.node 2>/dev/null | head -1)
+if [[ -z "$NATIVE_OUT" ]]; then
+  echo "❌ napi build did not produce an index.*.node artifact"
+  exit 1
+fi
+cp "$NATIVE_OUT" "$SPARROW_DIR/npm/sparrowdb/sparrowdb.node"
+
+echo "📦 Propagating to KMSmcp node_modules…"
+cp "$SPARROW_DIR/npm/sparrowdb/sparrowdb.node" "$KMSMCP_NODE_MODULES/sparrowdb.node"
+cp "$SPARROW_DIR/npm/sparrowdb/index.d.ts"     "$KMSMCP_NODE_MODULES/index.d.ts"
+
+SIZE=$(ls -lh "$SPARROW_DIR/npm/sparrowdb/sparrowdb.node" | awk '{print $5}')
+DTS_LINES=$(wc -l < "$SPARROW_DIR/npm/sparrowdb/index.d.ts" | tr -d ' ')
+NEW_API_REFS=$(grep -c 'hybridSearch\|vectorSearch\|fulltextSearch' "$KMSMCP_NODE_MODULES/index.d.ts")
+echo "✅ Done."
+echo "   sparrowdb.node: $SIZE  (also copied to KMSmcp)"
+echo "   index.d.ts: $DTS_LINES lines  (also copied to KMSmcp)"
+echo "   New API refs (hybridSearch/vectorSearch/fulltextSearch) in KMSmcp's index.d.ts: $NEW_API_REFS"


### PR DESCRIPTION
## Summary
- Use `napi build` (cargo + .d.ts gen) so KMSmcp gets fresh TypeScript types alongside the binary
- Propagate BOTH `sparrowdb.node` and `index.d.ts` into KMSmcp's `node_modules/sparrowdb/` (previously only wrote into the SparrowDB repo — useless for consumption)
- Auto-install `@napi-rs/cli` in SparrowDB's `npm/sparrowdb/` on first run

## Why
KMSmcp's `require('sparrowdb')` has been silently broken on darwin-arm64 since the 0.1.20 npm publish. Verified today: published tarball ships a Linux-ELF `sparrowdb.node` → `dlopen ... slice is not valid mach-o file` on this Mac mini. The pre-existing build script didn't fix it — it wrote into the SparrowDB repo, not into KMSmcp's `node_modules/`.

With SparrowDB#405 landing the regenerated TS surface for `hybridSearch`/`vectorSearch`/`fulltextSearch`, KMSmcp also needs the fresh `index.d.ts` propagated.

## Depends on
- ryaker/SparrowDB#405 (adds `@napi-rs/cli` to `npm/sparrowdb/devDependencies`). Without that PR's `package.json` + lockfile, the bootstrap `npm install` here won't pull napi-cli.

## Test plan
- [x] `bash scripts/build-sparrowdb-node.sh` runs end-to-end on this Mac mini
- [x] `node_modules/sparrowdb/sparrowdb.node` is now Mach-O arm64 (was Linux ELF)
- [x] `node_modules/sparrowdb/index.d.ts` has typed signatures for hybridSearch/vectorSearch/fulltextSearch
- [x] `node -e "require('sparrowdb').SparrowDB.prototype"` exposes all 7 new methods
- [ ] Re-run on a fresh KMSmcp clone (post-#405 merge) to confirm bootstrap install works

🤖 Generated with [Claude Code](https://claude.com/claude-code)