### PR TITLE
fix(build): gate rm of .node binary on cargo availability

### DIFF
--- a/scripts/build-sparrowdb-node.sh
+++ b/scripts/build-sparrowdb-node.sh
@@ -37,6 +37,17 @@ if [[ ! -x "$NAPI_BIN" ]]; then
   (cd "$SPARROW_DIR/npm/sparrowdb" && npm install)
 fi
 
+# Fail fast if cargo is missing BEFORE we delete the existing .node binary.
+# Without this guard, `rm -f index.*.node` succeeds, the napi build then fails on
+# missing cargo, and the caller (e.g. a fresh worktree clone) is left with no
+# binary and no recovery path. See KMS memory 9a601fc9 (gotcha #2) and PR #61.
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "❌ cargo not found in PATH — refusing to delete existing .node binary."
+  echo "   Install Rust toolchain (https://rustup.rs) or ensure ~/.cargo/bin is on PATH."
+  echo "   Existing index.*.node and sparrowdb.node left untouched."
+  exit 1
+fi
+
 echo "🦀 Building sparrowdb-node (cargo + .d.ts) from: $SPARROW_DIR"
 (cd "$SPARROW_DIR/npm/sparrowdb" && rm -f index.*.node && \
   ./node_modules/.bin/napi build --release --platform \

--- a/scripts/build-sparrowdb-node.sh
+++ b/scripts/build-sparrowdb-node.sh
@@ -42,9 +42,9 @@ fi
 # missing cargo, and the caller (e.g. a fresh worktree clone) is left with no
 # binary and no recovery path. See KMS memory 9a601fc9 (gotcha #2) and PR #61.
 if ! command -v cargo >/dev/null 2>&1; then
-  echo "❌ cargo not found in PATH — refusing to delete existing .node binary."
-  echo "   Install Rust toolchain (https://rustup.rs) or ensure ~/.cargo/bin is on PATH."
-  echo "   Existing index.*.node and sparrowdb.node left untouched."
+  echo "❌ cargo not found in PATH — refusing to delete existing .node binary." >&2
+  echo "   Install Rust toolchain (https://rustup.rs) or ensure ~/.cargo/bin is on PATH." >&2
+  echo "   Existing index.*.node and sparrowdb.node left untouched." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

`scripts/build-sparrowdb-node.sh` previously ran `rm -f index.*.node` *before* probing for cargo. On a cargo-missing system (e.g. a fresh worktree clone without Rust on PATH), the rm succeeded, the napi build then failed on missing cargo, and the caller was left with no binary and no recovery path — requiring a manual copy from the parent KMSmcp checkout.

This bit DG-T1-A's worktree agent during Wave 2 of PR #61. Documented in KMS memory `9a601fc9` (gotcha #2).

## Fix

Probe `command -v cargo` before any destructive operations and fail fast with a clear, actionable error if cargo is missing. Existing `index.*.node` and `sparrowdb.node` are left untouched on the failure path.

Approach (a) — fail-fast cargo check before any filesystem mutation — chosen over options (b) and (c) because:
- Cleaner than wrapping the rm in a guard; the rm is buried in a subshell pipeline with napi build
- Simpler than the temp-name pattern (napi controls its own output filename)
- Gives the user an actionable error message before any state changes

## Test plan

- [x] **cargo missing** (sanitized PATH `/usr/bin:/bin:/usr/sbin:/sbin`): fails fast at exit 1 with `cargo not found in PATH — refusing to delete existing .node binary.`; existing `index.darwin-arm64.node` and `sparrowdb.node` preserved (verified via `ls -lh` after the run).
- [x] **cargo present** (normal PATH): full build succeeds end-to-end. Output: `Finished release profile [optimized] target(s) in 22.41s` followed by `✅ Done.` with the expected `sparrowdb.node: 2.3M` propagation.

## Constraints honored

- No other build scripts, Doppler config, or shared state modified
- No changes to `node_modules/sparrowdb/` or live `dist/` files
- Five-line additive change to a single shell script

🤖 Generated with [Claude Code](https://claude.com/claude-code)