### PR TITLE
fix(build): re-apply SparrowDb→SparrowDB rename after every napi regen

### DIFF
--- a/scripts/build-sparrowdb-node.sh
+++ b/scripts/build-sparrowdb-node.sh
@@ -44,6 +44,13 @@ echo "🦀 Building sparrowdb-node (cargo + .d.ts) from: $SPARROW_DIR"
     --cargo-cwd ../../crates/sparrowdb-node \
     --cargo-name sparrowdb_node)
 
+# napi-rs 2.18.4 PascalCase-converts struct `SparrowDB` to `SparrowDb` in factory
+# return types. The class declaration is correct (`SparrowDB`), but
+# `static open(...): SparrowDb` references an undefined symbol → TS compile
+# fails for consumers. Repair on every regen until upstream napi-rs lands a fix.
+# perl (not BSD sed) for portable \b word boundary.
+perl -i -pe 's/\bSparrowDb\b/SparrowDB/g' "$SPARROW_DIR/npm/sparrowdb/index.d.ts"
+
 # napi emits index.<platform>.node — find it and normalize to sparrowdb.node.
 NATIVE_OUT=$(ls "$SPARROW_DIR/npm/sparrowdb/"index.*.node 2>/dev/null | head -1)
 if [[ -z "$NATIVE_OUT" ]]; then


### PR DESCRIPTION
## Summary
PR #57's underlying napi-rs PascalCase quirk re-emerges on every `napi build`. The committed fix in SparrowDB#405 was a manual one-token edit; regen reverts it.

Add a perl post-process step right after `napi build`:
```bash
perl -i -pe 's/\bSparrowDb\b/SparrowDB/g' "$SPARROW_DIR/npm/sparrowdb/index.d.ts"
```

## Why perl, not sed
BSD sed (macOS) doesn't support `\b` word boundary. perl is portable across BSD/GNU.

## Verified
End-to-end: `rm -rf node_modules/sparrowdb/{sparrowdb.node,index.d.ts} && bash scripts/build-sparrowdb-node.sh` → 0 `SparrowDb` refs in `node_modules/sparrowdb/index.d.ts`. `node -e "require('sparrowdb').SparrowDB.prototype"` exposes all 7 vector/FTS/hybrid methods.

## Follow-up
File a napi-rs upstream issue for the PascalCase compaction (`SparrowDB` → `SparrowDb`). Remove this perl line when it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)