### PR TITLE
feat(dedup-gate): DG-T2-A LLM judge for borderline-band candidates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,7 @@ Naming convention: `Project.fact_name` or `Person.preferences.facet`. Reuse the 
 
 When in doubt, omit subject — pure pass-through, no validation. But for any fact you expect to update or supersede later, set it.
 
-## Dedup Gate (Tier 1 — DG-T1-B)
+## Dedup Gate (Tier 1 — DG-T1-B + Tier 2 — DG-T2-A)
 
 When you call `unified_store`, the gate may refuse the write if a near-duplicate already exists for the same `userId` + `contentType` + (optional) `metadata.subject`. The response shape:
 
@@ -177,7 +177,7 @@ When you call `unified_store`, the gate may refuse the write if a near-duplicate
       "subject": "Phoenix.camera_count",
       "created": "2026-04-13T...",
       "flag": null,
-      "llm_relation": null
+      "llm_relation": "duplicate"
     }
   ],
   "message": "Likely duplicate found (cos=0.91 >= 0.88). Retry with action.",
@@ -206,6 +206,27 @@ Per-contentType overrides:
 **DG-T1-C dispatch is not yet wired** (issue #46). For now, when the gate returns `dedup_required` you should manually call `kms_supersede(old_id, new_content, reason)` (or `kms_update`, `kms_delete`, etc.) using the candidate ID from the response. The `action=…` field will be honored as the dispatch shortcut once DG-T1-C lands; until then, passing `action` simply bypasses the gate and proceeds to a normal `unified_store`.
 
 **The gate uses `metadata.subject` as a scope filter when present.** Two writes with the same `subject` get the tightest dedup check (narrowed to that facet of that topic). When you omit `subject`, the gate falls back to `userId + contentType` only — so writes without a subject still trigger dedup against any same-userId-same-contentType entry, not zero matches. Tag high-traffic facts with explicit `metadata.subject` (see preceding section) to scope the dedup check tighter and avoid false positives across unrelated facets of the same topic.
+
+### Tier 2 — `llm_relation` (DG-T2-A, issue #49)
+
+Each candidate in a `dedup_required` response now carries an `llm_relation` field populated by **Claude Haiku 4.5** (`claude-haiku-4-5-20251001`) for confirm-band candidates. Refuse-band candidates get the relation `"duplicate"` inline (free win — the embedder already agrees so strongly we skip the LLM call).
+
+**Relation enum:**
+
+| Relation | Meaning | Recommended action |
+|---|---|---|
+| `duplicate` | Same fact expressed differently; no new information in NEW | `kms_delete` the new write (or skip) — nothing to add |
+| `supersedes` | NEW corrects/replaces the existing entry | `kms_supersede(old_id, new_content, reason)` |
+| `supersedes-reverse` | The existing entry is the more accurate one; NEW is outdated | Don't write NEW; consider `kms_update` on existing if NEW has incremental info |
+| `complement` | Both are true — different facets of related topic | `action=complement&related_to=<old_id>` (write both, link them) |
+| `contradicts` | **Factually opposed; only one can be true** | **STOP.** Do NOT proceed without explicit acknowledgement. Surface to the human; one of the two must be retracted via `kms_supersede` or `kms_flag(RETRACTED)`. |
+| `unrelated` | Different facts that happen to share keywords | Proceed with `action=force-new&reason=<...>` — the embedder mis-fired |
+
+**On `contradicts`:** treat as a hard stop. The new write directly opposes an existing fact. Either the existing entry is wrong (use `kms_supersede`) or the new claim is wrong (don't write it). Picking blindly creates two contradicting entries that both leak into context injection — exactly the failure mode the gate exists to prevent.
+
+**Graceful degradation:** when `ANTHROPIC_API_KEY` is unset, `llm_relation` is `null` for all confirm-band candidates and `"duplicate"` for refuse-band. The gate still works on Tier 1 cosine alone — Tier 2 is purely advisory enrichment.
+
+**Cost & latency budget:** Haiku 4.5 with 5 s per-candidate timeout, single-word forced response (~12 tokens). LRU-cached at 1000 entries per process so repeated borderline calls in a session are free. Refuse-band candidates skip the LLM entirely.
 
 **Known limitation (upstream)**: As of sparrowdb 0.1.22, the Node.js binding does NOT expose parameter-binding for `execute()` (no `execute_with_params`), and the Cypher parser rejects list literals in `SET` / `CREATE`. This means `storeEmbedding`'s `SET k.embedding = [...]` write path silently fails — the HNSW index stays empty, and the dedup gate is inert in practice (it always finds 0 candidates and proceeds to a normal store). The gate logic, type guards, and threshold dispatch are all correct and will activate the moment the upstream binding gains either (a) `execute_with_params` for vector inserts, or (b) parser support for f32-list literals in SET. Tracked separately from DG-T1-B.
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -17,6 +17,7 @@ import { OllamaInference } from './inference/OllamaInference.js';
 import { EnrichmentQueue } from './inference/EnrichmentQueue.js';
 import { EntityLinker } from './inference/EntityLinker.js';
 import { OllamaEmbeddingService } from './embedding/EmbeddingService.js';
+import { AnthropicHaikuJudge } from './embedding/AnthropicHaikuJudge.js';
 import { MongoDBStorage, Mem0Storage, SparrowDBStorage } from './storage/index.js';
 import { UnifiedStoreTool, UnifiedSearchTool, KMSInstructionsTool, DocumentStoreTool } from './tools/index.js';
 export class UnifiedKMSServer {
@@ -129,10 +130,25 @@ export class UnifiedKMSServer {
         const embeddingService = new OllamaEmbeddingService({
             baseUrl: process.env.OLLAMA_BASE_URL || 'http://localhost:11434'
         });
+        // LLM judge for the dedup gate's Tier 2 borderline classification
+        // (DG-T2-A, issue #49). Optional — when ANTHROPIC_API_KEY is missing we
+        // pass null and the gate degrades gracefully (every candidate gets
+        // `llm_relation: null`). API key is Doppler-injected in production.
+        let llmJudge = null;
+        if (process.env.ANTHROPIC_API_KEY) {
+            console.log('🤖 Initializing LLM Judge (Claude Haiku 4.5)...');
+            llmJudge = new AnthropicHaikuJudge({
+                apiKey: process.env.ANTHROPIC_API_KEY
+            });
+        }
+        else {
+            console.warn('⚠️  ANTHROPIC_API_KEY not set — Tier 2 dedup classifier disabled. ' +
+                'Confirm-band candidates will return llm_relation=null.');
+        }
         // Step 4: Initialize tools
         console.log('🛠️  Initializing Tools...');
         this.tools = {
-            store: new UnifiedStoreTool(this.router, this.storage, this.factCache, ollamaRouter, enrichmentQueue, embeddingService),
+            store: new UnifiedStoreTool(this.router, this.storage, this.factCache, ollamaRouter, enrichmentQueue, embeddingService, llmJudge),
             search: new UnifiedSearchTool(this.storage, this.factCache),
             instructions: new KMSInstructionsTool(),
             documentStore: new DocumentStoreTool(this.storage.mongodb)

--- a/dist/tools/UnifiedStoreTool.js
+++ b/dist/tools/UnifiedStoreTool.js
@@ -4,6 +4,7 @@
 import crypto from 'crypto';
 import { FACTCache } from '../cache/FACTCache.js';
 import { ContentInference } from '../inference/ContentInference.js';
+import { logger } from '../logger.js';
 const debug = (...args) => { if (process.env.KMS_DEBUG)
     console.error(...args); };
 // -------------------------------------------------------------------------
@@ -242,7 +243,7 @@ export class UnifiedStoreTool {
                                 judgeAvailable = await this.llmJudge.isAvailable();
                             }
                             catch (e) {
-                                console.warn(`⚠️ unified_store: llmJudge.isAvailable() threw (skipping Tier 2): ` +
+                                logger.warn(`unified_store: llmJudge.isAvailable() threw (skipping Tier 2): ` +
                                     `${e instanceof Error ? e.message : String(e)}`);
                             }
                             if (judgeAvailable) {
@@ -253,13 +254,36 @@ export class UnifiedStoreTool {
                                     }
                                 });
                                 if (confirmBandIndices.length > 0) {
+                                    // Hydrate full content for each confirm-band candidate before
+                                    // classification. content_preview is capped at 200 chars which
+                                    // can cause misclassification on longer entries. Fall back to
+                                    // content_preview if the graph backend doesn't expose findById
+                                    // or the entry is unexpectedly missing.
+                                    const graph = this.storage.graph;
+                                    const hasGraphFindById = typeof graph.findById === 'function';
+                                    const fullContents = {};
+                                    for (const idx of confirmBandIndices) {
+                                        let full = candidates[idx].content_preview;
+                                        if (hasGraphFindById) {
+                                            try {
+                                                const entry = await graph.findById(candidates[idx].id);
+                                                if (entry && typeof entry.content === 'string' && entry.content.length > 0) {
+                                                    full = entry.content;
+                                                }
+                                            }
+                                            catch {
+                                                // Non-fatal — fall back to content_preview
+                                            }
+                                        }
+                                        fullContents[idx] = full;
+                                    }
                                     // Resolve in parallel — independent calls, the LLMJudgeService
                                     // owns its own timeout. We use Promise.allSettled so a single
                                     // failure doesn't drop the others.
                                     const judge = this.llmJudge;
                                     const results = await Promise.allSettled(confirmBandIndices.map(idx => judge.classify({
                                         newContent: knowledge.content,
-                                        candidateContent: candidates[idx].content_preview,
+                                        candidateContent: fullContents[idx],
                                     })));
                                     results.forEach((r, i) => {
                                         const idx = confirmBandIndices[i];
@@ -269,7 +293,7 @@ export class UnifiedStoreTool {
                                         else {
                                             // Per-candidate failure: log and leave null — other
                                             // candidates' results still ship.
-                                            console.warn(`⚠️ unified_store: llmJudge.classify failed for candidate ${candidates[idx].id} ` +
+                                            logger.warn(`unified_store: llmJudge.classify failed for candidate ${candidates[idx].id} ` +
                                                 `(continuing with llm_relation=null): ` +
                                                 `${r.reason instanceof Error ? r.reason.message : String(r.reason)}`);
                                         }

--- a/dist/tools/UnifiedStoreTool.js
+++ b/dist/tools/UnifiedStoreTool.js
@@ -52,15 +52,17 @@ export class UnifiedStoreTool {
     ollamaRouter;
     enrichmentQueue;
     embeddingService;
+    llmJudge;
     /** Tracks last known availability to detect transitions and log them. */
     _lastEmbedderAvailable = null;
-    constructor(router, storage, cache, ollamaRouter, enrichmentQueue, embeddingService) {
+    constructor(router, storage, cache, ollamaRouter, enrichmentQueue, embeddingService, llmJudge) {
         this.router = router;
         this.storage = storage;
         this.cache = cache; // Now using real cache
         this.ollamaRouter = ollamaRouter ?? null;
         this.enrichmentQueue = enrichmentQueue ?? null;
         this.embeddingService = embeddingService ?? null;
+        this.llmJudge = llmJudge ?? null;
     }
     /**
      * Store knowledge with intelligent routing
@@ -220,10 +222,70 @@ export class UnifiedStoreTool {
                         const msg = inRefuse
                             ? `Likely duplicate found (cos=${top.similarity.toFixed(3)} ≥ ${refuseThreshold}). Retry with action.`
                             : `Borderline match found (cos=${top.similarity.toFixed(3)} in [${confirmThreshold}, ${refuseThreshold})). Retry with action to confirm intent.`;
+                        // -------------------------------------------------------------
+                        // Tier 2 LLM judge (DG-T2-A) — classify candidate relationships
+                        //
+                        // For each candidate decide its `llm_relation`:
+                        //   - sim ≥ refuseThreshold → 'duplicate' inline (cost-free; the
+                        //     embedder agrees so strongly we don't need the LLM)
+                        //   - confirmThreshold ≤ sim < refuseThreshold → call judge
+                        //   - judge unavailable → null for all
+                        //   - per-candidate classify failure → null for that one only
+                        //
+                        // All confirm-band classifications run in parallel because they
+                        // are independent. Hard 5s timeout enforced by the judge itself.
+                        // -------------------------------------------------------------
+                        const llmRelations = candidates.map(c => c.similarity >= refuseThreshold ? 'duplicate' : null);
+                        if (this.llmJudge) {
+                            let judgeAvailable = false;
+                            try {
+                                judgeAvailable = await this.llmJudge.isAvailable();
+                            }
+                            catch (e) {
+                                console.warn(`⚠️ unified_store: llmJudge.isAvailable() threw (skipping Tier 2): ` +
+                                    `${e instanceof Error ? e.message : String(e)}`);
+                            }
+                            if (judgeAvailable) {
+                                const confirmBandIndices = [];
+                                candidates.forEach((c, idx) => {
+                                    if (c.similarity < refuseThreshold && c.similarity >= confirmThreshold) {
+                                        confirmBandIndices.push(idx);
+                                    }
+                                });
+                                if (confirmBandIndices.length > 0) {
+                                    // Resolve in parallel — independent calls, the LLMJudgeService
+                                    // owns its own timeout. We use Promise.allSettled so a single
+                                    // failure doesn't drop the others.
+                                    const judge = this.llmJudge;
+                                    const results = await Promise.allSettled(confirmBandIndices.map(idx => judge.classify({
+                                        newContent: knowledge.content,
+                                        candidateContent: candidates[idx].content_preview,
+                                    })));
+                                    results.forEach((r, i) => {
+                                        const idx = confirmBandIndices[i];
+                                        if (r.status === 'fulfilled') {
+                                            llmRelations[idx] = r.value;
+                                        }
+                                        else {
+                                            // Per-candidate failure: log and leave null — other
+                                            // candidates' results still ship.
+                                            console.warn(`⚠️ unified_store: llmJudge.classify failed for candidate ${candidates[idx].id} ` +
+                                                `(continuing with llm_relation=null): ` +
+                                                `${r.reason instanceof Error ? r.reason.message : String(r.reason)}`);
+                                        }
+                                    });
+                                    debug(`🤖 Tier 2 judge classified ${confirmBandIndices.length} confirm-band candidate(s) ` +
+                                        `(model=${this.llmJudge.modelId})`);
+                                }
+                            }
+                            else {
+                                debug(`🤖 Tier 2 judge unavailable — leaving llm_relation=null for confirm-band candidates`);
+                            }
+                        }
                         const oldIdHint = top.id;
                         const response = {
                             status: 'dedup_required',
-                            candidates: candidates.map(c => ({
+                            candidates: candidates.map((c, idx) => ({
                                 id: c.id,
                                 similarity: c.similarity,
                                 content_preview: c.content_preview,
@@ -232,7 +294,7 @@ export class UnifiedStoreTool {
                                 subject: c.subject,
                                 created: c.created,
                                 flag: c.flag ?? null,
-                                llm_relation: null // Tier 2 (DG-T2-A) will populate this
+                                llm_relation: llmRelations[idx]
                             })),
                             message: msg,
                             retry_with: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,11 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
+<<<<<<< HEAD
         "@anthropic-ai/sdk": "^0.40.1",
+=======
+        "@anthropic-ai/sdk": "^0.95.0",
+>>>>>>> 95d0cb1f ([DG-T2-A] LLM judge for borderline-band candidates (closes #49))
         "@modelcontextprotocol/sdk": "^1.18.1",
         "@types/better-sqlite3": "^7.6.13",
         "better-sqlite3": "^12.5.0",
@@ -64,11 +68,12 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.40.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.40.1.tgz",
-      "integrity": "sha512-DJMWm8lTEM9Lk/MSFL+V+ugF7jKOn0M2Ujvb5fN8r2nY14aHbGPZ1k6sgjL+tpJ3VuOGJNG+4R83jEpOuYPv8w==",
+      "version": "0.95.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.95.0.tgz",
+      "integrity": "sha512-7It2B76OFJH9jC/a0TicXFMq0ZZM25ei+i/mK7JnsE1Ibmo0Yfkqm+DXOHeU/ZxxKwLLGPP6qaAvKmQmgV6XhA==",
       "license": "MIT",
       "dependencies": {
+<<<<<<< HEAD
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
         "abort-controller": "^3.0.0",
@@ -94,19 +99,24 @@
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
+=======
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+>>>>>>> 95d0cb1f ([DG-T2-A] LLM judge for borderline-band candidates (closes #49))
       },
-      "engines": {
-        "node": "4.x || >=6.0.0"
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
       },
       "peerDependencies": {
-        "encoding": "^0.1.0"
+        "zod": "^3.25.0 || ^4.0.0"
       },
       "peerDependenciesMeta": {
-        "encoding": {
+        "zod": {
           "optional": true
         }
       }
     },
+<<<<<<< HEAD
     "node_modules/@anthropic-ai/sdk/node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -135,6 +145,8 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+=======
+>>>>>>> 95d0cb1f ([DG-T2-A] LLM judge for borderline-band candidates (closes #49))
     "node_modules/@azure/abort-controller": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
@@ -802,6 +814,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2725,6 +2746,12 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -5552,6 +5579,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
@@ -7632,6 +7665,19 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -10424,6 +10470,16 @@
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -10731,6 +10787,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "1.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-<<<<<<< HEAD
         "@anthropic-ai/sdk": "^0.40.1",
-=======
-        "@anthropic-ai/sdk": "^0.95.0",
->>>>>>> 95d0cb1f ([DG-T2-A] LLM judge for borderline-band candidates (closes #49))
         "@modelcontextprotocol/sdk": "^1.18.1",
         "@types/better-sqlite3": "^7.6.13",
         "better-sqlite3": "^12.5.0",
@@ -68,12 +64,11 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.95.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.95.0.tgz",
-      "integrity": "sha512-7It2B76OFJH9jC/a0TicXFMq0ZZM25ei+i/mK7JnsE1Ibmo0Yfkqm+DXOHeU/ZxxKwLLGPP6qaAvKmQmgV6XhA==",
+      "version": "0.40.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.40.1.tgz",
+      "integrity": "sha512-DJMWm8lTEM9Lk/MSFL+V+ugF7jKOn0M2Ujvb5fN8r2nY14aHbGPZ1k6sgjL+tpJ3VuOGJNG+4R83jEpOuYPv8w==",
       "license": "MIT",
       "dependencies": {
-<<<<<<< HEAD
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
         "abort-controller": "^3.0.0",
@@ -99,10 +94,6 @@
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
-=======
-        "json-schema-to-ts": "^3.1.1",
-        "standardwebhooks": "^1.0.0"
->>>>>>> 95d0cb1f ([DG-T2-A] LLM judge for borderline-band candidates (closes #49))
       },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
@@ -116,7 +107,6 @@
         }
       }
     },
-<<<<<<< HEAD
     "node_modules/@anthropic-ai/sdk/node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -145,14 +135,11 @@
         "webidl-conversions": "^3.0.0"
       }
     },
-=======
->>>>>>> 95d0cb1f ([DG-T2-A] LLM judge for borderline-band candidates (closes #49))
     "node_modules/@azure/abort-controller": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
       "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -165,7 +152,6 @@
       "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
       "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-util": "^1.13.0",
@@ -199,7 +185,6 @@
       "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.4.0.tgz",
       "integrity": "sha512-f1P96IB399YiN2ARYHP7EpZi3Bf3wH4SN2lGzrw7JVwm7bbsVYtf2iKSBwTywD2P62NOPZGHFSZi+6jjb75JuA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2"
       },
@@ -216,7 +201,6 @@
       "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.6.2.tgz",
       "integrity": "sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -248,7 +232,6 @@
       "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
       "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -261,7 +244,6 @@
       "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
       "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@typespec/ts-http-runtime": "^0.3.0",
@@ -299,7 +281,6 @@
       "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
       "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typespec/ts-http-runtime": "^0.3.0",
         "tslib": "^2.6.2"
@@ -313,7 +294,6 @@
       "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.9.0.tgz",
       "integrity": "sha512-CzE+4PefDSJWj26zU7G1bKchlGRRHMBFreG4tAlGuzyI8hAPiYGobaJvZBgZBf6L63iphX7VH+ityL8VgEQz9Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@azure/msal-common": "16.5.2"
       },
@@ -326,7 +306,6 @@
       "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.5.2.tgz",
       "integrity": "sha512-GkDEL6TYo3HgT3UuqakdgE9PZfc1hMki6+Hwgy1uddb/EauvAKfu85vVhuofRSo22D1xTnWt8Ucwfg4vSCVwvA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -336,7 +315,6 @@
       "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.5.tgz",
       "integrity": "sha512-ObTeMoNPmq19X3z40et9Xvs4ZoWVeJg43PZMRLG5iwVL+2nCtAerG3YTDItqPp1CfXNwmCXBbg8jn1DOx65c3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@azure/msal-common": "16.5.2",
         "jsonwebtoken": "^9.0.0"
@@ -397,6 +375,7 @@
       "integrity": "sha512-BU2f9tlKQ5CAthiMIgpzAh4eDTLWo1mqi9jqE2OxMG0E/OM199VJt2q8BztTxpnSW0i1ymdwLXRJnYzvDM5r2w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -816,15 +795,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/template": {
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -911,7 +881,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -926,7 +895,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -1449,7 +1417,6 @@
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
       "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -2009,7 +1976,6 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.44.tgz",
       "integrity": "sha512-RePW1IjGCHr9ua2vcby3aE8mOOz3EnwDZxMEGbNDT91kf14eqkJqxDXvaZFviGdcN9DTrxM5RPQNAHmwSm4tbg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "@standard-schema/spec": "^1.1.0",
@@ -2031,7 +1997,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2044,7 +2009,6 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2057,7 +2021,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -2193,6 +2156,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2542,36 +2506,31 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
       "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
       "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -2581,36 +2540,31 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
       "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@qdrant/js-client-rest": {
       "version": "1.13.0",
@@ -2636,7 +2590,6 @@
       "resolved": "https://registry.npmjs.org/@qdrant/openapi-typescript-fetch/-/openapi-typescript-fetch-1.2.6.tgz",
       "integrity": "sha512-oQG/FejNpItrxRHoyctYvT3rwGZOnK4jr3JdppO/c78ktDvkWiPXPHNsrDf33K9sZdRb6PR7gi4noIapu5q4HA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0",
         "pnpm": ">=8"
@@ -2647,7 +2600,6 @@
       "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
       "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@redis/client": "^1.0.0"
       }
@@ -2671,15 +2623,13 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/@redis/graph": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
       "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@redis/client": "^1.0.0"
       }
@@ -2689,7 +2639,6 @@
       "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
       "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@redis/client": "^1.0.0"
       }
@@ -2699,7 +2648,6 @@
       "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
       "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@redis/client": "^1.0.0"
       }
@@ -2709,7 +2657,6 @@
       "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
       "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@redis/client": "^1.0.0"
       }
@@ -2718,8 +2665,7 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@sevinf/maybe/-/maybe-0.5.0.tgz",
       "integrity": "sha512-ARhyoYDnY1LES3vYI0fiG6e9esWfTNcXcO6+MPJJXcnyMV3bim4lnFt45VXouV7y82F4x3YH8nOQ6VztuvUiWg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -2747,25 +2693,17 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
-    "node_modules/@stablelib/base64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
-      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
-      "license": "MIT"
-    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.105.3",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.105.3.tgz",
       "integrity": "sha512-hMFuzP++mjRfe0/BUq4/e82CXIDgyjUgg0khLN8waol/gzoM1t2iGmhfJSGvQHQ1dr3XqWpP6ThAw4bLHMot5Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "2.8.1"
       },
@@ -2778,7 +2716,6 @@
       "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.105.3.tgz",
       "integrity": "sha512-KyutUwLLUZ9fRXsiFACL6lq7akBVHFl0fnqQnrxjbsPco8jeb4EyirQuvr52QCLnikzjMRC0uxAHOSM54aDrZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "2.8.1"
       },
@@ -2790,15 +2727,13 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.1.tgz",
       "integrity": "sha512-hWGJkDAfWUNY8k0C080u3sGNFd2ncl9erhKgP7hnGkgJWEfT5Pd/SXal4QmWXBECVlZrannMAc9sBaaRyWpiUA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@supabase/postgrest-js": {
       "version": "2.105.3",
       "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.105.3.tgz",
       "integrity": "sha512-jFVYRHcri0ZMcTzKpQ2r2wWOB8/rPsbj92kxmCmVJUiRrdgiMtuYlkS06Fhs8UJZhEOL0UpGhh06XDwh8JwtBQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "2.8.1"
       },
@@ -2811,7 +2746,6 @@
       "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.105.3.tgz",
       "integrity": "sha512-L+qPiJlq1RKh3QD2fORGCFo2RKDKlvG9mjvPtUEQJ2tMixrx70VIV6j8BdWzQkbc1Nao6mvTWajyDhX3TFgljw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@supabase/phoenix": "^0.4.1",
         "@types/ws": "^8.18.1",
@@ -2827,7 +2761,6 @@
       "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.105.3.tgz",
       "integrity": "sha512-M7oPCCcHim/FsR6rKIs10Nd9mW051N2SQvA27jiVLa7oQMFFb7faX5dCQRV4GS5QeFsBcV5J/fWl4Ppoaw8cBQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "iceberg-js": "^0.8.1",
         "tslib": "2.8.1"
@@ -2859,8 +2792,7 @@
       "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
@@ -2868,8 +2800,7 @@
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
@@ -2877,8 +2808,7 @@
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
@@ -2886,8 +2816,7 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3048,6 +2977,7 @@
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
       "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
@@ -3094,6 +3024,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.2.tgz",
       "integrity": "sha512-9pLGGwdzOUBDYi0GNjM97FIA+f92fqSke6joWeBjWXllfNxZBs7qeMF7tvtOIsbY45xkWkxrdwUfUf3MnQa9gA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3136,8 +3067,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/semver": {
       "version": "7.7.0",
@@ -3216,7 +3146,6 @@
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -3278,6 +3207,7 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -3439,7 +3369,6 @@
       "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.5.tgz",
       "integrity": "sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.0",
@@ -3487,6 +3416,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3511,7 +3441,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "acorn": "^8.11.0"
       },
@@ -3524,7 +3453,6 @@
       "resolved": "https://registry.npmjs.org/afinn-165/-/afinn-165-2.0.2.tgz",
       "integrity": "sha512-mJ/RLUfpXfQA6bzugv+bBsc/QYkVrKaLYeS8fWBpKbTCsonv4iuV9ET0fgReEunm9vKLkaNgnekuSNlTC3WQ1Q==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -3535,7 +3463,6 @@
       "resolved": "https://registry.npmjs.org/afinn-165-financialmarketnews/-/afinn-165-financialmarketnews-3.0.0.tgz",
       "integrity": "sha512-0g9A1S3ZomFIGDTzZ0t6xmv4AuokBvBmpes8htiyHpH7N4xDmvSQL6UxL/Zcs2ypRb3VwgCscaD8Q3zEawKYhw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -3546,7 +3473,6 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -3692,7 +3618,6 @@
       "resolved": "https://registry.npmjs.org/apparatus/-/apparatus-0.0.10.tgz",
       "integrity": "sha512-KLy/ugo33KZA7nugtQ7O0E1c8kQ52N3IvD/XgIh4w/Nr28ypfkwDfA67F1ev4N1m5D+BOk1+b2dEJDfpj/VvZg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "sylvester": ">= 0.0.8"
       },
@@ -3706,8 +3631,7 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -3899,8 +3823,7 @@
     "node_modules/base-64": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
-      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA==",
-      "peer": true
+      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -3928,6 +3851,7 @@
       "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -3941,7 +3865,6 @@
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
       "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -4086,6 +4009,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -4173,7 +4097,6 @@
       "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
       "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -4183,7 +4106,6 @@
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
       "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "run-applescript": "^7.0.0"
       },
@@ -4304,7 +4226,6 @@
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
       "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -4357,7 +4278,6 @@
       "resolved": "https://registry.npmjs.org/cloudflare/-/cloudflare-4.5.0.tgz",
       "integrity": "sha512-fPcbPKx4zF45jBvQ0z7PCdgejVAPBBCZxwqk1k7krQNfpM07Cfj97/Q6wBzvYqlWXx/zt1S9+m8vnfCe06umbQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -4373,7 +4293,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
       "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -4383,7 +4302,6 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -4403,29 +4321,25 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cloudflare/node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cloudflare/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/cloudflare/node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -4611,8 +4525,7 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4633,7 +4546,6 @@
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
       "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -4669,7 +4581,6 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4735,7 +4646,6 @@
       "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
       "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bundle-name": "^4.1.0",
         "default-browser-id": "^5.0.0"
@@ -4752,7 +4662,6 @@
       "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
       "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -4765,7 +4674,6 @@
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
       "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4847,7 +4755,6 @@
       "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -4866,7 +4773,6 @@
       "resolved": "https://registry.npmjs.org/digest-fetch/-/digest-fetch-1.3.0.tgz",
       "integrity": "sha512-CGJuv6iKNM7QyZlM2T3sPAdZWd/p9zQiRNS9G+9COUCwzWFTs0Xp8NF5iePx7wtvhDykReiRRrSeNb4oMmB8lA==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "base-64": "^0.1.0",
         "md5": "^2.3.0"
@@ -4903,7 +4809,6 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
       "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4945,7 +4850,6 @@
       "resolved": "https://registry.npmjs.org/efrt/-/efrt-2.7.0.tgz",
       "integrity": "sha512-/RInbCy1d4P6Zdfa+TMVsf/ufZVotat5hCw3QXmWtjU+3pFEOvOQ7ibo3aIxyCJw2leIeAMjmPj+1SLJiCpdrQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -5143,6 +5047,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5347,15 +5252,13 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -5519,8 +5422,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -5578,12 +5480,6 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-sha256": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
-      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
-      "license": "Unlicense"
     },
     "node_modules/fast-uri": {
       "version": "3.1.2",
@@ -5922,7 +5818,6 @@
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
       "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
@@ -5938,7 +5833,6 @@
       "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "gaxios": "^5.0.0",
         "json-bigint": "^1.0.0"
@@ -5953,7 +5847,6 @@
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "debug": "4"
       },
@@ -5967,7 +5860,6 @@
       "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^5.0.0",
@@ -5984,7 +5876,6 @@
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -5999,7 +5890,6 @@
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -6020,16 +5910,14 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/gcp-metadata/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/gcp-metadata/node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -6037,7 +5925,6 @@
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -6048,7 +5935,6 @@
       "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
       "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -6253,7 +6139,6 @@
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
       "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
@@ -6271,7 +6156,6 @@
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
       "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "gaxios": "^7.0.0",
         "google-logging-utils": "^1.0.0",
@@ -6286,7 +6170,6 @@
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
       "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -6298,7 +6181,6 @@
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
       "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -6309,7 +6191,6 @@
       "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
       "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -6337,7 +6218,6 @@
       "resolved": "https://registry.npmjs.org/grad-school/-/grad-school-0.0.5.tgz",
       "integrity": "sha512-rXunEHF9M9EkMydTBux7+IryYXEZinRk6g8OBOGDBzo/qWJjhTxy86i5q7lQYpCLHN8Sqv1XX3OIOc7ka2gtvQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -6354,7 +6234,6 @@
       "resolved": "https://registry.npmjs.org/groq-sdk/-/groq-sdk-0.3.0.tgz",
       "integrity": "sha512-Cdgjh4YoSBE2X4S9sxPGXaAy1dlN4bRtAaDZ3cnq+XsxhhN9WSBeHF64l7LWwuD5ntmw7YC5Vf4Ff1oHCg1LOg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -6372,7 +6251,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
       "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -6382,7 +6260,6 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -6402,29 +6279,25 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/groq-sdk/node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/groq-sdk/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/groq-sdk/node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -6492,6 +6365,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.17.tgz",
       "integrity": "sha512-FbJJNb/XgX7YW0hX/V8w5oYLztKEsRLykCMZWt1WdLtsfjzMvmoqWBA4H4t5norinq8/rh20oiZYr+WSl4UzAQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -6524,7 +6398,6 @@
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -6538,7 +6411,6 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -6571,7 +6443,6 @@
       "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
       "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -6742,8 +6613,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
@@ -6766,7 +6636,6 @@
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
       "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "is-docker": "cli.js"
       },
@@ -6825,7 +6694,6 @@
       "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
       "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-docker": "^3.0.0"
       },
@@ -6882,7 +6750,6 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
       "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-inside-container": "^1.0.0"
       },
@@ -7019,6 +6886,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -7605,7 +7473,6 @@
       "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
       "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.5.1"
       }
@@ -7647,7 +7514,6 @@
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
@@ -7665,19 +7531,6 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json-schema-to-ts": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
-      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "ts-algebra": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -7777,7 +7630,6 @@
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-3.3.0.tgz",
       "integrity": "sha512-kpSuLD3/7RenBnjnJdOHXCKC8dTd1JzeOiJhN0necWWci6cC+qX+VuwPnMVgb+a4+KNJSfgqahpnfWaeDXCimw==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       }
@@ -7807,7 +7659,6 @@
       "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.6.1.tgz",
       "integrity": "sha512-qNBNPRFqScIlGaPGfMrxhw/GTOL4GJKMp1P4jeA3xuI+Gkj5Ei3wvOtxpYaZMTeBbXTW3yi4n4Wf3nCgogvttg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-queue": "6.6.2"
       },
@@ -7966,8 +7817,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -8054,7 +7904,6 @@
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
       "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "charenc": "0.0.2",
         "crypt": "0.0.2",
@@ -8111,7 +7960,6 @@
       "resolved": "https://registry.npmjs.org/memjs/-/memjs-1.3.2.tgz",
       "integrity": "sha512-qUEg2g8vxPe+zPn09KidjIStHPtoBO8Cttm8bgJFWWabbsjQ9Av9Ky+6UcvKx6ue0LLb/LEhtcyQpRyKfzeXcg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8317,7 +8165,6 @@
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-9.6.1.tgz",
       "integrity": "sha512-3T8/b0plM3ZJPW3WjlzVMIGJEYYTjgDPQ05Qzru3xu3/wOPSFKWYxdwUF2dl8h3NG5dVkzIuOkZdLacnlLf/sA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "kareem": "3.3.0",
         "mongodb": "~7.2",
@@ -8339,7 +8186,6 @@
       "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
       "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/webidl-conversions": "*"
       }
@@ -8349,25 +8195,8 @@
       "resolved": "https://registry.npmjs.org/bson/-/bson-7.2.0.tgz",
       "integrity": "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
-      }
-    },
-    "node_modules/mongoose/node_modules/gcp-metadata": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
-      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "google-logging-utils": "^1.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/mongoose/node_modules/mongodb": {
@@ -8375,7 +8204,6 @@
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.2.0.tgz",
       "integrity": "sha512-F/2+BMZtLVhY30ioZp0dAmZ+IRZMBqI+nrv6t5+9/1AIwCa8sMRC3jBf81lpxMhnZgqq8CoUD503Z1oZWq1/sw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@mongodb-js/saslprep": "^1.3.0",
         "bson": "^7.2.0",
@@ -8422,7 +8250,6 @@
       "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz",
       "integrity": "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@types/whatwg-url": "^13.0.0",
         "whatwg-url": "^14.1.0"
@@ -8436,7 +8263,6 @@
       "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
       "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -8446,7 +8272,6 @@
       "resolved": "https://registry.npmjs.org/mquery/-/mquery-6.0.0.tgz",
       "integrity": "sha512-b2KQNsmgtkscfeDgkYMcWGn9vZI9YoXh802VDEwE6qc50zxBFQ0Oo8ROkawbPAsXCY1/Z1yp0MagqsZStPWJjw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -8462,7 +8287,6 @@
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
       "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "mustache": "bin/mustache"
       }
@@ -8478,7 +8302,6 @@
       "resolved": "https://registry.npmjs.org/natural/-/natural-8.1.1.tgz",
       "integrity": "sha512-Ucb+lsUcGxUqu3rn8cwHjT6gJQosO63nIX/aBQXB3+IDkNbFV7PuviysO+Rzz3aKn7PZhPj3bNF4PS9gDVjYCQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "afinn-165": "^2.0.2",
         "afinn-165-financialmarketnews": "^3.0.0",
@@ -8511,7 +8334,6 @@
       "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.12.1.tgz",
       "integrity": "sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 18.19.0"
       },
@@ -8549,7 +8371,6 @@
       "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.12.1.tgz",
       "integrity": "sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 18.19.0"
       },
@@ -8562,7 +8383,6 @@
       "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.12.1.tgz",
       "integrity": "sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 18.19.0"
       },
@@ -8575,7 +8395,6 @@
       "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.12.1.tgz",
       "integrity": "sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 18.19.0"
       },
@@ -8588,7 +8407,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -8616,7 +8434,6 @@
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
       "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-int8": "1.0.1",
         "postgres-array": "~2.0.0",
@@ -8633,7 +8450,6 @@
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
       "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -8643,7 +8459,6 @@
       "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
       "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8653,7 +8468,6 @@
       "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
       "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8663,7 +8477,6 @@
       "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
       "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "xtend": "^4.0.0"
       },
@@ -8676,7 +8489,6 @@
       "resolved": "https://registry.npmjs.org/redis/-/redis-5.12.1.tgz",
       "integrity": "sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@redis/bloom": "5.12.1",
         "@redis/client": "5.12.1",
@@ -8697,7 +8509,6 @@
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
-      "peer": true,
       "bin": {
         "uuid": "dist-node/bin/uuid"
       }
@@ -8851,8 +8662,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ollama": {
       "version": "0.5.18",
@@ -8906,7 +8716,6 @@
       "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
       "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "default-browser": "^5.2.1",
         "define-lazy-prop": "^3.0.0",
@@ -8925,6 +8734,7 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
       "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -9030,7 +8840,6 @@
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -9072,7 +8881,6 @@
       "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
       "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eventemitter3": "^4.0.4",
         "p-timeout": "^3.2.0"
@@ -9089,7 +8897,6 @@
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
       "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/retry": "0.12.0",
         "retry": "^0.13.1"
@@ -9103,7 +8910,6 @@
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
       "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-finally": "^1.0.0"
       },
@@ -9125,8 +8931,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
       "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -9256,22 +9061,19 @@
       "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
       "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/pg-connection-string": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
       "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -9281,7 +9083,6 @@
       "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
       "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -9291,7 +9092,6 @@
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
       "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "pg": ">=8.0"
       }
@@ -9300,15 +9100,13 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
       "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/pg-types": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.1.0.tgz",
       "integrity": "sha512-o2XFanIMy/3+mThw69O8d4n1E5zsLhdO+OPqswezu7Z5ekP4hYDqlDjlmOpYMbzY2Br0ufCwJLdDIXeNVwcWFg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-int8": "1.0.1",
         "pg-numeric": "1.0.2",
@@ -9327,7 +9125,6 @@
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
       "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-int8": "1.0.1",
         "postgres-array": "~2.0.0",
@@ -9344,7 +9141,6 @@
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
       "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -9354,7 +9150,6 @@
       "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
       "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9364,7 +9159,6 @@
       "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
       "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9374,7 +9168,6 @@
       "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
       "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "xtend": "^4.0.0"
       },
@@ -9387,7 +9180,6 @@
       "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
       "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "split2": "^4.1.0"
       }
@@ -9503,7 +9295,6 @@
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.4.tgz",
       "integrity": "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9513,7 +9304,6 @@
       "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
       "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "obuf": "~1.1.2"
       },
@@ -9526,7 +9316,6 @@
       "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.1.0.tgz",
       "integrity": "sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9536,7 +9325,6 @@
       "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
       "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9545,8 +9333,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.4.tgz",
       "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
@@ -9630,7 +9417,6 @@
       "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -9990,7 +9776,6 @@
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -10054,7 +9839,6 @@
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
       "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -10120,7 +9904,6 @@
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
       "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -10309,8 +10092,7 @@
       "version": "17.1.3",
       "resolved": "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz",
       "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
@@ -10417,6 +10199,21 @@
         "@sparrowdb/win32-x64-msvc": "0.1.20"
       }
     },
+    "node_modules/sparrowdb/node_modules/@sparrowdb/darwin-arm64": {
+      "optional": true
+    },
+    "node_modules/sparrowdb/node_modules/@sparrowdb/darwin-x64": {
+      "optional": true
+    },
+    "node_modules/sparrowdb/node_modules/@sparrowdb/linux-arm64-gnu": {
+      "optional": true
+    },
+    "node_modules/sparrowdb/node_modules/@sparrowdb/linux-x64-gnu": {
+      "optional": true
+    },
+    "node_modules/sparrowdb/node_modules/@sparrowdb/win32-x64-msvc": {
+      "optional": true
+    },
     "node_modules/sparse-bitfield": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
@@ -10431,7 +10228,6 @@
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">= 10.x"
       }
@@ -10470,16 +10266,6 @@
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
       "license": "MIT"
     },
-    "node_modules/standardwebhooks": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
-      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
-      "license": "MIT",
-      "dependencies": {
-        "@stablelib/base64": "^1.0.0",
-        "fast-sha256": "^1.3.0"
-      }
-    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -10494,7 +10280,6 @@
       "resolved": "https://registry.npmjs.org/stopwords-iso/-/stopwords-iso-1.1.0.tgz",
       "integrity": "sha512-I6GPS/E0zyieHehMRPQcqkiBMJKGgLta+1hREixhoLPqEA0AlVFiC43dl8uPpmkkeRdDMzYRWFWk5/l9x7nmNg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10587,8 +10372,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/suffix-thumb/-/suffix-thumb-5.0.2.tgz",
       "integrity": "sha512-I5PWXAFKx3FYnI9a+dQMWNqTxoRt6vdBdb0O+BJ1sxXCWtSoQCusc13E58f+9p4MYx/qCnEMkD5jac6K2j3dgA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/superagent": {
       "version": "8.1.2",
@@ -10669,7 +10453,6 @@
       "version": "0.0.21",
       "resolved": "https://registry.npmjs.org/sylvester/-/sylvester-0.0.21.tgz",
       "integrity": "sha512-yUT0ukFkFEt4nb+NY+n2ag51aS/u9UHXoZw+A4jgD77/jzZsBoSDHuqysrVCBC4CYR4TYvUJq54ONpXgDBH8tA==",
-      "peer": true,
       "engines": {
         "node": ">=0.2.6"
       }
@@ -10788,12 +10571,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/ts-algebra": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
-      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "license": "MIT"
-    },
     "node_modules/ts-api-utils": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
@@ -10871,52 +10648,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ts-node": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
-      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
       }
     },
     "node_modules/tslib": {
@@ -11011,6 +10742,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11023,15 +10755,13 @@
       "version": "1.13.8",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
       "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "5.28.5",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
       "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },
@@ -11130,8 +10860,7 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -11189,8 +10918,7 @@
       "version": "3.6.20",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
       "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/whatwg-url": {
       "version": "14.2.0",
@@ -11235,7 +10963,6 @@
       "resolved": "https://registry.npmjs.org/wordnet-db/-/wordnet-db-3.1.14.tgz",
       "integrity": "sha512-zVyFsvE+mq9MCmwXUWHIcpfbrHHClZWZiVOzKSxNJruIcFn2RbY55zkhiAMMxM8zCVSmtNiViq8FsAZSFpMYag==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.6.0"
       }
@@ -11283,7 +11010,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -11305,7 +11031,6 @@
       "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
       "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-wsl": "^3.1.0"
       },
@@ -11321,7 +11046,6 @@
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.4"
       }
@@ -11379,7 +11103,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -11402,6 +11125,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
       "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "author": "Richard Yaker",
   "license": "MIT",
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.95.0",
+    "@anthropic-ai/sdk": "^0.40.1",
     "@modelcontextprotocol/sdk": "^1.18.1",
     "@types/better-sqlite3": "^7.6.13",
     "better-sqlite3": "^12.5.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "author": "Richard Yaker",
   "license": "MIT",
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.40.1",
+    "@anthropic-ai/sdk": "^0.95.0",
     "@modelcontextprotocol/sdk": "^1.18.1",
     "@types/better-sqlite3": "^7.6.13",
     "better-sqlite3": "^12.5.0",

--- a/src/__tests__/UnifiedStoreTool.dedup_gate.test.ts
+++ b/src/__tests__/UnifiedStoreTool.dedup_gate.test.ts
@@ -163,7 +163,10 @@ describe('DG-T1-B — UnifiedStoreTool dedup gate (issue #45)', () => {
     expect(result.candidates).toHaveLength(1)
     expect(result.candidates[0].id).toBe('existing-fact-id')
     expect(result.candidates[0].similarity).toBeCloseTo(0.92, 5)
-    expect(result.candidates[0].llm_relation).toBeNull()  // Tier 2 not yet wired
+    // DG-T2-A: refuse-band candidates get 'duplicate' inline (no LLM call —
+    // the embedder agrees so strongly we don't need a Tier 2 classification).
+    // Tests with no llmJudge wired still get this free-win 'duplicate' tag.
+    expect(result.candidates[0].llm_relation).toBe('duplicate')
     expect(result.thresholds.refuse).toBe(0.88)
     expect(result.thresholds.confirm).toBe(0.78)
     expect(result.retry_with).toEqual(

--- a/src/__tests__/UnifiedStoreTool.dedup_judge.test.ts
+++ b/src/__tests__/UnifiedStoreTool.dedup_judge.test.ts
@@ -1,0 +1,667 @@
+/**
+ * DG-T2-A — Tier 2 LLM-judge integration tests (issue #49).
+ *
+ * Verifies the UnifiedStoreTool wiring of LLMJudgeService into the dedup
+ * gate's confirm-band classification path:
+ *
+ *   1. Confirm-band candidates trigger classify() with the right args
+ *   2. Refuse-band candidates skip the LLM and get 'duplicate' inline
+ *   3. Mixed bands: only confirm-band candidates call the judge
+ *   4. judge.classify() throw → that candidate gets null, others succeed
+ *   5. judge.isAvailable() → false → no calls, all null (Tier 1 result still ships)
+ *   6. Cached repeats don't re-invoke classify() (cache hit)
+ *   7. judge === null (not configured) → no calls, refuse band still gets 'duplicate'
+ *   8. parseLLMRelation handles all 6 valid relations + falls back to 'unrelated'
+ *   9. LRUCache: bumps on read, evicts oldest at capacity
+ *  10. judgeCacheKey: deterministic, content-pair sensitive
+ */
+
+import { UnifiedStoreTool, type UnifiedStoreResult, type DedupRequiredResponse } from '../tools/UnifiedStoreTool.js'
+import { IntelligentStorageRouter } from '../routing/IntelligentStorageRouter.js'
+import type { GraphStorage } from '../types/index.js'
+import type { EmbeddingService } from '../embedding/EmbeddingService.js'
+import type { LLMJudgeService, LLMRelation } from '../embedding/LLMJudgeService.js'
+import {
+  parseLLMRelation,
+  judgeCacheKey,
+  LRUCache,
+} from '../embedding/LLMJudgeService.js'
+
+function isDedupRequired(r: UnifiedStoreResult): r is DedupRequiredResponse {
+  return (r as any).status === 'dedup_required'
+}
+
+function unitVec(axis = 0, dim = 768): Float32Array {
+  const v = new Float32Array(dim)
+  v[axis] = 1
+  return v
+}
+
+describe('DG-T2-A — UnifiedStoreTool LLM judge wiring (issue #49)', () => {
+  let mongo: any
+  let graph: any
+  let mem0: any
+  let cache: any
+  let router: IntelligentStorageRouter
+  let embedder: jest.Mocked<EmbeddingService>
+  let judge: jest.Mocked<LLMJudgeService>
+
+  beforeEach(() => {
+    mongo = {
+      store: jest.fn().mockResolvedValue(undefined),
+      update: jest.fn().mockResolvedValue(true),
+      delete: jest.fn().mockResolvedValue(true),
+      flag: jest.fn().mockResolvedValue(true),
+      listFlagged: jest.fn().mockResolvedValue([])
+    }
+
+    graph = {
+      name: 'sparrowdb',
+      store: jest.fn().mockResolvedValue(undefined),
+      storeEmbedding: jest.fn().mockResolvedValue(true),
+      findSimilar: jest.fn().mockResolvedValue([]),
+      update: jest.fn().mockResolvedValue(true),
+      delete: jest.fn().mockResolvedValue(true),
+      flag: jest.fn().mockResolvedValue(true),
+      findById: jest.fn().mockReturnValue(null),
+      listFlagged: jest.fn().mockReturnValue([])
+    } as unknown as GraphStorage
+
+    mem0 = {
+      store: jest.fn().mockResolvedValue(undefined),
+      deleteMemory: jest.fn().mockResolvedValue(true)
+    }
+
+    cache = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValue(undefined),
+      invalidate: jest.fn().mockResolvedValue(undefined)
+    }
+
+    router = {
+      determineStorage: jest.fn().mockReturnValue({
+        primary: 'graph',
+        secondary: ['mongodb', 'mem0'],
+        cacheStrategy: 'L3',
+        reasoning: 'test'
+      }),
+      getRoutingStats: jest.fn().mockReturnValue({})
+    } as unknown as IntelligentStorageRouter
+
+    embedder = {
+      embedderId: 'nomic-embed-text:v1',
+      dimensions: 768,
+      embed: jest.fn().mockResolvedValue(unitVec(0)),
+      isAvailable: jest.fn().mockResolvedValue(true)
+    } as unknown as jest.Mocked<EmbeddingService>
+
+    judge = {
+      modelId: 'claude-haiku-4-5-20251001',
+      classify: jest.fn().mockResolvedValue('complement' as LLMRelation),
+      isAvailable: jest.fn().mockResolvedValue(true)
+    } as unknown as jest.Mocked<LLMJudgeService>
+  })
+
+  function makeTool(judgeOverride: LLMJudgeService | null | undefined = judge): UnifiedStoreTool {
+    return new UnifiedStoreTool(
+      router,
+      { mongodb: mongo, graph, mem0 },
+      cache,
+      null, null,
+      embedder,
+      judgeOverride ?? null
+    )
+  }
+
+  // -------------------------------------------------------------------------
+  // 1. Confirm-band → classify() called with the right args
+  // -------------------------------------------------------------------------
+
+  it('calls classify() for confirm-band candidate with new + candidate content', async () => {
+    ;(graph as any).findSimilar = jest.fn().mockResolvedValue([
+      {
+        id: 'existing-fact',
+        similarity: 0.83,  // confirm band: 0.78 ≤ 0.83 < 0.88
+        contentType: 'fact',
+        source: 'technical',
+        created: '2026-04-01T00:00:00Z',
+        flag: null,
+        content_preview: 'EXISTING CONTENT preview'
+      }
+    ])
+
+    judge.classify.mockResolvedValue('supersedes')
+
+    const tool = makeTool()
+    const result = await tool.store({
+      content: 'NEW CONTENT for the gate',
+      contentType: 'fact',
+      userId: 'richard_yaker'
+    })
+
+    expect(isDedupRequired(result)).toBe(true)
+    if (!isDedupRequired(result)) return
+
+    expect(judge.classify).toHaveBeenCalledTimes(1)
+    expect(judge.classify).toHaveBeenCalledWith({
+      newContent: 'NEW CONTENT for the gate',
+      candidateContent: 'EXISTING CONTENT preview'
+    })
+    expect(result.candidates[0].llm_relation).toBe('supersedes')
+    expect(result.band).toBe('confirm')
+  })
+
+  // -------------------------------------------------------------------------
+  // 2. Refuse-band: 'duplicate' inline, no classify() call
+  // -------------------------------------------------------------------------
+
+  it('refuse-band candidates get llm_relation=duplicate without calling classify()', async () => {
+    ;(graph as any).findSimilar = jest.fn().mockResolvedValue([
+      {
+        id: 'existing-fact',
+        similarity: 0.95,  // refuse band: ≥ 0.88
+        contentType: 'fact',
+        source: 'technical',
+        created: '2026-04-01T00:00:00Z',
+        flag: null,
+        content_preview: 'near-identical content'
+      }
+    ])
+
+    const tool = makeTool()
+    const result = await tool.store({
+      content: 'newer near-identical content',
+      contentType: 'fact',
+      userId: 'richard_yaker'
+    })
+
+    expect(isDedupRequired(result)).toBe(true)
+    if (!isDedupRequired(result)) return
+
+    expect(judge.classify).not.toHaveBeenCalled()  // free win — saves $$$
+    expect(result.candidates[0].llm_relation).toBe('duplicate')
+    expect(result.band).toBe('refuse')
+  })
+
+  // -------------------------------------------------------------------------
+  // 3. Mixed bands in a single response: only confirm-band hits judge
+  // -------------------------------------------------------------------------
+
+  it('with mixed-similarity candidates, only confirm-band ones call classify()', async () => {
+    ;(graph as any).findSimilar = jest.fn().mockResolvedValue([
+      // Top is refuse-band → triggers gate
+      { id: 'high', similarity: 0.91, contentType: 'fact', source: 'technical', created: '2026-04-01T00:00:00Z', flag: null, content_preview: 'high-sim content' },
+      // Confirm-band → judge called
+      { id: 'mid',  similarity: 0.82, contentType: 'fact', source: 'technical', created: '2026-04-01T00:00:00Z', flag: null, content_preview: 'mid-sim content' },
+      // Below confirm threshold (0.78) → still in candidates list since findSimilar
+      // returns top-K, but llm_relation stays null (no classification needed)
+      { id: 'low',  similarity: 0.71, contentType: 'fact', source: 'technical', created: '2026-04-01T00:00:00Z', flag: null, content_preview: 'low-sim content' },
+    ])
+
+    judge.classify.mockResolvedValue('complement')
+
+    const tool = makeTool()
+    const result = await tool.store({
+      content: 'new content',
+      contentType: 'fact',
+      userId: 'richard_yaker'
+    })
+
+    expect(isDedupRequired(result)).toBe(true)
+    if (!isDedupRequired(result)) return
+
+    // Only the mid-sim candidate (0.82) gets classified — high gets 'duplicate'
+    // inline, low stays null.
+    expect(judge.classify).toHaveBeenCalledTimes(1)
+    expect(judge.classify).toHaveBeenCalledWith({
+      newContent: 'new content',
+      candidateContent: 'mid-sim content'
+    })
+
+    const byId = Object.fromEntries(result.candidates.map(c => [c.id, c.llm_relation]))
+    expect(byId['high']).toBe('duplicate')
+    expect(byId['mid']).toBe('complement')
+    expect(byId['low']).toBeNull()
+  })
+
+  // -------------------------------------------------------------------------
+  // 4. classify() failure for ONE candidate doesn't sink the whole response
+  // -------------------------------------------------------------------------
+
+  it('per-candidate classify() throw → that candidate=null, others classified', async () => {
+    ;(graph as any).findSimilar = jest.fn().mockResolvedValue([
+      // Both in confirm band — both should be classified in parallel.
+      // Top is the one we'll have classify() reject for.
+      { id: 'a', similarity: 0.85, contentType: 'fact', source: 'technical', created: '2026-04-01T00:00:00Z', flag: null, content_preview: 'A content' },
+      { id: 'b', similarity: 0.81, contentType: 'fact', source: 'technical', created: '2026-04-01T00:00:00Z', flag: null, content_preview: 'B content' },
+    ])
+
+    // First call (for 'a') rejects, second (for 'b') succeeds.
+    judge.classify
+      .mockRejectedValueOnce(new Error('judge timeout'))
+      .mockResolvedValueOnce('complement')
+
+    const tool = makeTool()
+    const result = await tool.store({
+      content: 'new content',
+      contentType: 'fact',
+      userId: 'richard_yaker'
+    })
+
+    expect(isDedupRequired(result)).toBe(true)
+    if (!isDedupRequired(result)) return
+
+    expect(judge.classify).toHaveBeenCalledTimes(2)
+    const byId = Object.fromEntries(result.candidates.map(c => [c.id, c.llm_relation]))
+    expect(byId['a']).toBeNull()         // failed classify → null
+    expect(byId['b']).toBe('complement') // succeeded
+    // Critical: gate response still ships — failure didn't abort
+    expect(result.status).toBe('dedup_required')
+  })
+
+  // -------------------------------------------------------------------------
+  // 5. judge.isAvailable() → false → no classify() calls
+  // -------------------------------------------------------------------------
+
+  it('judge unavailable → no classify() calls; confirm-band gets null', async () => {
+    judge.isAvailable.mockResolvedValue(false)
+    ;(graph as any).findSimilar = jest.fn().mockResolvedValue([
+      { id: 'a', similarity: 0.83, contentType: 'fact', source: 'technical', created: '2026-04-01T00:00:00Z', flag: null, content_preview: 'A' },
+    ])
+
+    const tool = makeTool()
+    const result = await tool.store({
+      content: 'new content',
+      contentType: 'fact',
+      userId: 'richard_yaker'
+    })
+
+    expect(isDedupRequired(result)).toBe(true)
+    if (!isDedupRequired(result)) return
+
+    expect(judge.classify).not.toHaveBeenCalled()
+    expect(result.candidates[0].llm_relation).toBeNull()
+    // Tier 1 result still ships — gate refusal works without Tier 2
+    expect(result.band).toBe('confirm')
+  })
+
+  // -------------------------------------------------------------------------
+  // 6. judge.isAvailable() throw → degrades gracefully (no calls, all null)
+  // -------------------------------------------------------------------------
+
+  it('judge.isAvailable() throw → skips Tier 2, still ships gate response', async () => {
+    judge.isAvailable.mockRejectedValue(new Error('availability check exploded'))
+    ;(graph as any).findSimilar = jest.fn().mockResolvedValue([
+      { id: 'a', similarity: 0.83, contentType: 'fact', source: 'technical', created: '2026-04-01T00:00:00Z', flag: null, content_preview: 'A' },
+    ])
+
+    const tool = makeTool()
+    const result = await tool.store({
+      content: 'new content',
+      contentType: 'fact',
+      userId: 'richard_yaker'
+    })
+
+    expect(isDedupRequired(result)).toBe(true)
+    if (!isDedupRequired(result)) return
+    expect(judge.classify).not.toHaveBeenCalled()
+    expect(result.candidates[0].llm_relation).toBeNull()
+  })
+
+  // -------------------------------------------------------------------------
+  // 7. judge === null (not configured) → degrades gracefully
+  // -------------------------------------------------------------------------
+
+  it('llmJudge=null → no Tier 2 attempted; refuse-band still gets "duplicate"', async () => {
+    ;(graph as any).findSimilar = jest.fn().mockResolvedValue([
+      { id: 'high', similarity: 0.91, contentType: 'fact', source: 'technical', created: '2026-04-01T00:00:00Z', flag: null, content_preview: 'high' },
+      { id: 'mid',  similarity: 0.82, contentType: 'fact', source: 'technical', created: '2026-04-01T00:00:00Z', flag: null, content_preview: 'mid'  },
+    ])
+
+    const tool = makeTool(null)
+    const result = await tool.store({
+      content: 'new content',
+      contentType: 'fact',
+      userId: 'richard_yaker'
+    })
+
+    expect(isDedupRequired(result)).toBe(true)
+    if (!isDedupRequired(result)) return
+
+    const byId = Object.fromEntries(result.candidates.map(c => [c.id, c.llm_relation]))
+    expect(byId['high']).toBe('duplicate')  // free-win path doesn't need judge
+    expect(byId['mid']).toBeNull()           // confirm-band needs judge → null
+    // Judge mock was injected per-test but tool was made with null override —
+    // verify the mock was never invoked.
+    expect(judge.classify).not.toHaveBeenCalled()
+    expect(judge.isAvailable).not.toHaveBeenCalled()
+  })
+
+  // -------------------------------------------------------------------------
+  // 8. classify() runs in parallel for multiple confirm-band candidates
+  // -------------------------------------------------------------------------
+
+  it('classifies multiple confirm-band candidates in parallel (Promise.allSettled)', async () => {
+    ;(graph as any).findSimilar = jest.fn().mockResolvedValue([
+      { id: 'a', similarity: 0.85, contentType: 'fact', source: 'technical', created: '2026-04-01T00:00:00Z', flag: null, content_preview: 'A' },
+      { id: 'b', similarity: 0.83, contentType: 'fact', source: 'technical', created: '2026-04-01T00:00:00Z', flag: null, content_preview: 'B' },
+      { id: 'c', similarity: 0.80, contentType: 'fact', source: 'technical', created: '2026-04-01T00:00:00Z', flag: null, content_preview: 'C' },
+    ])
+
+    let callOrder = 0
+    const callOrderMap: Record<string, number> = {}
+    judge.classify.mockImplementation(async ({ candidateContent }) => {
+      callOrderMap[candidateContent] = ++callOrder
+      // Return a different relation per call so we can verify they're all routed correctly.
+      const map: Record<string, LLMRelation> = { A: 'duplicate', B: 'complement', C: 'unrelated' }
+      return map[candidateContent] ?? 'unrelated'
+    })
+
+    const tool = makeTool()
+    const result = await tool.store({
+      content: 'new content',
+      contentType: 'fact',
+      userId: 'richard_yaker'
+    })
+
+    expect(isDedupRequired(result)).toBe(true)
+    if (!isDedupRequired(result)) return
+
+    expect(judge.classify).toHaveBeenCalledTimes(3)
+    const byId = Object.fromEntries(result.candidates.map(c => [c.id, c.llm_relation]))
+    expect(byId['a']).toBe('duplicate')
+    expect(byId['b']).toBe('complement')
+    expect(byId['c']).toBe('unrelated')
+  })
+
+  // -------------------------------------------------------------------------
+  // 9. Distinct (sim < confirm) — gate doesn't trigger, judge not called
+  // -------------------------------------------------------------------------
+
+  it('distinct candidate (sim < 0.78) → no gate, no judge', async () => {
+    ;(graph as any).findSimilar = jest.fn().mockResolvedValue([
+      { id: 'a', similarity: 0.5, contentType: 'fact', source: 'technical', created: '2026-04-01T00:00:00Z', flag: null, content_preview: 'A' },
+    ])
+
+    const tool = makeTool()
+    const result = await tool.store({
+      content: 'new content',
+      contentType: 'fact',
+      userId: 'richard_yaker'
+    })
+
+    expect(isDedupRequired(result)).toBe(false)
+    expect(judge.classify).not.toHaveBeenCalled()
+  })
+})
+
+// ===========================================================================
+// LLMJudgeService unit tests — pure parser + cache, no UnifiedStoreTool wiring.
+// ===========================================================================
+
+describe('parseLLMRelation()', () => {
+  it('matches each of the 6 valid relations', () => {
+    expect(parseLLMRelation('duplicate')).toBe('duplicate')
+    expect(parseLLMRelation('supersedes')).toBe('supersedes')
+    expect(parseLLMRelation('supersedes-reverse')).toBe('supersedes-reverse')
+    expect(parseLLMRelation('complement')).toBe('complement')
+    expect(parseLLMRelation('contradicts')).toBe('contradicts')
+    expect(parseLLMRelation('unrelated')).toBe('unrelated')
+  })
+
+  it('handles uppercase and whitespace', () => {
+    expect(parseLLMRelation('DUPLICATE')).toBe('duplicate')
+    expect(parseLLMRelation('  Complement  \n')).toBe('complement')
+  })
+
+  it('strips surrounding text and finds the relation token', () => {
+    expect(parseLLMRelation('The relation is: duplicate.')).toBe('duplicate')
+    expect(parseLLMRelation('My answer: contradicts!')).toBe('contradicts')
+  })
+
+  it('prefers supersedes-reverse over supersedes when both substring-match', () => {
+    // The longer token must win — that's exactly the "asymmetric" relation
+    // that fails when shorter matches first.
+    expect(parseLLMRelation('supersedes-reverse')).toBe('supersedes-reverse')
+    expect(parseLLMRelation('My answer is supersedes-reverse!')).toBe('supersedes-reverse')
+  })
+
+  it('falls back to "unrelated" on garbage input', () => {
+    expect(parseLLMRelation('')).toBe('unrelated')
+    expect(parseLLMRelation('hello world')).toBe('unrelated')
+    expect(parseLLMRelation('I am not sure')).toBe('unrelated')
+  })
+
+  it('falls back on non-string input (defensive)', () => {
+    // @ts-expect-error — testing runtime resilience
+    expect(parseLLMRelation(null)).toBe('unrelated')
+    // @ts-expect-error — testing runtime resilience
+    expect(parseLLMRelation(undefined)).toBe('unrelated')
+  })
+})
+
+describe('judgeCacheKey()', () => {
+  it('produces identical keys for identical pairs', () => {
+    const a = judgeCacheKey('hello', 'world')
+    const b = judgeCacheKey('hello', 'world')
+    expect(a).toBe(b)
+  })
+
+  it('produces different keys when content order is swapped (asymmetric)', () => {
+    const a = judgeCacheKey('hello', 'world')
+    const b = judgeCacheKey('world', 'hello')
+    expect(a).not.toBe(b)
+  })
+
+  it('handles content with the separator character (no crash)', () => {
+    // The single-character separator means boundary-collision is theoretically
+    // possible (a|b + c hashes the same as a + b|c since both serialize to
+    // "a|b|c"). In practice the LRU cache scope is per-process and the cost
+    // of a rare hash collision is one re-classification, not data corruption.
+    // This test just confirms the function doesn't throw on separator content.
+    const a = judgeCacheKey('a|b', 'c')
+    expect(a).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  it('produces 64-char SHA-256 hex output', () => {
+    const k = judgeCacheKey('foo', 'bar')
+    expect(k).toMatch(/^[0-9a-f]{64}$/)
+  })
+})
+
+describe('LRUCache', () => {
+  it('stores and retrieves values', () => {
+    const c = new LRUCache<string, number>(3)
+    c.set('a', 1)
+    expect(c.get('a')).toBe(1)
+    expect(c.size).toBe(1)
+  })
+
+  it('evicts the least-recently-used entry at capacity', () => {
+    const c = new LRUCache<string, number>(2)
+    c.set('a', 1)
+    c.set('b', 2)
+    c.set('c', 3)  // evicts 'a' (LRU)
+    expect(c.get('a')).toBeUndefined()
+    expect(c.get('b')).toBe(2)
+    expect(c.get('c')).toBe(3)
+  })
+
+  it('read bumps a key to most-recent (saves it from eviction)', () => {
+    const c = new LRUCache<string, number>(2)
+    c.set('a', 1)
+    c.set('b', 2)
+    c.get('a')      // 'a' is now most-recent
+    c.set('c', 3)   // evicts 'b' (now LRU)
+    expect(c.get('a')).toBe(1)
+    expect(c.get('b')).toBeUndefined()
+    expect(c.get('c')).toBe(3)
+  })
+
+  it('overwrite of existing key updates value AND bumps recency', () => {
+    const c = new LRUCache<string, number>(2)
+    c.set('a', 1)
+    c.set('b', 2)
+    c.set('a', 99)  // overwrite + bump
+    c.set('c', 3)   // evicts 'b' (LRU)
+    expect(c.get('a')).toBe(99)
+    expect(c.get('b')).toBeUndefined()
+  })
+
+  it('rejects non-positive maxSize', () => {
+    expect(() => new LRUCache<string, number>(0)).toThrow(/maxSize/)
+    expect(() => new LRUCache<string, number>(-1)).toThrow(/maxSize/)
+  })
+
+  it('clear() empties the cache', () => {
+    const c = new LRUCache<string, number>(3)
+    c.set('a', 1); c.set('b', 2)
+    c.clear()
+    expect(c.size).toBe(0)
+    expect(c.get('a')).toBeUndefined()
+  })
+})
+
+// ===========================================================================
+// AnthropicHaikuJudge — integration tests with a fake SDK client.
+// ===========================================================================
+
+describe('AnthropicHaikuJudge', () => {
+  // Lazy-import so jest doesn't fail collecting this file when the SDK isn't
+  // present (it always is in this repo, but the pattern is safer).
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+
+  it('caches identical (newContent, candidateContent) pairs (no duplicate API calls)', async () => {
+    const { AnthropicHaikuJudge } = await import('../embedding/AnthropicHaikuJudge.js')
+
+    const fakeCreate = jest.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'complement' }]
+    })
+    const fakeClient = { messages: { create: fakeCreate } } as any
+
+    const j = new AnthropicHaikuJudge({ apiKey: 'test-key', client: fakeClient })
+
+    const a = await j.classify({ newContent: 'X', candidateContent: 'Y' })
+    const b = await j.classify({ newContent: 'X', candidateContent: 'Y' })
+    const c = await j.classify({ newContent: 'X', candidateContent: 'Y' })
+
+    expect(a).toBe('complement')
+    expect(b).toBe('complement')
+    expect(c).toBe('complement')
+    // Cached after first call — only one underlying API hit.
+    expect(fakeCreate).toHaveBeenCalledTimes(1)
+  })
+
+  it('different content pairs each hit the API once', async () => {
+    const { AnthropicHaikuJudge } = await import('../embedding/AnthropicHaikuJudge.js')
+
+    const fakeCreate = jest.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'unrelated' }]
+    })
+    const fakeClient = { messages: { create: fakeCreate } } as any
+
+    const j = new AnthropicHaikuJudge({ apiKey: 'test-key', client: fakeClient })
+    await j.classify({ newContent: 'A', candidateContent: 'B' })
+    await j.classify({ newContent: 'A', candidateContent: 'C' })
+    await j.classify({ newContent: 'D', candidateContent: 'B' })
+
+    expect(fakeCreate).toHaveBeenCalledTimes(3)
+  })
+
+  it('isAvailable() = false when no API key is configured', async () => {
+    const { AnthropicHaikuJudge } = await import('../embedding/AnthropicHaikuJudge.js')
+
+    const prevKey = process.env.ANTHROPIC_API_KEY
+    delete process.env.ANTHROPIC_API_KEY
+    try {
+      // Inject a fake client so the SDK doesn't reject on missing key during
+      // construction — we want to test the isAvailable() short-circuit.
+      const fakeClient = { messages: { create: jest.fn() } } as any
+      const j = new AnthropicHaikuJudge({ client: fakeClient })
+      expect(await j.isAvailable()).toBe(false)
+    } finally {
+      if (prevKey !== undefined) process.env.ANTHROPIC_API_KEY = prevKey
+    }
+  })
+
+  it('isAvailable() = true when API key is configured', async () => {
+    const { AnthropicHaikuJudge } = await import('../embedding/AnthropicHaikuJudge.js')
+
+    const fakeClient = { messages: { create: jest.fn() } } as any
+    const j = new AnthropicHaikuJudge({ apiKey: 'test-key', client: fakeClient })
+    expect(await j.isAvailable()).toBe(true)
+  })
+
+  it('parses raw model response leniently (strips surrounding text)', async () => {
+    const { AnthropicHaikuJudge } = await import('../embedding/AnthropicHaikuJudge.js')
+
+    const fakeCreate = jest.fn().mockResolvedValue({
+      // Model returned a phrase instead of a single word — parser should
+      // still extract the relation token.
+      content: [{ type: 'text', text: 'The answer is contradicts.' }]
+    })
+    const fakeClient = { messages: { create: fakeCreate } } as any
+
+    const j = new AnthropicHaikuJudge({ apiKey: 'test-key', client: fakeClient })
+    const r = await j.classify({ newContent: 'X', candidateContent: 'Y' })
+    expect(r).toBe('contradicts')
+  })
+
+  it('returns "unrelated" when response is unparseable (safe fallback)', async () => {
+    const { AnthropicHaikuJudge } = await import('../embedding/AnthropicHaikuJudge.js')
+
+    const fakeCreate = jest.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'I have no idea what these are' }]
+    })
+    const fakeClient = { messages: { create: fakeCreate } } as any
+
+    const j = new AnthropicHaikuJudge({ apiKey: 'test-key', client: fakeClient })
+    const r = await j.classify({ newContent: 'X', candidateContent: 'Y' })
+    expect(r).toBe('unrelated')
+  })
+
+  it('returns "unrelated" without API call on empty content (defensive)', async () => {
+    const { AnthropicHaikuJudge } = await import('../embedding/AnthropicHaikuJudge.js')
+
+    const fakeCreate = jest.fn()
+    const fakeClient = { messages: { create: fakeCreate } } as any
+
+    const j = new AnthropicHaikuJudge({ apiKey: 'test-key', client: fakeClient })
+    expect(await j.classify({ newContent: '', candidateContent: 'Y' })).toBe('unrelated')
+    expect(await j.classify({ newContent: 'X', candidateContent: '' })).toBe('unrelated')
+    expect(fakeCreate).not.toHaveBeenCalled()
+  })
+
+  it('passes the configured model id and includes both contents in the prompt', async () => {
+    const { AnthropicHaikuJudge } = await import('../embedding/AnthropicHaikuJudge.js')
+
+    const fakeCreate = jest.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'duplicate' }]
+    })
+    const fakeClient = { messages: { create: fakeCreate } } as any
+
+    const j = new AnthropicHaikuJudge({
+      apiKey: 'test-key',
+      client: fakeClient,
+      model: 'claude-haiku-test-model'
+    })
+    await j.classify({ newContent: 'NEW_TEXT_PAYLOAD', candidateContent: 'OLD_TEXT_PAYLOAD' })
+
+    expect(fakeCreate).toHaveBeenCalledTimes(1)
+    const callArgs = fakeCreate.mock.calls[0][0]
+    expect(callArgs.model).toBe('claude-haiku-test-model')
+    expect(callArgs.system).toContain('classifier')
+    expect(callArgs.messages[0].content).toContain('NEW_TEXT_PAYLOAD')
+    expect(callArgs.messages[0].content).toContain('OLD_TEXT_PAYLOAD')
+    // Default modelId reads from constructor argument
+    expect(j.modelId).toBe('claude-haiku-test-model')
+  })
+
+  it('default model id matches the spec (claude-haiku-4-5-20251001)', async () => {
+    const { AnthropicHaikuJudge } = await import('../embedding/AnthropicHaikuJudge.js')
+
+    const fakeClient = { messages: { create: jest.fn() } } as any
+    const j = new AnthropicHaikuJudge({ apiKey: 'test-key', client: fakeClient })
+    expect(j.modelId).toBe('claude-haiku-4-5-20251001')
+  })
+})

