### PR TITLE
fix: restore KMS service health after SparrowDB+Mem0 cutover incident

### DIFF
--- a/dist/storage/Mem0Storage.js
+++ b/dist/storage/Mem0Storage.js
@@ -94,8 +94,6 @@ export class Mem0Storage {
             };
             console.log(`🧠 [Mem0Storage.search] Search query: "${searchQuery}"`);
             console.log(`🧠 [Mem0Storage.search] Search options:`, JSON.stringify(searchOptions, null, 2));
-            // SDK type declares `Memory[]` but runtime can be either bare array or
-            // `{ results: Memory[] }` depending on endpoint version — handle both.
             const response = await this.client.search(searchQuery, searchOptions);
             const results = Array.isArray(response) ? response : (response?.results ?? []);
             const processedResults = results.map((r) => ({
@@ -122,17 +120,13 @@ export class Mem0Storage {
             // v3 SDK: use getAll() with filters.user_id and pageSize=1 to get the count.
             // Avoids the brittle raw fetch to /v1/memories/ that was used in the 1.x days.
             const userId = this.config.defaultUserId || 'personal';
-            // SDK destructures `page_size` (snake) — `pageSize` (camel) goes ignored, leaving
-            // pagination off. Also pass user_id at top level: getAll v1 serializes options via
-            // URLSearchParams which can't nest objects, so filters: { user_id } becomes the
-            // literal "[object Object]" on the wire.
             const page = await this.client.getAll({
                 page: 1,
                 page_size: 1,
                 user_id: userId
             });
             // Paginated response: { count, next, previous, results }. Bare array fallback for non-paginated.
-            const totalMemories = page?.count ?? (Array.isArray(page) ? page.length : 'unknown');
+            const totalMemories = (Array.isArray(page) ? page.length : page?.count) ?? 'unknown';
             return {
                 totalMemories,
                 userId,
@@ -151,8 +145,6 @@ export class Mem0Storage {
     }
     async getMemoriesForUser(userId, limit = 50) {
         try {
-            // SDK destructures snake_case `page_size`; user_id must be top-level since
-            // getAll v1 URL-encodes options and can't nest objects.
             const page = await this.client.getAll({
                 page: 1,
                 page_size: limit,
@@ -167,6 +159,7 @@ export class Mem0Storage {
                     id: m.id,
                     content: m.memory,
                     metadata: m.metadata,
+                    userId: m.userId ?? m.user_id,
                     createdAt: created ? new Date(created) : undefined,
                     updatedAt: updated ? new Date(updated) : undefined
                 };

--- a/dist/storage/Mem0Storage.js
+++ b/dist/storage/Mem0Storage.js
@@ -83,19 +83,21 @@ export class Mem0Storage {
             const userId = this.generateUserIdFromQuery(query);
             console.log(`🧠 [Mem0Storage.search] Using user ID: ${userId}`);
             const searchQuery = query.query;
-            // v3: user_id MUST live inside filters (top-level entity params now rejected by SDK).
+            // Mem0 v1 endpoint expects user_id at TOP LEVEL of payload, not nested under filters.
+            // (Earlier comment claimed v3 SDK rejected top-level entity params — that was wrong;
+            // the SDK has no such throw, and v1 search rejects the request unless one of
+            // {user_id, agent_id, app_id, run_id} is present at body root.)
             const searchOptions = {
+                user_id: userId,
                 topK: query.options?.maxResults || 10,
-                filters: {
-                    user_id: userId,
-                    ...this.buildMem0Filters(query.filters)
-                }
+                filters: this.buildMem0Filters(query.filters)
             };
             console.log(`🧠 [Mem0Storage.search] Search query: "${searchQuery}"`);
             console.log(`🧠 [Mem0Storage.search] Search options:`, JSON.stringify(searchOptions, null, 2));
-            // v3 search returns { results: Memory[] } (wrapped) instead of Memory[].
+            // SDK type declares `Memory[]` but runtime can be either bare array or
+            // `{ results: Memory[] }` depending on endpoint version — handle both.
             const response = await this.client.search(searchQuery, searchOptions);
-            const results = response?.results ?? [];
+            const results = Array.isArray(response) ? response : (response?.results ?? []);
             const processedResults = results.map((r) => ({
                 id: r.id || r.metadata?.kms_id,
                 content: r.memory || '',
@@ -105,7 +107,7 @@ export class Mem0Storage {
                 timestamp: r.metadata?.timestamp ? new Date(r.metadata.timestamp) : new Date(),
                 contentType: r.metadata?.content_type,
                 source: r.metadata?.source,
-                userId: r.userId
+                userId: r.userId ?? r.user_id
             }));
             console.log(`🧠 Mem0 found ${processedResults.length} results`);
             return processedResults;
@@ -120,13 +122,19 @@ export class Mem0Storage {
             // v3 SDK: use getAll() with filters.user_id and pageSize=1 to get the count.
             // Avoids the brittle raw fetch to /v1/memories/ that was used in the 1.x days.
             const userId = this.config.defaultUserId || 'personal';
+            // SDK destructures `page_size` (snake) — `pageSize` (camel) goes ignored, leaving
+            // pagination off. Also pass user_id at top level: getAll v1 serializes options via
+            // URLSearchParams which can't nest objects, so filters: { user_id } becomes the
+            // literal "[object Object]" on the wire.
             const page = await this.client.getAll({
                 page: 1,
-                pageSize: 1,
-                filters: { user_id: userId }
+                page_size: 1,
+                user_id: userId
             });
+            // Paginated response: { count, next, previous, results }. Bare array fallback for non-paginated.
+            const totalMemories = page?.count ?? (Array.isArray(page) ? page.length : 'unknown');
             return {
-                totalMemories: page?.count ?? 'unknown',
+                totalMemories,
                 userId,
                 status: 'connected',
                 apiEndpoint: 'Mem0 Cloud (v3)'
@@ -143,20 +151,26 @@ export class Mem0Storage {
     }
     async getMemoriesForUser(userId, limit = 50) {
         try {
-            // v3: the 1.x `get({ user_id, limit })` overload moved to `getAll(options)`.
-            // user_id must go inside filters; limit becomes pageSize.
+            // SDK destructures snake_case `page_size`; user_id must be top-level since
+            // getAll v1 URL-encodes options and can't nest objects.
             const page = await this.client.getAll({
-                pageSize: limit,
-                filters: { user_id: userId }
+                page: 1,
+                page_size: limit,
+                user_id: userId
             });
-            const memories = page?.results ?? [];
-            return memories.map((m) => ({
-                id: m.id,
-                content: m.memory,
-                metadata: m.metadata,
-                createdAt: m.createdAt ? new Date(m.createdAt) : undefined,
-                updatedAt: m.updatedAt ? new Date(m.updatedAt) : undefined
-            }));
+            // getAll runtime shape varies (bare array vs { results: [...], count }).
+            const memList = Array.isArray(page) ? page : (page?.results ?? []);
+            return memList.map((m) => {
+                const created = m.createdAt ?? m.created_at;
+                const updated = m.updatedAt ?? m.updated_at;
+                return {
+                    id: m.id,
+                    content: m.memory,
+                    metadata: m.metadata,
+                    createdAt: created ? new Date(created) : undefined,
+                    updatedAt: updated ? new Date(updated) : undefined
+                };
+            });
         }
         catch (error) {
             console.error('❌ Mem0 getMemoriesForUser error:', error);
@@ -245,15 +259,15 @@ export class Mem0Storage {
         try {
             console.log(`🧪 [Mem0Storage.testDirectSearch] Testing direct search for: "${query}" with user: ${userId}`);
             const searchQuery = query;
-            // v3: user_id must live in filters (top-level entity params now rejected).
+            // Mem0 v1 search expects user_id at top level of payload (see Mem0Storage.search above).
             const searchOptions = {
-                topK: 10,
-                filters: { user_id: userId }
+                user_id: userId,
+                topK: 10
             };
             console.log(`🧪 [Mem0Storage.testDirectSearch] Search query: "${searchQuery}"`);
             console.log(`🧪 [Mem0Storage.testDirectSearch] Search options:`, JSON.stringify(searchOptions, null, 2));
             const response = await this.client.search(searchQuery, searchOptions);
-            const results = response?.results ?? [];
+            const results = Array.isArray(response) ? response : (response?.results ?? []);
             console.log(`🧪 [Mem0Storage.testDirectSearch] Raw results:`, JSON.stringify(results, null, 2));
             return {
                 success: true,

--- a/dist/storage/SparrowDBStorage.js
+++ b/dist/storage/SparrowDBStorage.js
@@ -405,8 +405,19 @@ export class SparrowDBStorage {
         try {
             const nodeResult = this.db.execute(`MATCH (n:Knowledge) RETURN count(n)`);
             const totalNodes = Number(nodeResult.rows[0]?.['count(n)'] ?? 0);
-            const relResult = this.db.execute(`MATCH ()-[r]->() RETURN count(r) AS cnt`);
-            const totalRelationships = Number(relResult.rows[0]?.['cnt'] ?? 0);
+            // SparrowDB 0.1.22 binding regression: MATCH ()-[r]->() RETURN count(r)
+            // throws "not found" / GenericFailure even when relationships exist. Until the
+            // upstream fix lands, default to 0 and don't propagate the error — node count
+            // is the more important figure and rel count can be reconstructed from the
+            // sidecar if needed.
+            let totalRelationships = 0;
+            try {
+                const relResult = this.db.execute(`MATCH ()-[r]->() RETURN count(r) AS cnt`);
+                totalRelationships = Number(relResult.rows[0]?.['cnt'] ?? 0);
+            }
+            catch (relErr) {
+                logger.warn('⚠️ SparrowDB rel-count query failed (binding regression — defaulting to 0):', relErr);
+            }
             // Content type distribution from sidecar (authoritative — SparrowDB strings truncated).
             const contentTypes = {};
             for (const entry of this.contentIndex.values()) {

--- a/src/storage/Mem0Storage.ts
+++ b/src/storage/Mem0Storage.ts
@@ -110,8 +110,9 @@ export class Mem0Storage implements StorageSystem {
 
       // SDK type declares `Memory[]` but runtime can be either bare array or
       // `{ results: Memory[] }` depending on endpoint version — handle both.
-      const response = await this.client.search(searchQuery, searchOptions) as any
-      const results = Array.isArray(response) ? response : (response?.results ?? [])
+      type Mem0SearchResponse = any[] | { results?: any[] }
+      const response = await this.client.search(searchQuery, searchOptions) as unknown as Mem0SearchResponse
+      const results: any[] = Array.isArray(response) ? response : (response?.results ?? [])
 
       const processedResults = results.map((r: any) => ({
         id: r.id || r.metadata?.kms_id,
@@ -142,13 +143,14 @@ export class Mem0Storage implements StorageSystem {
       // pagination off. Also pass user_id at top level: getAll v1 serializes options via
       // URLSearchParams which can't nest objects, so filters: { user_id } becomes the
       // literal "[object Object]" on the wire.
+      type Mem0GetAllResponse = any[] | { count?: number; results?: any[]; next?: string | null; previous?: string | null }
       const page = await this.client.getAll({
         page: 1,
         page_size: 1,
         user_id: userId
-      } as any) as any
+      } as any) as unknown as Mem0GetAllResponse
       // Paginated response: { count, next, previous, results }. Bare array fallback for non-paginated.
-      const totalMemories = page?.count ?? (Array.isArray(page) ? page.length : 'unknown')
+      const totalMemories = (Array.isArray(page) ? page.length : page?.count) ?? 'unknown'
       return {
         totalMemories,
         userId,
@@ -169,14 +171,15 @@ export class Mem0Storage implements StorageSystem {
     try {
       // SDK destructures snake_case `page_size`; user_id must be top-level since
       // getAll v1 URL-encodes options and can't nest objects.
+      type Mem0GetAllResponse = any[] | { count?: number; results?: any[] }
       const page = await this.client.getAll({
         page: 1,
         page_size: limit,
         user_id: userId
-      } as any)
+      } as any) as unknown as Mem0GetAllResponse
 
       // getAll runtime shape varies (bare array vs { results: [...], count }).
-      const memList = Array.isArray(page) ? page : ((page as any)?.results ?? [])
+      const memList: any[] = Array.isArray(page) ? page : (page?.results ?? [])
       return memList.map((m: any) => {
         const created = m.createdAt ?? m.created_at
         const updated = m.updatedAt ?? m.updated_at
@@ -184,6 +187,7 @@ export class Mem0Storage implements StorageSystem {
           id: m.id,
           content: m.memory,
           metadata: m.metadata,
+          userId: m.userId ?? m.user_id,
           createdAt: created ? new Date(created) : undefined,
           updatedAt: updated ? new Date(updated) : undefined
         }

--- a/src/storage/Mem0Storage.ts
+++ b/src/storage/Mem0Storage.ts
@@ -95,23 +95,25 @@ export class Mem0Storage implements StorageSystem {
       console.log(`🧠 [Mem0Storage.search] Using user ID: ${userId}`)
 
       const searchQuery = query.query
-      // v3: user_id MUST live inside filters (top-level entity params now rejected by SDK).
+      // Mem0 v1 endpoint expects user_id at TOP LEVEL of payload, not nested under filters.
+      // (Earlier comment claimed v3 SDK rejected top-level entity params — that was wrong;
+      // the SDK has no such throw, and v1 search rejects the request unless one of
+      // {user_id, agent_id, app_id, run_id} is present at body root.)
       const searchOptions = {
+        user_id: userId,
         topK: query.options?.maxResults || 10,
-        filters: {
-          user_id: userId,
-          ...this.buildMem0Filters(query.filters)
-        }
+        filters: this.buildMem0Filters(query.filters)
       }
 
       console.log(`🧠 [Mem0Storage.search] Search query: "${searchQuery}"`)
       console.log(`🧠 [Mem0Storage.search] Search options:`, JSON.stringify(searchOptions, null, 2))
 
-      // v3 search returns { results: Memory[] } (wrapped) instead of Memory[].
-      const response = await this.client.search(searchQuery, searchOptions)
-      const results = response?.results ?? []
+      // SDK type declares `Memory[]` but runtime can be either bare array or
+      // `{ results: Memory[] }` depending on endpoint version — handle both.
+      const response = await this.client.search(searchQuery, searchOptions) as any
+      const results = Array.isArray(response) ? response : (response?.results ?? [])
 
-      const processedResults = results.map((r: Memory) => ({
+      const processedResults = results.map((r: any) => ({
         id: r.id || r.metadata?.kms_id,
         content: r.memory || '',
         confidence: r.score || r.metadata?.confidence || 0.5,
@@ -120,7 +122,7 @@ export class Mem0Storage implements StorageSystem {
         timestamp: r.metadata?.timestamp ? new Date(r.metadata.timestamp) : new Date(),
         contentType: r.metadata?.content_type,
         source: r.metadata?.source,
-        userId: r.userId
+        userId: r.userId ?? r.user_id
       }))
 
       console.log(`🧠 Mem0 found ${processedResults.length} results`)
@@ -136,13 +138,19 @@ export class Mem0Storage implements StorageSystem {
       // v3 SDK: use getAll() with filters.user_id and pageSize=1 to get the count.
       // Avoids the brittle raw fetch to /v1/memories/ that was used in the 1.x days.
       const userId = this.config.defaultUserId || 'personal'
+      // SDK destructures `page_size` (snake) — `pageSize` (camel) goes ignored, leaving
+      // pagination off. Also pass user_id at top level: getAll v1 serializes options via
+      // URLSearchParams which can't nest objects, so filters: { user_id } becomes the
+      // literal "[object Object]" on the wire.
       const page = await this.client.getAll({
         page: 1,
-        pageSize: 1,
-        filters: { user_id: userId }
-      })
+        page_size: 1,
+        user_id: userId
+      } as any) as any
+      // Paginated response: { count, next, previous, results }. Bare array fallback for non-paginated.
+      const totalMemories = page?.count ?? (Array.isArray(page) ? page.length : 'unknown')
       return {
-        totalMemories: page?.count ?? 'unknown',
+        totalMemories,
         userId,
         status: 'connected',
         apiEndpoint: 'Mem0 Cloud (v3)'
@@ -159,21 +167,27 @@ export class Mem0Storage implements StorageSystem {
 
   async getMemoriesForUser(userId: string, limit = 50): Promise<any[]> {
     try {
-      // v3: the 1.x `get({ user_id, limit })` overload moved to `getAll(options)`.
-      // user_id must go inside filters; limit becomes pageSize.
+      // SDK destructures snake_case `page_size`; user_id must be top-level since
+      // getAll v1 URL-encodes options and can't nest objects.
       const page = await this.client.getAll({
-        pageSize: limit,
-        filters: { user_id: userId }
-      })
+        page: 1,
+        page_size: limit,
+        user_id: userId
+      } as any)
 
-      const memories = page?.results ?? []
-      return memories.map((m: Memory) => ({
-        id: m.id,
-        content: m.memory,
-        metadata: m.metadata,
-        createdAt: m.createdAt ? new Date(m.createdAt) : undefined,
-        updatedAt: m.updatedAt ? new Date(m.updatedAt) : undefined
-      }))
+      // getAll runtime shape varies (bare array vs { results: [...], count }).
+      const memList = Array.isArray(page) ? page : ((page as any)?.results ?? [])
+      return memList.map((m: any) => {
+        const created = m.createdAt ?? m.created_at
+        const updated = m.updatedAt ?? m.updated_at
+        return {
+          id: m.id,
+          content: m.memory,
+          metadata: m.metadata,
+          createdAt: created ? new Date(created) : undefined,
+          updatedAt: updated ? new Date(updated) : undefined
+        }
+      })
     } catch (error) {
       console.error('❌ Mem0 getMemoriesForUser error:', error)
       return []
@@ -275,17 +289,17 @@ export class Mem0Storage implements StorageSystem {
       console.log(`🧪 [Mem0Storage.testDirectSearch] Testing direct search for: "${query}" with user: ${userId}`)
 
       const searchQuery = query
-      // v3: user_id must live in filters (top-level entity params now rejected).
+      // Mem0 v1 search expects user_id at top level of payload (see Mem0Storage.search above).
       const searchOptions = {
-        topK: 10,
-        filters: { user_id: userId }
+        user_id: userId,
+        topK: 10
       }
 
       console.log(`🧪 [Mem0Storage.testDirectSearch] Search query: "${searchQuery}"`)
       console.log(`🧪 [Mem0Storage.testDirectSearch] Search options:`, JSON.stringify(searchOptions, null, 2))
 
-      const response = await this.client.search(searchQuery, searchOptions)
-      const results = response?.results ?? []
+      const response = await this.client.search(searchQuery, searchOptions) as any
+      const results = Array.isArray(response) ? response : (response?.results ?? [])
       console.log(`🧪 [Mem0Storage.testDirectSearch] Raw results:`, JSON.stringify(results, null, 2))
 
       return {

--- a/src/storage/SparrowDBStorage.ts
+++ b/src/storage/SparrowDBStorage.ts
@@ -531,10 +531,20 @@ export class SparrowDBStorage implements StorageSystem {
       )
       const totalNodes = Number(nodeResult.rows[0]?.['count(n)'] ?? 0)
 
-      const relResult = this.db.execute(
-        `MATCH ()-[r]->() RETURN count(r) AS cnt`
-      )
-      const totalRelationships = Number(relResult.rows[0]?.['cnt'] ?? 0)
+      // SparrowDB 0.1.22 binding regression: MATCH ()-[r]->() RETURN count(r)
+      // throws "not found" / GenericFailure even when relationships exist. Until the
+      // upstream fix lands, default to 0 and don't propagate the error — node count
+      // is the more important figure and rel count can be reconstructed from the
+      // sidecar if needed.
+      let totalRelationships = 0
+      try {
+        const relResult = this.db.execute(
+          `MATCH ()-[r]->() RETURN count(r) AS cnt`
+        )
+        totalRelationships = Number(relResult.rows[0]?.['cnt'] ?? 0)
+      } catch (relErr) {
+        logger.warn('⚠️ SparrowDB rel-count query failed (binding regression — defaulting to 0):', relErr)
+      }
 
       // Content type distribution from sidecar (authoritative — SparrowDB strings truncated).
       const contentTypes: Record<string, number> = {}


### PR DESCRIPTION
## Summary

End-of-cutover diagnostic this evening: `kms_ping` reports `status: degraded` with two distinct silent-failure modes (both showing `storageTime=0ms` in earlier write attempts that Rich flagged at end of his SparrowDB session).

Root-caused both bugs and shipped fixes. Live MCP-wire `kms_ping` post-deploy now returns `status: ok` with all three datastores connected.

## Bug 1 — Mem0 v3 SDK call shape (KMSmcp bug)

The earlier v3 upgrade (PR #56) was based on a hallucinated SDK rule: _"v3 rejects top-level entity params, must nest in `filters: { user_id }`"_. No such throw exists anywhere in `mem0ai@3.0.2` source. The actual reality:

- **`search()` v1 endpoint** posts options as JSON body. Mem0 backend looks for `{user_id, agent_id, app_id, run_id}` at body **root**, NOT nested in `filters` (which is reserved for metadata/date filters). Nested `user_id` was silently ignored, and the API rejected with `One of the filters: app_id, user_id, agent_id, run_id is required!`.
- **`getAll()` v1 endpoint** URL-encodes options via `URLSearchParams`, which **cannot serialize nested objects** — `filters: { user_id }` becomes the literal string `[object Object]` on the wire.
- The SDK destructures `page_size` (snake_case). `pageSize` (camelCase) gets ignored, leaving pagination off.
- The SDK type declares `Memory[]` for `search`/`getAll` but runtime can return `{ results: Memory[], count, ... }` — handle both shapes defensively.
- Memory response keys are snake_case at runtime (`created_at`, `updated_at`, `user_id`) despite the prior agent's claim. Type definitions are out of sync with runtime; treat as `any`.

**Fix**: pass `user_id` at top level, use `page_size` (snake), defensive shape handling for both array and `{ results }` responses, accept both snake and camel response keys.

## Bug 2 — SparrowDB 0.1.22 relationship-count regression (upstream bug)

`MATCH ()-[r]->() RETURN count(r) AS cnt` throws `Error: not found` (code: `GenericFailure`) on the 0.1.22 binding. Node-pattern queries (`MATCH (n:Knowledge)`) work fine — only relationship-pattern queries fail.

Verified via direct `node -e` reproduction outside KMSmcp — bug is in SparrowDB binding, not our code.

**Fix**: wrap the rel-count call in `getStats()` in try/catch, default to 0, log a warning. Pending upstream fix in SparrowDB; workaround can be reverted once 0.1.23+ ships.

## Verification

Direct MCP-wire `kms_ping` after dist/ hot-reload:

```json
{
  "status": "ok",
  "datastores": {
    "graph": { "status": "connected", "nodes": 1199, "relationships": 0 },
    "mem0": { "status": "connected", "totalMemories": 3235, "apiEndpoint": "Mem0 Cloud (v3)" },
    "mongodb": { "status": "connected", "totalDocuments": 860 }
  }
}
```

28/28 tests still passing. `dist/` rebuilt and force-added per established pattern.

## Follow-ups (not in this PR)

- File SparrowDB upstream issue for the rel-count regression so the workaround can be reverted once 0.1.23+ ships.
- The 1199 node count vs 1013-from-query suggests sidecar ↔ graph drift (~186 entries with sidecar but no SparrowDB node). Worth a separate diagnostic ticket — likely from cutover dev writes that didn't make it into the graph layer. Not blocking.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` 28/28 passing
- [x] localhost:8180/health returns healthy
- [x] Direct MCP-wire kms_ping returns `status: "ok"` with all 3 datastores connected