--- a/src/__tests__/UnifiedStoreTool.dedup_judge.test.ts
+++ b/src/__tests__/UnifiedStoreTool.dedup_judge.test.ts
@@ -348,11 +348,17 @@ describe('DG-T2-A — UnifiedStoreTool LLM judge wiring (issue #49)', () => {
       { id: 'c', similarity: 0.80, contentType: 'fact', source: 'technical', created: '2026-04-01T00:00:00Z', flag: null, content_preview: 'C' },
     ])
 
-    let callOrder = 0
-    const callOrderMap: Record<string, number> = {}
-    judge.classify.mockImplementation(async ({ candidateContent }) => {
-      callOrderMap[candidateContent] = ++callOrder
-      // Return a different relation per call so we can verify they're all routed correctly.
+    // Block each classify() call until all three have entered the mock. This
+    // only resolves if the production code dispatched them in parallel —
+    // sequential dispatch would deadlock here (the barrier never reaches 3).
+    let startedCount = 0
+    let barrierResolve: (() => void) | undefined
+    const barrier = new Promise<void>(resolve => { barrierResolve = resolve })
+
+    judge.classify.mockImplementation(async ({ candidateContent }: { candidateContent: string }) => {
+      startedCount++
+      if (startedCount === 3) barrierResolve!()
+      await barrier
       const map: Record<string, LLMRelation> = { A: 'duplicate', B: 'complement', C: 'unrelated' }
       return map[candidateContent] ?? 'unrelated'
     })

--- a/src/embedding/AnthropicHaikuJudge.ts
+++ b/src/embedding/AnthropicHaikuJudge.ts
@@ -36,7 +36,6 @@ const DEFAULT_MODEL = 'claude-haiku-4-5-20251001'
 const DEFAULT_TIMEOUT_MS = 5_000
 const DEFAULT_CACHE_SIZE = 1000
 const DEFAULT_MAX_TOKENS = 12  // single-word response — 12 tokens is plenty
-const AVAILABILITY_CACHE_TTL_MS = 30_000
 
 // The classifier prompt — tight and forced to a single-word response. We feed
 // the candidate first and the new content second because the relations are
@@ -76,7 +75,6 @@ export class AnthropicHaikuJudge implements LLMJudgeService {
   private readonly timeoutMs: number
   private readonly cache: LRUCache<string, LLMRelation>
   private readonly hasApiKey: boolean
-  private availableCache: { value: boolean; expiresAt: number } | null = null
 
   constructor(config: AnthropicHaikuJudgeConfig = {}) {
     const apiKey = config.apiKey ?? process.env.ANTHROPIC_API_KEY ?? ''
@@ -93,19 +91,10 @@ export class AnthropicHaikuJudge implements LLMJudgeService {
   }
 
   async isAvailable(): Promise<boolean> {
-    // No API key → definitively unavailable; don't waste a 30s cache slot.
-    if (!this.hasApiKey) return false
-
-    // Cached probe: we can't ping the Anthropic API for "alive?" cheaply
-    // (every endpoint counts against quota), so we use the api-key-presence
-    // signal as the liveness indicator. If a real network failure happens
-    // mid-classify, the caller already handles the throw → null.
-    const now = Date.now()
-    if (this.availableCache && this.availableCache.expiresAt > now) {
-      return this.availableCache.value
-    }
-    this.availableCache = { value: true, expiresAt: now + AVAILABILITY_CACHE_TTL_MS }
-    return true
+    // API-key-presence is the only reliable liveness signal we have without
+    // burning a real API call. Network failures mid-classify are caught by the
+    // caller (UnifiedStoreTool) which already handles the throw → null path.
+    return this.hasApiKey
   }
 
   async classify(args: {
@@ -145,7 +134,7 @@ export class AnthropicHaikuJudge implements LLMJudgeService {
           system: SYSTEM_PROMPT,
           messages: [{ role: 'user', content: userMessage }],
         },
-        { signal: controller.signal as any }
+        { signal: controller.signal, timeout: this.timeoutMs }
       )
 
       // Pull the first text block. The SDK can return tool_use / image blocks

--- a/src/embedding/AnthropicHaikuJudge.ts
+++ b/src/embedding/AnthropicHaikuJudge.ts
@@ -1,0 +1,170 @@
+/**
+ * AnthropicHaikuJudge — concrete LLMJudgeService backed by Claude Haiku 4.5
+ * via the Anthropic Messages API. Used by the dedup gate's Tier 2 (DG-T2-A,
+ * issue #49) to classify the relationship between a new write and a candidate
+ * that fell into the borderline confirm-band.
+ *
+ * Why Haiku 4.5:
+ *   - Cheapest production-grade Anthropic model (~10× cheaper than Sonnet)
+ *   - Fast enough that the 5 s timeout is conservative — typical p50 is
+ *     well under a second for short classifications.
+ *   - Sufficient reasoning capacity for the 6-relation enum we need.
+ *
+ * Design choices:
+ *   - LRU cache (1000 entries) on (newContent, candidateContent) pair so a
+ *     single MCP session that hits the gate repeatedly with the same content
+ *     pays zero extra cost beyond the first call.
+ *   - 5 s AbortController per call. On timeout we throw — the
+ *     UnifiedStoreTool integration treats the throw as "leave llm_relation
+ *     null" rather than failing the whole gate response.
+ *   - Single-word forced response with explicit instruction to choose from
+ *     the 6-relation enum. Lenient parser falls back to 'unrelated' if the
+ *     response can't be parsed (safest — won't trigger any UI urgency).
+ */
+
+import Anthropic from '@anthropic-ai/sdk'
+import {
+  LLMJudgeService,
+  LLMRelation,
+  LRUCache,
+  judgeCacheKey,
+  parseLLMRelation,
+} from './LLMJudgeService.js'
+import { logger } from '../logger.js'
+
+const DEFAULT_MODEL = 'claude-haiku-4-5-20251001'
+const DEFAULT_TIMEOUT_MS = 5_000
+const DEFAULT_CACHE_SIZE = 1000
+const DEFAULT_MAX_TOKENS = 12  // single-word response — 12 tokens is plenty
+const AVAILABILITY_CACHE_TTL_MS = 30_000
+
+// The classifier prompt — tight and forced to a single-word response. We feed
+// the candidate first and the new content second because the relations are
+// asymmetric (supersedes vs supersedes-reverse) and the model needs a
+// consistent ordering convention.
+const SYSTEM_PROMPT = `You are a strict classifier. Compare two pieces of knowledge content and respond with EXACTLY ONE WORD chosen from this enum:
+
+- duplicate: same fact expressed differently, no new information in NEW
+- supersedes: NEW corrects/replaces/updates EXISTING (newer, more accurate)
+- supersedes-reverse: EXISTING corrects/replaces NEW (NEW is the outdated one)
+- complement: both true, different facets/aspects of related topic, keep both
+- contradicts: factually opposed; only one can be true
+- unrelated: different facts that happen to share keywords
+
+Respond with ONLY the single enum word. No punctuation, no explanation, no formatting.`
+
+export interface AnthropicHaikuJudgeConfig {
+  /** Anthropic API key. Defaults to env ANTHROPIC_API_KEY. */
+  apiKey?: string
+  /** Model id (defaults to claude-haiku-4-5-20251001). */
+  model?: string
+  /** Per-call timeout in ms (default: 5000). */
+  timeoutMs?: number
+  /** Max LRU cache entries (default: 1000). */
+  cacheSize?: number
+  /**
+   * Optional override of the underlying SDK client — primarily for tests so we
+   * can inject a fake without monkey-patching node_modules. Production callers
+   * should leave this unset.
+   */
+  client?: Pick<Anthropic, 'messages'>
+}
+
+export class AnthropicHaikuJudge implements LLMJudgeService {
+  public readonly modelId: string
+  private readonly client: Pick<Anthropic, 'messages'>
+  private readonly timeoutMs: number
+  private readonly cache: LRUCache<string, LLMRelation>
+  private readonly hasApiKey: boolean
+  private availableCache: { value: boolean; expiresAt: number } | null = null
+
+  constructor(config: AnthropicHaikuJudgeConfig = {}) {
+    const apiKey = config.apiKey ?? process.env.ANTHROPIC_API_KEY ?? ''
+    this.hasApiKey = apiKey.length > 0
+    this.modelId = config.model ?? DEFAULT_MODEL
+    this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS
+    this.cache = new LRUCache<string, LLMRelation>(config.cacheSize ?? DEFAULT_CACHE_SIZE)
+
+    // Test-injected client wins. Otherwise build the real SDK client even if
+    // the API key is empty — `isAvailable()` will short-circuit before any
+    // request goes out.
+    this.client = config.client
+      ?? new Anthropic({ apiKey: apiKey || 'missing-key-will-fail-fast' })
+  }
+
+  async isAvailable(): Promise<boolean> {
+    // No API key → definitively unavailable; don't waste a 30s cache slot.
+    if (!this.hasApiKey) return false
+
+    // Cached probe: we can't ping the Anthropic API for "alive?" cheaply
+    // (every endpoint counts against quota), so we use the api-key-presence
+    // signal as the liveness indicator. If a real network failure happens
+    // mid-classify, the caller already handles the throw → null.
+    const now = Date.now()
+    if (this.availableCache && this.availableCache.expiresAt > now) {
+      return this.availableCache.value
+    }
+    this.availableCache = { value: true, expiresAt: now + AVAILABILITY_CACHE_TTL_MS }
+    return true
+  }
+
+  async classify(args: {
+    newContent: string
+    candidateContent: string
+  }): Promise<LLMRelation> {
+    const { newContent, candidateContent } = args
+
+    // Defensive: empty inputs never hit the API. Treat as 'unrelated' so the
+    // dedup gate response still ships a structurally valid candidate.
+    if (!newContent || !candidateContent) {
+      return 'unrelated'
+    }
+
+    // Cache hit — free win, saves $.
+    const key = judgeCacheKey(newContent, candidateContent)
+    const cached = this.cache.get(key)
+    if (cached !== undefined) {
+      logger.debug(`[AnthropicHaikuJudge] cache HIT for pair (${key.slice(0, 8)}…)`)
+      return cached
+    }
+
+    // Hard 5s timeout. AbortController plumbed through the SDK's signal arg.
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs)
+
+    try {
+      // Format: candidate first, new content second — matches the prompt's
+      // EXISTING/NEW labels so the asymmetric relations resolve correctly.
+      const userMessage =
+        `EXISTING:\n${candidateContent}\n\n---\n\nNEW:\n${newContent}\n\nRelation:`
+
+      const response = await this.client.messages.create(
+        {
+          model: this.modelId,
+          max_tokens: DEFAULT_MAX_TOKENS,
+          system: SYSTEM_PROMPT,
+          messages: [{ role: 'user', content: userMessage }],
+        },
+        { signal: controller.signal as any }
+      )
+
+      // Pull the first text block. The SDK can return tool_use / image blocks
+      // for richer responses, but for our classification prompt we only ever
+      // get text back.
+      const textBlock = (response.content || []).find(
+        (b: any) => b.type === 'text'
+      ) as { type: 'text'; text: string } | undefined
+
+      const raw = textBlock?.text ?? ''
+      const relation = parseLLMRelation(raw)
+
+      this.cache.set(key, relation)
+      logger.debug(
+        `[AnthropicHaikuJudge] classified pair (${key.slice(0, 8)}…) → ${relation} (raw="${raw.slice(0, 40)}")`
+      )
+      return relation
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+}

--- a/src/embedding/LLMJudgeService.ts
+++ b/src/embedding/LLMJudgeService.ts
@@ -1,0 +1,185 @@
+/**
+ * LLMJudgeService — Tier 2 dedup-gate classifier (DG-T2-A, issue #49).
+ *
+ * For candidates that fall in the borderline confirm-band (between
+ * `confirmThreshold` and `refuseThreshold`), Tier 1 cosine similarity alone
+ * isn't enough to characterize the relationship. We hand the (new_content,
+ * candidate_content) pair to a small/cheap LLM and ask it to classify the
+ * relationship into one of six relations:
+ *
+ *   - duplicate          : same fact, no new information
+ *   - supersedes         : new content corrects/replaces the candidate
+ *   - supersedes-reverse : candidate corrects/replaces the new content (rare)
+ *   - complement         : both true, different facets — keep both
+ *   - contradicts        : factually opposed; humans must decide
+ *   - unrelated          : different facts that happened to embed near each other
+ *
+ * Architectural notes:
+ *   - Mirrors the EmbeddingService shape: dependency-injected, liveness probe,
+ *     graceful degradation. Every code path that uses this service must
+ *     handle `null` (judge unavailable / not configured).
+ *   - LRU-cached: keyed on SHA-256 of `newContent|candidateContent` so identical
+ *     pairs in a single session don't re-call the model. Max 1000 entries.
+ *   - Hard 5-second per-call timeout via AbortController. On timeout we return
+ *     `unrelated` from `classify()` only if the implementation chooses; the
+ *     UnifiedStoreTool integration treats any thrown error as "leave the
+ *     candidate's `llm_relation: null`" so the gate response still ships.
+ *   - Cost-conscious: callers MUST skip this for refuse-band candidates
+ *     (those are already definitively "duplicate" structurally).
+ */
+
+import crypto from 'crypto'
+import { logger } from '../logger.js'
+
+export type LLMRelation =
+  | 'duplicate'
+  | 'supersedes'
+  | 'supersedes-reverse'
+  | 'complement'
+  | 'contradicts'
+  | 'unrelated'
+
+const ALL_RELATIONS: readonly LLMRelation[] = [
+  'duplicate',
+  'supersedes',
+  'supersedes-reverse',
+  'complement',
+  'contradicts',
+  'unrelated'
+] as const
+
+/**
+ * The Tier 2 LLM judge. Implementations should be deterministic at the prompt
+ * level (same pair → same answer) but the cache makes that less load-bearing.
+ */
+export interface LLMJudgeService {
+  /** Stable model identifier for audit logs. e.g. 'claude-haiku-4-5-20251001'. */
+  readonly modelId: string
+
+  /**
+   * Classify the relationship between two pieces of content. Throws on
+   * transport/model failure — the caller (UnifiedStoreTool) catches and
+   * leaves `llm_relation: null` for that candidate.
+   */
+  classify(args: {
+    newContent: string
+    candidateContent: string
+  }): Promise<LLMRelation>
+
+  /**
+   * Quick liveness probe. Used by callers to short-circuit when the judge is
+   * unconfigured/unreachable so we don't burn the 5 s timeout on every
+   * candidate. Cached internally (~30 s) so callers can poll cheaply.
+   */
+  isAvailable(): Promise<boolean>
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers (parsing + cache) — exported for testing the concrete impl.
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a free-form LLM response into an LLMRelation, leniently.
+ * Strategy:
+ *   1. Lowercase + trim
+ *   2. Look for an exact match against any of the 6 relation strings as a
+ *      whole word (regex with word boundaries — `supersedes-reverse` first
+ *      so it doesn't get short-circuited by `supersedes`)
+ *   3. Fallback: 'unrelated' (safest — won't trigger any UI urgency)
+ *
+ * Exported so the concrete implementation and its tests share the same
+ * parser definition.
+ */
+export function parseLLMRelation(raw: string): LLMRelation {
+  if (typeof raw !== 'string' || raw.length === 0) return 'unrelated'
+  const normalized = raw.trim().toLowerCase()
+
+  // Order matters: longer/more-specific tokens first so 'supersedes-reverse'
+  // wins over 'supersedes' when both substrings appear.
+  const orderedProbes: LLMRelation[] = [
+    'supersedes-reverse',
+    'supersedes',
+    'duplicate',
+    'complement',
+    'contradicts',
+    'unrelated'
+  ]
+
+  for (const probe of orderedProbes) {
+    // \b doesn't match across the dash in JS regex by default — the dash is
+    // a word boundary itself — so anchor with explicit start/non-word lookarounds.
+    const re = new RegExp(`(^|[^a-z0-9-])${probe}([^a-z0-9-]|$)`)
+    if (re.test(normalized)) return probe
+  }
+
+  return 'unrelated'
+}
+
+/**
+ * Build the deterministic cache key for a (newContent, candidateContent) pair.
+ * SHA-256 + ascii separator so collisions across content boundaries are
+ * vanishingly unlikely.
+ */
+export function judgeCacheKey(newContent: string, candidateContent: string): string {
+  return crypto
+    .createHash('sha256')
+    .update(newContent)
+    .update('|')
+    .update(candidateContent)
+    .digest('hex')
+}
+
+/**
+ * Tiny LRU map. We don't pull in `lru-cache` because it's not already a
+ * dependency and the behavior we need (insertion-order eviction with
+ * read-bump) is ~30 lines.
+ */
+export class LRUCache<K, V> {
+  private map = new Map<K, V>()
+  constructor(private readonly maxSize: number) {
+    if (maxSize <= 0) throw new Error('LRUCache: maxSize must be > 0')
+  }
+
+  get(key: K): V | undefined {
+    if (!this.map.has(key)) return undefined
+    // Bump to most-recent by re-inserting.
+    const value = this.map.get(key) as V
+    this.map.delete(key)
+    this.map.set(key, value)
+    return value
+  }
+
+  set(key: K, value: V): void {
+    // If key already present, delete first so the re-insert puts it at the
+    // end (most-recent) regardless of its prior position.
+    if (this.map.has(key)) this.map.delete(key)
+    this.map.set(key, value)
+    while (this.map.size > this.maxSize) {
+      // Map iteration is insertion-order — first key is least-recently used.
+      const oldest = this.map.keys().next().value
+      if (oldest === undefined) break
+      this.map.delete(oldest)
+    }
+  }
+
+  has(key: K): boolean {
+    return this.map.has(key)
+  }
+
+  get size(): number {
+    return this.map.size
+  }
+
+  clear(): void {
+    this.map.clear()
+  }
+}
+
+export const LLM_RELATIONS = ALL_RELATIONS
+
+/**
+ * Re-export the logger reference so callers using `LLMJudgeService` don't have
+ * to import it separately when they want to log around a classify() call.
+ * Prevents accidental console.log usage in MCP stdio mode.
+ */
+export { logger as judgeLogger }

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,8 @@ import { OllamaInference } from './inference/OllamaInference.js'
 import { EnrichmentQueue } from './inference/EnrichmentQueue.js'
 import { EntityLinker } from './inference/EntityLinker.js'
 import { OllamaEmbeddingService } from './embedding/EmbeddingService.js'
+import { AnthropicHaikuJudge } from './embedding/AnthropicHaikuJudge.js'
+import type { LLMJudgeService } from './embedding/LLMJudgeService.js'
 import { MongoDBStorage, Mem0Storage, SparrowDBStorage } from './storage/index.js'
 import { UnifiedStoreTool, UnifiedSearchTool, KMSInstructionsTool, DocumentStoreTool } from './tools/index.js'
 
@@ -174,10 +176,27 @@ export class UnifiedKMSServer {
       baseUrl: process.env.OLLAMA_BASE_URL || 'http://localhost:11434'
     })
 
+    // LLM judge for the dedup gate's Tier 2 borderline classification
+    // (DG-T2-A, issue #49). Optional — when ANTHROPIC_API_KEY is missing we
+    // pass null and the gate degrades gracefully (every candidate gets
+    // `llm_relation: null`). API key is Doppler-injected in production.
+    let llmJudge: LLMJudgeService | null = null
+    if (process.env.ANTHROPIC_API_KEY) {
+      console.log('🤖 Initializing LLM Judge (Claude Haiku 4.5)...')
+      llmJudge = new AnthropicHaikuJudge({
+        apiKey: process.env.ANTHROPIC_API_KEY
+      })
+    } else {
+      console.warn(
+        '⚠️  ANTHROPIC_API_KEY not set — Tier 2 dedup classifier disabled. ' +
+        'Confirm-band candidates will return llm_relation=null.'
+      )
+    }
+
     // Step 4: Initialize tools
     console.log('🛠️  Initializing Tools...')
     this.tools = {
-      store: new UnifiedStoreTool(this.router, this.storage, this.factCache, ollamaRouter, enrichmentQueue, embeddingService),
+      store: new UnifiedStoreTool(this.router, this.storage, this.factCache, ollamaRouter, enrichmentQueue, embeddingService, llmJudge),
       search: new UnifiedSearchTool(this.storage, this.factCache),
       instructions: new KMSInstructionsTool(),
       documentStore: new DocumentStoreTool(this.storage.mongodb)

--- a/src/tools/UnifiedStoreTool.ts
+++ b/src/tools/UnifiedStoreTool.ts
@@ -16,6 +16,7 @@ import {
   PENDING_EMBEDDING_KEY,
   PENDING_EMBEDDER_ID_KEY
 } from '../embedding/EmbeddingService.js'
+import type { LLMJudgeService, LLMRelation } from '../embedding/LLMJudgeService.js' 
 
 const debug = (...args: unknown[]) => { if (process.env.KMS_DEBUG) console.error(...args) }
 
@@ -75,8 +76,19 @@ export interface DedupCandidate {
   subject?: string
   created: string
   flag?: string | null
-  /** Populated by Tier 2 LLM judge (DG-T2-A). null until that ticket lands. */
-  llm_relation: string | null
+  /**
+   * Populated by Tier 2 LLM judge (DG-T2-A, issue #49). One of:
+   *   - 'duplicate' | 'supersedes' | 'supersedes-reverse'
+   *   - 'complement' | 'contradicts' | 'unrelated'
+   *
+   * Null when:
+   *   - judge unavailable (no API key configured)
+   *   - candidate is in the refuse band (was set to 'duplicate' inline; see
+   *     UnifiedStoreTool.store)
+   *   - the individual classify() call failed/timed out (other candidates'
+   *     classifications still ship)
+   */
+  llm_relation: LLMRelation | null
 }
 
 export interface DedupRequiredResponse {
@@ -118,6 +130,7 @@ export class UnifiedStoreTool {
   private ollamaRouter: OllamaStorageRouter | null
   private enrichmentQueue: EnrichmentQueue | null
   private embeddingService: EmbeddingService | null
+  private llmJudge: LLMJudgeService | null
   /** Tracks last known availability to detect transitions and log them. */
   private _lastEmbedderAvailable: boolean | null = null
 
@@ -127,7 +140,8 @@ export class UnifiedStoreTool {
     cache: FACTCache | null,
     ollamaRouter?: OllamaStorageRouter | null,
     enrichmentQueue?: EnrichmentQueue | null,
-    embeddingService?: EmbeddingService | null
+    embeddingService?: EmbeddingService | null,
+    llmJudge?: LLMJudgeService | null
   ) {
     this.router = router
     this.storage = storage
@@ -135,6 +149,7 @@ export class UnifiedStoreTool {
     this.ollamaRouter = ollamaRouter ?? null
     this.enrichmentQueue = enrichmentQueue ?? null
     this.embeddingService = embeddingService ?? null
+    this.llmJudge = llmJudge ?? null
   }
 
   /**
@@ -366,10 +381,81 @@ export class UnifiedStoreTool {
               ? `Likely duplicate found (cos=${top.similarity.toFixed(3)} ≥ ${refuseThreshold}). Retry with action.`
               : `Borderline match found (cos=${top.similarity.toFixed(3)} in [${confirmThreshold}, ${refuseThreshold})). Retry with action to confirm intent.`
 
+            // -------------------------------------------------------------
+            // Tier 2 LLM judge (DG-T2-A) — classify candidate relationships
+            //
+            // For each candidate decide its `llm_relation`:
+            //   - sim ≥ refuseThreshold → 'duplicate' inline (cost-free; the
+            //     embedder agrees so strongly we don't need the LLM)
+            //   - confirmThreshold ≤ sim < refuseThreshold → call judge
+            //   - judge unavailable → null for all
+            //   - per-candidate classify failure → null for that one only
+            //
+            // All confirm-band classifications run in parallel because they
+            // are independent. Hard 5s timeout enforced by the judge itself.
+            // -------------------------------------------------------------
+            const llmRelations: Array<LLMRelation | null> = candidates.map(c =>
+              c.similarity >= refuseThreshold ? 'duplicate' : null
+            )
+
+            if (this.llmJudge) {
+              let judgeAvailable = false
+              try {
+                judgeAvailable = await this.llmJudge.isAvailable()
+              } catch (e) {
+                console.warn(
+                  `⚠️ unified_store: llmJudge.isAvailable() threw (skipping Tier 2): ` +
+                  `${e instanceof Error ? e.message : String(e)}`
+                )
+              }
+
+              if (judgeAvailable) {
+                const confirmBandIndices: number[] = []
+                candidates.forEach((c, idx) => {
+                  if (c.similarity < refuseThreshold && c.similarity >= confirmThreshold) {
+                    confirmBandIndices.push(idx)
+                  }
+                })
+
+                if (confirmBandIndices.length > 0) {
+                  // Resolve in parallel — independent calls, the LLMJudgeService
+                  // owns its own timeout. We use Promise.allSettled so a single
+                  // failure doesn't drop the others.
+                  const judge = this.llmJudge
+                  const results = await Promise.allSettled(
+                    confirmBandIndices.map(idx => judge.classify({
+                      newContent: knowledge.content,
+                      candidateContent: candidates[idx].content_preview,
+                    }))
+                  )
+                  results.forEach((r, i) => {
+                    const idx = confirmBandIndices[i]
+                    if (r.status === 'fulfilled') {
+                      llmRelations[idx] = r.value
+                    } else {
+                      // Per-candidate failure: log and leave null — other
+                      // candidates' results still ship.
+                      console.warn(
+                        `⚠️ unified_store: llmJudge.classify failed for candidate ${candidates[idx].id} ` +
+                        `(continuing with llm_relation=null): ` +
+                        `${r.reason instanceof Error ? r.reason.message : String(r.reason)}`
+                      )
+                    }
+                  })
+                  debug(
+                    `🤖 Tier 2 judge classified ${confirmBandIndices.length} confirm-band candidate(s) ` +
+                    `(model=${this.llmJudge.modelId})`
+                  )
+                }
+              } else {
+                debug(`🤖 Tier 2 judge unavailable — leaving llm_relation=null for confirm-band candidates`)
+              }
+            }
+
             const oldIdHint = top.id
             const response: DedupRequiredResponse = {
               status: 'dedup_required',
-              candidates: candidates.map(c => ({
+              candidates: candidates.map((c, idx) => ({
                 id: c.id,
                 similarity: c.similarity,
                 content_preview: c.content_preview,
@@ -378,7 +464,7 @@ export class UnifiedStoreTool {
                 subject: c.subject,
                 created: c.created,
                 flag: c.flag ?? null,
-                llm_relation: null  // Tier 2 (DG-T2-A) will populate this
+                llm_relation: llmRelations[idx]
               })),
               message: msg,
               retry_with: [

--- a/src/tools/UnifiedStoreTool.ts
+++ b/src/tools/UnifiedStoreTool.ts
@@ -16,7 +16,8 @@ import {
   PENDING_EMBEDDING_KEY,
   PENDING_EMBEDDER_ID_KEY
 } from '../embedding/EmbeddingService.js'
-import type { LLMJudgeService, LLMRelation } from '../embedding/LLMJudgeService.js' 
+import type { LLMJudgeService, LLMRelation } from '../embedding/LLMJudgeService.js'
+import { logger } from '../logger.js' 
 
 const debug = (...args: unknown[]) => { if (process.env.KMS_DEBUG) console.error(...args) }
 
@@ -403,8 +404,8 @@ export class UnifiedStoreTool {
               try {
                 judgeAvailable = await this.llmJudge.isAvailable()
               } catch (e) {
-                console.warn(
-                  `⚠️ unified_store: llmJudge.isAvailable() threw (skipping Tier 2): ` +
+                logger.warn(
+                  `unified_store: llmJudge.isAvailable() threw (skipping Tier 2): ` +
                   `${e instanceof Error ? e.message : String(e)}`
                 )
               }
@@ -418,6 +419,29 @@ export class UnifiedStoreTool {
                 })
 
                 if (confirmBandIndices.length > 0) {
+                  // Hydrate full content for each confirm-band candidate before
+                  // classification. content_preview is capped at 200 chars which
+                  // can cause misclassification on longer entries. Fall back to
+                  // content_preview if the graph backend doesn't expose findById
+                  // or the entry is unexpectedly missing.
+                  const graph = this.storage.graph as any
+                  const hasGraphFindById = typeof graph.findById === 'function'
+                  const fullContents: Record<number, string> = {}
+                  for (const idx of confirmBandIndices) {
+                    let full = candidates[idx].content_preview
+                    if (hasGraphFindById) {
+                      try {
+                        const entry = await graph.findById(candidates[idx].id)
+                        if (entry && typeof entry.content === 'string' && entry.content.length > 0) {
+                          full = entry.content
+                        }
+                      } catch {
+                        // Non-fatal — fall back to content_preview
+                      }
+                    }
+                    fullContents[idx] = full
+                  }
+
                   // Resolve in parallel — independent calls, the LLMJudgeService
                   // owns its own timeout. We use Promise.allSettled so a single
                   // failure doesn't drop the others.
@@ -425,7 +449,7 @@ export class UnifiedStoreTool {
                   const results = await Promise.allSettled(
                     confirmBandIndices.map(idx => judge.classify({
                       newContent: knowledge.content,
-                      candidateContent: candidates[idx].content_preview,
+                      candidateContent: fullContents[idx],
                     }))
                   )
                   results.forEach((r, i) => {
@@ -435,8 +459,8 @@ export class UnifiedStoreTool {
                     } else {
                       // Per-candidate failure: log and leave null — other
                       // candidates' results still ship.
-                      console.warn(
-                        `⚠️ unified_store: llmJudge.classify failed for candidate ${candidates[idx].id} ` +
+                      logger.warn(
+                        `unified_store: llmJudge.classify failed for candidate ${candidates[idx].id} ` +
                         `(continuing with llm_relation=null): ` +
                         `${r.reason instanceof Error ? r.reason.message : String(r.reason)}`
                       )


### PR DESCRIPTION
Closes #49.

Wires **Tier 2** of the dedup gate (Wave 5): a small/cheap LLM judge that classifies the relationship between a new write and each candidate that fell into the borderline **confirm-band**. The relation is surfaced on every `DedupRequiredResponse.candidate` as `llm_relation` so callers (and downstream UI) can pick the right corrective action without a second round-trip.

## Summary

- **`src/embedding/LLMJudgeService.ts`** — interface + LRU cache utility + lenient response parser. Mirrors `EmbeddingService`'s DI / liveness-probe / graceful-degradation shape.
- **`src/embedding/AnthropicHaikuJudge.ts`** — concrete implementation backed by `claude-haiku-4-5-20251001` via `@anthropic-ai/sdk`. Hard 5 s timeout per call, single-word forced response, LRU-cached at 1000 pairs.
- **`src/tools/UnifiedStoreTool.ts`** — gate now runs `judge.classify()` for each confirm-band candidate in parallel (`Promise.allSettled` so a single failure doesn't sink the rest). Refuse-band gets `'duplicate'` inline without an LLM call (free win, saves $).
- **`src/index.ts`** — instantiates the judge when `ANTHROPIC_API_KEY` is set; passes `null` otherwise (gate degrades gracefully on Tier 1 alone).
- **`CLAUDE.md`** — documents the 6-relation enum + recommended corrective action per relation. Explicit STOP guidance on `contradicts`: do not proceed without human acknowledgement.

## Relation enum

| Relation | Meaning | Action |
|---|---|---|
| `duplicate` | Same fact | Skip / delete the new write |
| `supersedes` | New corrects existing | `kms_supersede` |
| `supersedes-reverse` | Existing is more accurate | Don't write |
| `complement` | Both true, different facets | `action=complement` |
| `contradicts` | **Factually opposed** | **STOP — surface to human** |
| `unrelated` | Embedder mis-fired | `action=force-new` |

## Independence

This PR is **independent** of:
- PR #69 (DG-T1-C action dispatch)
- PR #70 (alternative dispatch wiring)

Each touches different code paths. Mergeable in any order.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] All baseline tests still pass (79 → unchanged in spirit; one existing assertion updated to reflect refuse-band's new `'duplicate'` inline value)
- [x] 34 new tests added, 113 total
  - [x] Confirm-band → `classify()` called with right args
  - [x] Refuse-band → `'duplicate'` inline, no LLM call
  - [x] Mixed bands → only confirm-band classified
  - [x] Per-candidate `classify()` throw → that candidate `null`, others succeed (response still ships)
  - [x] `judge.isAvailable()` → `false` → no calls, all `null`
  - [x] `judge.isAvailable()` throw → degrades gracefully
  - [x] `judge === null` (not configured) → no calls, refuse-band still gets `'duplicate'`
  - [x] Multiple confirm-band candidates → parallel `Promise.allSettled` resolution
  - [x] Distinct (sim < confirm) → no gate, no judge
  - [x] LRU cache: insertion-order eviction, read-bumps recency, overwrite bumps recency
  - [x] `judgeCacheKey()`: SHA-256, asymmetric, deterministic
  - [x] `parseLLMRelation()`: all 6 valid relations, `supersedes-reverse` wins over `supersedes`, falls back to `'unrelated'` on garbage
  - [x] AnthropicHaikuJudge: cache hit (1 call for 3 identical pairs), distinct pairs (3 calls), API key presence checks, lenient parsing
- [x] `CLAUDE.md` updated with relation enum + `contradicts` UI guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dedup gate responses now include LLM-based classification of candidate relationships (duplicate, supersedes, complements, contradicts, unrelated) to support smarter conflict resolution.
  * Graceful degradation when the LLM service is unavailable.

* **Documentation**
  * Expanded dedup gate documentation with relationship classification semantics, retry strategies, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->