### PR TITLE
feat: Granola → KMS importer (dual-write + dedup-gate routing)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.40.1",
         "@modelcontextprotocol/sdk": "^1.18.1",
         "@types/better-sqlite3": "^7.6.13",
         "better-sqlite3": "^12.5.0",
@@ -67,7 +68,6 @@
       "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.40.1.tgz",
       "integrity": "sha512-DJMWm8lTEM9Lk/MSFL+V+ugF7jKOn0M2Ujvb5fN8r2nY14aHbGPZ1k6sgjL+tpJ3VuOGJNG+4R83jEpOuYPv8w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -83,7 +83,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
       "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -93,7 +92,6 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -113,29 +111,25 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@anthropic-ai/sdk/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/@anthropic-ai/sdk/node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "clean": "rm -rf dist",
     "auth0:cleanup": "tsx scripts/cleanup-auth0-clients.ts",
     "auth0:cleanup:dry-run": "tsx scripts/cleanup-auth0-clients.ts --dry-run",
-    "build:sparrowdb": "bash scripts/build-sparrowdb-node.sh"
+    "build:sparrowdb": "bash scripts/build-sparrowdb-node.sh",
+    "import:granola": "tsx scripts/import-granola.ts",
+    "import:granola:dry-run": "tsx scripts/import-granola.ts --dry-run"
   },
   "keywords": [
     "mcp",
@@ -36,6 +38,7 @@
   "author": "Richard Yaker",
   "license": "MIT",
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.40.1",
     "@modelcontextprotocol/sdk": "^1.18.1",
     "@types/better-sqlite3": "^7.6.13",
     "better-sqlite3": "^12.5.0",

--- a/scripts/import-granola.ts
+++ b/scripts/import-granola.ts
@@ -1,0 +1,877 @@
+#!/usr/bin/env tsx
+/**
+ * Granola → KMS importer.
+ *
+ * Turns Granola meetings into KMS entries via the dual-write pattern:
+ *   1. ONE whole-meeting "memory" entry per meeting (the distilled summary,
+ *      NOT the raw transcript), tagged with metadata.subject="Granola.<title>"
+ *      and metadata.source_doc="granola://<id>".
+ *   2. N (2–5) "key-claim" entries per meeting (OB1 6-type taxonomy mapped to
+ *      KMSmcp contentTypes via mapClaimTypeToContentType). Each claim links
+ *      back to the whole-meeting entry with metadata.related_to=[...] and
+ *      shares the same source_doc pointer.
+ *
+ * Both write paths route through `unified_store` so the dedup gate fires
+ * naturally — duplicate meetings get caught upstream.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * Architecture
+ * ─────────────────────────────────────────────────────────────────────────
+ *
+ * Source A (default):  --input <file>
+ *   Read meetings from a pre-dumped JSON file. The file shape is:
+ *
+ *     [
+ *       {
+ *         "id":         "granola_id_xyz",
+ *         "title":      "Project sync — KMSmcp",
+ *         "date":       "2026-04-30T14:00:00Z",   // optional ISO
+ *         "transcript": "Speaker A: ...\nSpeaker B: ..."
+ *       },
+ *       ...
+ *     ]
+ *
+ *   This is the agent-driven flow: a Claude Code session (which has the
+ *   Granola MCP connected) calls list_meetings + get_meeting_transcript
+ *   for the desired window, dumps to JSON, then runs this script.
+ *
+ * Source B (placeholder): --source granola-mcp --granola-mcp-url ... --granola-mcp-token ...
+ *   Direct claude.ai MCP HTTP fetch. Stub'd; not wired in this PR. The
+ *   `GranolaSource` interface keeps the seam open. Wiring the live MCP
+ *   requires sorting out the claude.ai bearer + endpoint per session,
+ *   which is out of scope for the importer.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * KMS auth
+ * ─────────────────────────────────────────────────────────────────────────
+ *
+ * The live KMS at http://localhost:8180/mcp requires OAuth (OAUTH_ENABLED=true).
+ * The script supports two paths:
+ *   1. KMS_BEARER_TOKEN env var (preferred for one-off runs).
+ *   2. Auth0 client_credentials grant via OAUTH_CLIENT_ID + OAUTH_CLIENT_SECRET +
+ *      OAUTH_TOKEN_ENDPOINT + OAUTH_AUDIENCE (preferred for unattended/cron).
+ *      Use `doppler run --project ry-local --config dev_personal -- tsx ...`.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * Usage
+ * ─────────────────────────────────────────────────────────────────────────
+ *
+ *   # 1. Dump meetings from Granola via your Claude Code session into a JSON file:
+ *   #    (have the agent call mcp__claude_ai_Granola__list_meetings + get_meeting_transcript
+ *   #     for time_range="last_30_days" and write to ~/granola-dump.json)
+ *
+ *   # 2. Run the importer (with bearer token):
+ *   KMS_BEARER_TOKEN=eyJhbGc...  npx tsx scripts/import-granola.ts --input ~/granola-dump.json
+ *
+ *   # OR with doppler-managed client_credentials:
+ *   doppler run --project ry-local --config dev_personal -- \
+ *     npx tsx scripts/import-granola.ts --input ~/granola-dump.json
+ *
+ *   # Other flags:
+ *   #   --time-range last_30_days|this_week|last_week|custom|all_time   (advisory only;
+ *   #     the source file is the source of truth; this is logged for traceability)
+ *   #   --custom-start YYYY-MM-DD --custom-end YYYY-MM-DD               (with --time-range custom)
+ *   #   --kms-url http://localhost:8180/mcp                             (default)
+ *   #   --sync-log ~/.kms-granola-sync.json                             (default)
+ *   #   --user-id richard_yaker                                         (default — must match KMS_DEFAULT_USER_ID)
+ *   #   --anthropic-model claude-haiku-4-5                              (default)
+ *   #   --dry-run                                                       (skip the actual KMS writes; log what would happen)
+ *   #   --max-meetings <N>                                              (cap, useful for smoke-testing)
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * Resumability
+ * ─────────────────────────────────────────────────────────────────────────
+ *
+ * `~/.kms-granola-sync.json` is a JSON array of completed Granola meeting IDs.
+ * Re-running the script skips meetings already in the log. Failed meetings
+ * are NOT added to the log (so they retry next run).
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * Final report shape
+ * ─────────────────────────────────────────────────────────────────────────
+ *
+ *   {
+ *     "totalMeetings":  N,
+ *     "summaries":      N,                  // whole-meeting entries created
+ *     "claims":         N,                  // key-claim entries created
+ *     "skipped":        [{ id, title }],    // already in sync log
+ *     "failed":         [{ id, title, reason }],
+ *     "dedupRefused":   [{ id, title, candidates }]  // gate refused (counted distinctly from "failed")
+ *   }
+ */
+
+import Anthropic from '@anthropic-ai/sdk'
+import { existsSync, readFileSync, writeFileSync } from 'fs'
+import { homedir } from 'os'
+import { join } from 'path'
+import {
+  buildDistillPrompt,
+  DistilledMeeting,
+  mapClaimTypeToContentType,
+  parseDistilledResponse
+} from '../src/scripts/granola-distill-prompt.js'
+
+// ─────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────
+
+interface RawMeeting {
+  id: string
+  title: string
+  date?: string
+  transcript: string
+}
+
+interface SyncLog {
+  completed: string[]
+  lastRun?: string
+}
+
+interface ImportReport {
+  totalMeetings: number
+  summaries: number
+  claims: number
+  skipped: Array<{ id: string; title: string }>
+  failed: Array<{ id: string; title: string; reason: string }>
+  dedupRefused: Array<{ id: string; title: string; candidates: any[] }>
+}
+
+interface CliOptions {
+  input?: string
+  timeRange: string
+  customStart?: string
+  customEnd?: string
+  kmsUrl: string
+  syncLogPath: string
+  userId: string
+  anthropicModel: string
+  dryRun: boolean
+  maxMeetings?: number
+  bearerToken?: string
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Argv parsing — small, no dep on yargs/commander
+// ─────────────────────────────────────────────────────────────────────────
+
+export function parseArgs(argv: string[]): CliOptions {
+  const opts: CliOptions = {
+    timeRange: 'last_30_days',
+    kmsUrl: process.env.KMS_URL || 'http://localhost:8180/mcp',
+    syncLogPath: process.env.KMS_GRANOLA_SYNC_LOG || join(homedir(), '.kms-granola-sync.json'),
+    userId: process.env.KMS_DEFAULT_USER_ID || 'richard_yaker',
+    anthropicModel: process.env.ANTHROPIC_MODEL || 'claude-haiku-4-5',
+    dryRun: false,
+    bearerToken: process.env.KMS_BEARER_TOKEN
+  }
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    const next = () => argv[++i]
+    switch (arg) {
+      case '--input':              opts.input = next(); break
+      case '--time-range':         opts.timeRange = next(); break
+      case '--custom-start':       opts.customStart = next(); break
+      case '--custom-end':         opts.customEnd = next(); break
+      case '--kms-url':            opts.kmsUrl = next(); break
+      case '--sync-log':           opts.syncLogPath = next(); break
+      case '--user-id':            opts.userId = next(); break
+      case '--anthropic-model':    opts.anthropicModel = next(); break
+      case '--bearer-token':       opts.bearerToken = next(); break
+      case '--dry-run':            opts.dryRun = true; break
+      case '--max-meetings':       opts.maxMeetings = parseInt(next(), 10); break
+      case '-h':
+      case '--help':
+        printHelp()
+        process.exit(0)
+      default:
+        if (arg.startsWith('--')) {
+          console.error(`Unknown flag: ${arg}`)
+          process.exit(2)
+        }
+    }
+  }
+  return opts
+}
+
+function printHelp(): void {
+  console.log(`
+Granola → KMS importer
+
+Usage:
+  tsx scripts/import-granola.ts --input <meetings.json> [options]
+
+Required:
+  --input <file>            Path to a JSON array of meetings.
+
+Options:
+  --time-range <r>          last_30_days (default) | this_week | last_week | custom | all_time (advisory)
+  --custom-start YYYY-MM-DD With --time-range custom (advisory)
+  --custom-end YYYY-MM-DD   With --time-range custom (advisory)
+  --kms-url <url>           default: http://localhost:8180/mcp
+  --sync-log <path>         default: ~/.kms-granola-sync.json
+  --user-id <id>            default: richard_yaker (or KMS_DEFAULT_USER_ID env)
+  --anthropic-model <id>    default: claude-haiku-4-5
+  --bearer-token <token>    Bypass OAuth client-credentials, pass token directly.
+                            Or set KMS_BEARER_TOKEN env var.
+  --dry-run                 Don't actually write to KMS. Log what would happen.
+  --max-meetings <N>        Cap meetings processed (smoke-test).
+  -h, --help                This help.
+
+Environment:
+  KMS_BEARER_TOKEN          Preferred OAuth path for one-off runs.
+  ANTHROPIC_API_KEY         Required (Haiku 4.5 distillation).
+  KMS_URL                   Override --kms-url.
+  KMS_DEFAULT_USER_ID       Default --user-id.
+
+  When KMS_BEARER_TOKEN is unset, the script falls back to Auth0 client_credentials
+  using OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET, OAUTH_TOKEN_ENDPOINT, OAUTH_AUDIENCE
+  (typically supplied by 'doppler run --project ry-local --config dev_personal --').
+`)
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Sync log
+// ─────────────────────────────────────────────────────────────────────────
+
+export function loadSyncLog(path: string): SyncLog {
+  if (!existsSync(path)) {
+    return { completed: [] }
+  }
+  try {
+    const raw = readFileSync(path, 'utf-8')
+    const parsed = JSON.parse(raw)
+    if (!parsed || !Array.isArray(parsed.completed)) {
+      console.warn(`⚠️  Sync log at ${path} is malformed; starting empty.`)
+      return { completed: [] }
+    }
+    return { completed: parsed.completed, lastRun: parsed.lastRun }
+  } catch (e) {
+    console.warn(`⚠️  Could not read sync log ${path}: ${e instanceof Error ? e.message : e}`)
+    return { completed: [] }
+  }
+}
+
+export function saveSyncLog(path: string, log: SyncLog): void {
+  writeFileSync(
+    path,
+    JSON.stringify({ ...log, lastRun: new Date().toISOString() }, null, 2),
+    'utf-8'
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// OAuth — get bearer token via client_credentials if not supplied
+// ─────────────────────────────────────────────────────────────────────────
+
+async function fetchBearerTokenIfNeeded(opts: CliOptions): Promise<string | null> {
+  if (opts.bearerToken) return opts.bearerToken
+
+  const tokenEndpoint = process.env.OAUTH_TOKEN_ENDPOINT
+  const clientId = process.env.OAUTH_CLIENT_ID
+  const clientSecret = process.env.OAUTH_CLIENT_SECRET
+  const audience = process.env.OAUTH_AUDIENCE
+
+  if (!tokenEndpoint || !clientId || !clientSecret || !audience) {
+    console.warn(
+      `⚠️  No --bearer-token / KMS_BEARER_TOKEN set, and OAuth client_credentials env ` +
+      `vars are incomplete. Will attempt unauthenticated calls (will fail if KMS has OAUTH_ENABLED=true).`
+    )
+    return null
+  }
+
+  const body = new URLSearchParams({
+    grant_type: 'client_credentials',
+    client_id: clientId,
+    client_secret: clientSecret,
+    audience
+  })
+
+  const res = await fetch(tokenEndpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body
+  })
+  if (!res.ok) {
+    const txt = await res.text().catch(() => '')
+    throw new Error(`OAuth token request failed (${res.status}): ${txt}`)
+  }
+  const data = await res.json() as { access_token?: string }
+  if (!data.access_token) {
+    throw new Error(`OAuth token response had no access_token: ${JSON.stringify(data)}`)
+  }
+  return data.access_token
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// MCP client — minimal StreamableHTTP-compatible wrapper
+// ─────────────────────────────────────────────────────────────────────────
+
+export class MinimalMcpClient {
+  private kmsUrl: string
+  private bearer: string | null
+  private sessionId: string | null = null
+  private nextId = 1
+
+  constructor(kmsUrl: string, bearer: string | null) {
+    this.kmsUrl = kmsUrl
+    this.bearer = bearer
+  }
+
+  async initialize(): Promise<void> {
+    const initBody = {
+      jsonrpc: '2.0',
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-06-18',
+        capabilities: {},
+        clientInfo: { name: 'granola-importer', version: '1.0.0' }
+      },
+      id: this.nextId++
+    }
+    const { sessionId, body } = await this.postRaw(initBody, /* expectSession */ true)
+    if (!sessionId) {
+      throw new Error(
+        `MCP initialize did not return mcp-session-id header. Body: ${JSON.stringify(body).slice(0, 500)}`
+      )
+    }
+    this.sessionId = sessionId
+
+    // Send the required initialized notification.
+    await this.postRaw(
+      { jsonrpc: '2.0', method: 'notifications/initialized', params: {} },
+      false
+    )
+  }
+
+  /**
+   * Call a tool. Returns the parsed JSON result that the tool returned
+   * (i.e. the inner JSON payload from `result.content[0].text`).
+   */
+  async callTool<T = any>(name: string, args: Record<string, any>): Promise<T> {
+    if (!this.sessionId) throw new Error('MCP client not initialized')
+    const body = {
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: { name, arguments: args },
+      id: this.nextId++
+    }
+    const { body: response } = await this.postRaw(body, false)
+    if (response.error) {
+      throw new Error(
+        `Tool ${name} failed: ${response.error.message} (code ${response.error.code})`
+      )
+    }
+    const text = response?.result?.content?.[0]?.text
+    if (typeof text !== 'string') {
+      throw new Error(
+        `Tool ${name} returned unexpected shape (no result.content[0].text): ${JSON.stringify(response).slice(0, 400)}`
+      )
+    }
+    try {
+      return JSON.parse(text) as T
+    } catch (e) {
+      throw new Error(
+        `Tool ${name} returned non-JSON text body: ${text.slice(0, 400)}`
+      )
+    }
+  }
+
+  private async postRaw(
+    body: any,
+    captureSession: boolean
+  ): Promise<{ sessionId: string | null; body: any }> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      // Both MUST be in Accept; the StreamableHTTP SDK requires it.
+      'Accept': 'application/json, text/event-stream'
+    }
+    if (this.bearer) headers['Authorization'] = `Bearer ${this.bearer}`
+    if (this.sessionId) headers['mcp-session-id'] = this.sessionId
+
+    const res = await fetch(this.kmsUrl, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body)
+    })
+
+    const sessionHeader = res.headers.get('mcp-session-id')
+    const text = await res.text()
+
+    // Notifications get 202 with empty body — that's normal.
+    if (res.status === 202 && (!text || text.trim().length === 0)) {
+      return { sessionId: captureSession ? sessionHeader : null, body: null }
+    }
+
+    if (!res.ok) {
+      throw new Error(`MCP HTTP ${res.status}: ${text.slice(0, 500)}`)
+    }
+
+    // Try direct JSON first; fall back to SSE-line parse for clients that
+    // negotiated text/event-stream (the KMS sends one or the other depending
+    // on Accept handling).
+    let parsed: any
+    try {
+      parsed = JSON.parse(text)
+    } catch {
+      parsed = parseSseToJson(text)
+    }
+    return { sessionId: captureSession ? sessionHeader : null, body: parsed }
+  }
+
+  async close(): Promise<void> {
+    if (!this.sessionId) return
+    try {
+      const headers: Record<string, string> = { 'mcp-session-id': this.sessionId }
+      if (this.bearer) headers['Authorization'] = `Bearer ${this.bearer}`
+      await fetch(this.kmsUrl, { method: 'DELETE', headers })
+    } catch {
+      // best-effort
+    }
+  }
+}
+
+function parseSseToJson(sse: string): any {
+  // Find last `data: ...` line (StreamableHTTP single-message responses
+  // emit a single data chunk per JSON-RPC reply).
+  const lines = sse.split(/\r?\n/)
+  const dataLines = lines.filter(l => l.startsWith('data: ')).map(l => l.slice(6))
+  if (dataLines.length === 0) {
+    throw new Error(`Could not parse MCP response (not JSON, not SSE): ${sse.slice(0, 200)}`)
+  }
+  // Concatenate (some chunks span lines)
+  const joined = dataLines.join('')
+  return JSON.parse(joined)
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Granola source — read meetings from a JSON dump file
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface GranolaSource {
+  list(): Promise<RawMeeting[]>
+}
+
+export class FileGranolaSource implements GranolaSource {
+  constructor(private path: string) {}
+
+  async list(): Promise<RawMeeting[]> {
+    if (!existsSync(this.path)) {
+      throw new Error(`Granola dump file not found: ${this.path}`)
+    }
+    const raw = readFileSync(this.path, 'utf-8')
+    let parsed: any
+    try {
+      parsed = JSON.parse(raw)
+    } catch (e) {
+      throw new Error(`Granola dump is not valid JSON: ${e instanceof Error ? e.message : e}`)
+    }
+    if (!Array.isArray(parsed)) {
+      throw new Error('Granola dump must be a top-level JSON array of meetings')
+    }
+    return parsed.map((m: any, i: number): RawMeeting => {
+      if (!m || typeof m !== 'object') {
+        throw new Error(`Meeting ${i} is not an object`)
+      }
+      if (typeof m.id !== 'string' || typeof m.title !== 'string' || typeof m.transcript !== 'string') {
+        throw new Error(
+          `Meeting ${i} missing required string fields (id, title, transcript): ${JSON.stringify(m).slice(0, 200)}`
+        )
+      }
+      return {
+        id: m.id,
+        title: m.title,
+        date: typeof m.date === 'string' ? m.date : undefined,
+        transcript: m.transcript
+      }
+    })
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Distillation — Haiku 4.5 via @anthropic-ai/sdk
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface DistillerLike {
+  distill(meeting: RawMeeting): Promise<DistilledMeeting>
+}
+
+export class HaikuDistiller implements DistillerLike {
+  private client: Anthropic
+  private model: string
+
+  constructor(apiKey: string, model: string) {
+    this.client = new Anthropic({ apiKey })
+    this.model = model
+  }
+
+  async distill(meeting: RawMeeting): Promise<DistilledMeeting> {
+    const { system, user } = buildDistillPrompt({
+      title: meeting.title,
+      meetingId: meeting.id,
+      date: meeting.date,
+      transcript: meeting.transcript
+    })
+
+    const resp = await this.client.messages.create({
+      model: this.model,
+      max_tokens: 2048,
+      system,
+      messages: [{ role: 'user', content: user }]
+    })
+
+    // resp.content[0] is a text block when Haiku follows the prompt.
+    const block = resp.content?.[0] as any
+    const text = block?.type === 'text' ? block.text : ''
+    return parseDistilledResponse(text)
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Importer driver
+// ─────────────────────────────────────────────────────────────────────────
+
+interface ImporterDeps {
+  source: GranolaSource
+  distiller: DistillerLike
+  kms: MinimalMcpClient | null  // null in --dry-run
+  opts: CliOptions
+  log: SyncLog
+}
+
+interface SingleMeetingResult {
+  status: 'ok' | 'skipped' | 'failed' | 'dedup_refused'
+  meeting: RawMeeting
+  reason?: string
+  candidates?: any[]
+  summaryEntryId?: string
+  claimEntryIds?: string[]
+}
+
+/**
+ * Process a single meeting end-to-end.
+ *
+ * Public so tests can target one meeting at a time.
+ */
+export async function processMeeting(
+  meeting: RawMeeting,
+  deps: ImporterDeps
+): Promise<SingleMeetingResult> {
+  if (deps.log.completed.includes(meeting.id)) {
+    return { status: 'skipped', meeting, reason: 'already in sync log' }
+  }
+
+  // Distill
+  let distilled: DistilledMeeting
+  try {
+    distilled = await deps.distiller.distill(meeting)
+  } catch (e) {
+    return {
+      status: 'failed',
+      meeting,
+      reason: `distill: ${e instanceof Error ? e.message : String(e)}`
+    }
+  }
+
+  if (deps.opts.dryRun) {
+    console.log(`📝 [dry-run] would write summary + ${distilled.claims.length} claims for "${meeting.title}"`)
+    return {
+      status: 'ok',
+      meeting,
+      summaryEntryId: 'dry-run-summary',
+      claimEntryIds: distilled.claims.map((_, i) => `dry-run-claim-${i}`)
+    }
+  }
+
+  if (!deps.kms) {
+    return { status: 'failed', meeting, reason: 'no KMS client and not dry-run (internal error)' }
+  }
+
+  // Step 1: write whole-meeting summary entry
+  const subject = `Granola.${meeting.title}`
+  const sourceDoc = `granola://${meeting.id}`
+  const summaryArgs = {
+    content: distilled.summary,
+    contentType: 'memory' as const,
+    source: 'personal' as const,
+    userId: deps.opts.userId,
+    metadata: {
+      subject,
+      source: 'granola',
+      granola_meeting_id: meeting.id,
+      meeting_date: meeting.date,
+      source_doc: sourceDoc,
+      meeting_title: meeting.title
+    }
+  }
+
+  let summaryResult: any
+  try {
+    summaryResult = await deps.kms.callTool('unified_store', summaryArgs)
+  } catch (e) {
+    return {
+      status: 'failed',
+      meeting,
+      reason: `summary write: ${e instanceof Error ? e.message : String(e)}`
+    }
+  }
+
+  // Dedup gate refusal — skip cleanly, log, don't fail the whole run.
+  if (summaryResult?.status === 'dedup_required') {
+    return {
+      status: 'dedup_refused',
+      meeting,
+      candidates: summaryResult.candidates ?? [],
+      reason: summaryResult.message ?? 'dedup_required'
+    }
+  }
+  if (!summaryResult?.success || typeof summaryResult.id !== 'string') {
+    return {
+      status: 'failed',
+      meeting,
+      reason: `summary write returned unexpected shape: ${JSON.stringify(summaryResult).slice(0, 300)}`
+    }
+  }
+
+  const summaryEntryId = summaryResult.id as string
+
+  // Step 2: write each claim with metadata.related_to=[summaryEntryId]
+  const claimEntryIds: string[] = []
+  const claimFailures: string[] = []
+  for (let ci = 0; ci < distilled.claims.length; ci++) {
+    const claim = distilled.claims[ci]
+    const claimArgs = {
+      content: claim.content,
+      contentType: mapClaimTypeToContentType(claim.type),
+      source: 'personal' as const,
+      userId: deps.opts.userId,
+      metadata: {
+        subject: `${subject}.claim_${ci}`,
+        source: 'granola',
+        source_doc: sourceDoc,
+        granola_meeting_id: meeting.id,
+        meeting_date: meeting.date,
+        ob1_type: claim.type,
+        ob1_confidence: claim.confidence,
+        topics: claim.topics,
+        people: claim.people,
+        related_to: [summaryEntryId]
+      }
+    }
+
+    try {
+      const claimResult: any = await deps.kms.callTool('unified_store', claimArgs)
+      if (claimResult?.status === 'dedup_required') {
+        // Dedup refusal on a claim is non-fatal — log and move on.
+        claimFailures.push(
+          `claim ${ci} (${claim.type}): dedup_refused against ${claimResult.candidates?.[0]?.id ?? '?'}`
+        )
+        continue
+      }
+      if (!claimResult?.success || typeof claimResult.id !== 'string') {
+        claimFailures.push(`claim ${ci} (${claim.type}): unexpected response`)
+        continue
+      }
+      claimEntryIds.push(claimResult.id)
+    } catch (e) {
+      claimFailures.push(
+        `claim ${ci} (${claim.type}): ${e instanceof Error ? e.message : String(e)}`
+      )
+    }
+  }
+
+  // Even with some claim failures, we count the meeting OK if the summary
+  // landed — the summary IS the meeting record. Claims are bonus enrichment.
+  if (claimFailures.length > 0) {
+    console.warn(
+      `⚠️  Meeting "${meeting.title}" had ${claimFailures.length}/${distilled.claims.length} claim failure(s):\n  ${claimFailures.join('\n  ')}`
+    )
+  }
+
+  return {
+    status: 'ok',
+    meeting,
+    summaryEntryId,
+    claimEntryIds
+  }
+}
+
+export async function runImport(deps: ImporterDeps): Promise<ImportReport> {
+  const meetingsAll = await deps.source.list()
+  const meetings = deps.opts.maxMeetings
+    ? meetingsAll.slice(0, deps.opts.maxMeetings)
+    : meetingsAll
+
+  console.log(
+    `📥 Loaded ${meetings.length} meeting(s) from source ` +
+    `(time-range advisory: ${deps.opts.timeRange}${
+      deps.opts.timeRange === 'custom'
+        ? ` ${deps.opts.customStart ?? '?'}..${deps.opts.customEnd ?? '?'}`
+        : ''
+    })`
+  )
+
+  const report: ImportReport = {
+    totalMeetings: meetings.length,
+    summaries: 0,
+    claims: 0,
+    skipped: [],
+    failed: [],
+    dedupRefused: []
+  }
+
+  const t0 = Date.now()
+  for (let i = 0; i < meetings.length; i++) {
+    const meeting = meetings[i]
+    const result = await processMeeting(meeting, deps)
+
+    switch (result.status) {
+      case 'ok':
+        report.summaries += 1
+        report.claims += result.claimEntryIds?.length ?? 0
+        deps.log.completed.push(meeting.id)
+        // Save sync log immediately after each success — partial progress is
+        // valuable, especially for long Haiku-bound runs.
+        if (!deps.opts.dryRun) saveSyncLog(deps.opts.syncLogPath, deps.log)
+        break
+      case 'skipped':
+        report.skipped.push({ id: meeting.id, title: meeting.title })
+        break
+      case 'failed':
+        report.failed.push({ id: meeting.id, title: meeting.title, reason: result.reason ?? 'unknown' })
+        console.error(`❌ Meeting "${meeting.title}" (${meeting.id}) failed: ${result.reason}`)
+        break
+      case 'dedup_refused':
+        report.dedupRefused.push({
+          id: meeting.id,
+          title: meeting.title,
+          candidates: result.candidates ?? []
+        })
+        console.warn(
+          `🛑 Meeting "${meeting.title}" (${meeting.id}) refused by dedup gate ` +
+          `against ${result.candidates?.[0]?.id ?? '?'}`
+        )
+        break
+    }
+
+    if ((i + 1) % 5 === 0 || i === meetings.length - 1) {
+      const elapsedMs = Date.now() - t0
+      const perMeeting = elapsedMs / (i + 1)
+      const remaining = meetings.length - (i + 1)
+      const etaMin = Math.round((perMeeting * remaining) / 60000)
+      console.log(
+        `⏱️  ${i + 1}/${meetings.length} done, ETA ${etaMin}min, last_meeting="${meeting.title}"`
+      )
+    }
+  }
+
+  return report
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Main
+// ─────────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const opts = parseArgs(process.argv.slice(2))
+
+  if (!opts.input) {
+    console.error('❌ --input <file> is required (path to a JSON array of meetings).')
+    console.error('   See --help for the expected file shape.')
+    process.exit(2)
+  }
+
+  const apiKey = process.env.ANTHROPIC_API_KEY
+  if (!apiKey && !opts.dryRun) {
+    console.error('❌ ANTHROPIC_API_KEY env var is required (Haiku 4.5 distillation).')
+    console.error('   Set it directly or via doppler. Use --dry-run to skip distillation.')
+    process.exit(2)
+  }
+
+  console.log(`🚀 Granola → KMS importer starting`)
+  console.log(`   Input:        ${opts.input}`)
+  console.log(`   KMS URL:      ${opts.kmsUrl}`)
+  console.log(`   Sync log:     ${opts.syncLogPath}`)
+  console.log(`   User ID:      ${opts.userId}`)
+  console.log(`   Model:        ${opts.anthropicModel}`)
+  console.log(`   Dry run:      ${opts.dryRun}`)
+  if (opts.maxMeetings) console.log(`   Cap:          ${opts.maxMeetings} meetings`)
+
+  const source = new FileGranolaSource(opts.input)
+  const distiller = opts.dryRun
+    ? new NoopDistiller()
+    : new HaikuDistiller(apiKey!, opts.anthropicModel)
+
+  let kms: MinimalMcpClient | null = null
+  if (!opts.dryRun) {
+    const bearer = await fetchBearerTokenIfNeeded(opts).catch(e => {
+      console.error(`❌ Could not obtain KMS bearer token: ${e instanceof Error ? e.message : e}`)
+      process.exit(2)
+    })
+    kms = new MinimalMcpClient(opts.kmsUrl, bearer ?? null)
+    await kms.initialize()
+    console.log(`🔌 Connected to KMS, session active.`)
+  }
+
+  const log = loadSyncLog(opts.syncLogPath)
+  console.log(`📓 Sync log has ${log.completed.length} previously-completed meeting(s).`)
+
+  const report = await runImport({ source, distiller, kms, opts, log })
+
+  if (kms) await kms.close()
+
+  console.log(`\n══════════════ FINAL REPORT ══════════════`)
+  console.log(`Total meetings:       ${report.totalMeetings}`)
+  console.log(`Summary entries:      ${report.summaries}`)
+  console.log(`Claim entries:        ${report.claims}`)
+  console.log(`Skipped (sync log):   ${report.skipped.length}`)
+  console.log(`Dedup refused:        ${report.dedupRefused.length}`)
+  console.log(`Failed:               ${report.failed.length}`)
+  if (report.failed.length > 0) {
+    console.log(`\nFailures:`)
+    for (const f of report.failed) {
+      console.log(`  - "${f.title}" (${f.id}): ${f.reason}`)
+    }
+  }
+  if (report.dedupRefused.length > 0) {
+    console.log(`\nDedup refused (already in KMS):`)
+    for (const d of report.dedupRefused) {
+      console.log(`  - "${d.title}" (${d.id}) → top candidate ${d.candidates[0]?.id ?? '?'}`)
+    }
+  }
+  console.log(`\n✅ Done.`)
+
+  // Non-zero exit if any meeting hard-failed (dedup refusal is informational)
+  process.exit(report.failed.length > 0 ? 1 : 0)
+}
+
+/** Distiller that returns a stable stub — used in --dry-run when we still want to walk the pipeline. */
+class NoopDistiller implements DistillerLike {
+  async distill(meeting: RawMeeting): Promise<DistilledMeeting> {
+    return {
+      summary: `[dry-run stub] meeting ${meeting.id} (${meeting.title}) — would distill ${meeting.transcript.length} chars`,
+      claims: [
+        {
+          type: 'context',
+          content: `[dry-run stub] context placeholder for meeting ${meeting.title}`,
+          confidence: 'tentative',
+          topics: ['dry-run'],
+          people: []
+        }
+      ]
+    }
+  }
+}
+
+// Only run main() when invoked as a CLI, not when imported by tests.
+const isMainModule =
+  typeof process !== 'undefined' &&
+  process.argv[1] &&
+  (process.argv[1].endsWith('import-granola.ts') || process.argv[1].endsWith('import-granola.js'))
+
+if (isMainModule) {
+  main().catch(e => {
+    console.error(`💥 Unhandled: ${e instanceof Error ? e.stack ?? e.message : String(e)}`)
+    process.exit(1)
+  })
+}

--- a/scripts/import-granola.ts
+++ b/scripts/import-granola.ts
@@ -167,19 +167,35 @@ export function parseArgs(argv: string[]): CliOptions {
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]
-    const next = () => argv[++i]
+    const next = (flag: string): string => {
+      const val = argv[++i]
+      if (val === undefined) {
+        console.error(`❌ Flag ${flag} requires a value.`)
+        process.exit(2)
+      }
+      return val
+    }
     switch (arg) {
-      case '--input':              opts.input = next(); break
-      case '--time-range':         opts.timeRange = next(); break
-      case '--custom-start':       opts.customStart = next(); break
-      case '--custom-end':         opts.customEnd = next(); break
-      case '--kms-url':            opts.kmsUrl = next(); break
-      case '--sync-log':           opts.syncLogPath = next(); break
-      case '--user-id':            opts.userId = next(); break
-      case '--anthropic-model':    opts.anthropicModel = next(); break
-      case '--bearer-token':       opts.bearerToken = next(); break
+      case '--input':              opts.input = next('--input'); break
+      case '--time-range':         opts.timeRange = next('--time-range'); break
+      case '--custom-start':       opts.customStart = next('--custom-start'); break
+      case '--custom-end':         opts.customEnd = next('--custom-end'); break
+      case '--kms-url':            opts.kmsUrl = next('--kms-url'); break
+      case '--sync-log':           opts.syncLogPath = next('--sync-log'); break
+      case '--user-id':            opts.userId = next('--user-id'); break
+      case '--anthropic-model':    opts.anthropicModel = next('--anthropic-model'); break
+      case '--bearer-token':       opts.bearerToken = next('--bearer-token'); break
       case '--dry-run':            opts.dryRun = true; break
-      case '--max-meetings':       opts.maxMeetings = parseInt(next(), 10); break
+      case '--max-meetings': {
+        const raw = next('--max-meetings')
+        const parsed = parseInt(raw, 10)
+        if (isNaN(parsed) || parsed <= 0) {
+          console.error(`❌ --max-meetings requires a positive integer, got: ${raw}`)
+          process.exit(2)
+        }
+        opts.maxMeetings = parsed
+        break
+      }
       case '-h':
       case '--help':
         printHelp()
@@ -379,7 +395,8 @@ export class MinimalMcpClient {
 
   private async postRaw(
     body: any,
-    captureSession: boolean
+    captureSession: boolean,
+    timeoutMs = 30_000
   ): Promise<{ sessionId: string | null; body: any }> {
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -389,11 +406,24 @@ export class MinimalMcpClient {
     if (this.bearer) headers['Authorization'] = `Bearer ${this.bearer}`
     if (this.sessionId) headers['mcp-session-id'] = this.sessionId
 
-    const res = await fetch(this.kmsUrl, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(body)
-    })
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), timeoutMs)
+    let res: Response
+    try {
+      res = await fetch(this.kmsUrl, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+        signal: controller.signal
+      })
+    } catch (e: any) {
+      if (e?.name === 'AbortError') {
+        throw new Error(`MCP request timed out after ${timeoutMs}ms`)
+      }
+      throw e
+    } finally {
+      clearTimeout(timer)
+    }
 
     const sessionHeader = res.headers.get('mcp-session-id')
     const text = await res.text()
@@ -635,7 +665,10 @@ export async function processMeeting(
 
   const summaryEntryId = summaryResult.id as string
 
-  // Step 2: write each claim with metadata.related_to=[summaryEntryId]
+  // Step 2: write each claim linked back to the whole-meeting summary.
+  // The first-class `relationships` array is the canonical link (persisted by
+  // the storage router). metadata.related_to is kept as a human-readable
+  // breadcrumb for search/audit tooling.
   const claimEntryIds: string[] = []
   const claimFailures: string[] = []
   for (let ci = 0; ci < distilled.claims.length; ci++) {
@@ -656,7 +689,14 @@ export async function processMeeting(
         topics: claim.topics,
         people: claim.people,
         related_to: [summaryEntryId]
-      }
+      },
+      relationships: [
+        {
+          targetId: summaryEntryId,
+          type: 'DERIVED_FROM',
+          strength: 1.0
+        }
+      ]
     }
 
     try {
@@ -816,9 +856,13 @@ async function main(): Promise<void> {
   const log = loadSyncLog(opts.syncLogPath)
   console.log(`📓 Sync log has ${log.completed.length} previously-completed meeting(s).`)
 
-  const report = await runImport({ source, distiller, kms, opts, log })
-
-  if (kms) await kms.close()
+  let report: ImportReport
+  try {
+    report = await runImport({ source, distiller, kms, opts, log })
+  } finally {
+    // Always close the MCP session, even if runImport throws.
+    if (kms) await kms.close()
+  }
 
   console.log(`\n══════════════ FINAL REPORT ══════════════`)
   console.log(`Total meetings:       ${report.totalMeetings}`)

--- a/src/__tests__/import-granola.test.ts
+++ b/src/__tests__/import-granola.test.ts
@@ -1,0 +1,650 @@
+/**
+ * Tests for the Granola → KMS importer.
+ *
+ * Coverage:
+ *   - Distillation prompt produces valid JSON / parseDistilledResponse strict checks
+ *   - Sync-log resumability (skips meetings already in log)
+ *   - Dedup-required response from KMS handled (skip + log, don't fail run)
+ *   - Granola source failure handled gracefully (failure on one meeting doesn't
+ *     stop the whole batch — we test the per-meeting boundary in processMeeting,
+ *     and verify the batch loop in runImport rolls forward across mixed outcomes)
+ *
+ * No live KMS, no live Anthropic API. Everything is mocked at the seam.
+ */
+
+import {
+  parseDistilledResponse,
+  buildDistillPrompt,
+  mapClaimTypeToContentType
+} from '../scripts/granola-distill-prompt.js'
+
+// Import the importer pieces. Note: scripts/import-granola.ts lives outside
+// `src/`, so we use a relative path that ts-jest can resolve. The jest config
+// (`roots: ['<rootDir>/src']`) only affects test discovery — TS imports can
+// reach outside.
+import {
+  loadSyncLog,
+  parseArgs,
+  processMeeting,
+  runImport,
+  FileGranolaSource,
+  MinimalMcpClient,
+  GranolaSource,
+  DistillerLike
+} from '../../scripts/import-granola.js'
+import type { DistilledMeeting } from '../scripts/granola-distill-prompt.js'
+
+import { mkdtempSync, writeFileSync, rmSync, readFileSync, existsSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+// ─────────────────────────────────────────────────────────────────────────
+// Distillation prompt — pure unit tests
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('granola-distill-prompt', () => {
+  describe('buildDistillPrompt', () => {
+    it('locks the OB1 6-type taxonomy in the system prompt', () => {
+      const { system } = buildDistillPrompt({
+        title: 'Test',
+        meetingId: 'g_1',
+        transcript: 'A: hi\nB: bye'
+      })
+      // All six OB1 types must be enumerated
+      for (const t of ['decision', 'preference', 'learning', 'context', 'brainstorm', 'reference']) {
+        expect(system).toContain(t)
+      }
+    })
+
+    it('includes the curate-don\'t-dump rule verbatim', () => {
+      const { system } = buildDistillPrompt({
+        title: 'Test',
+        meetingId: 'g_1',
+        transcript: 'transcript text'
+      })
+      expect(system).toContain(
+        'Each claim must be a self-contained statement that makes sense without the original transcript context.'
+      )
+    })
+
+    it('caps claims at 5 in the prompt instructions', () => {
+      const { system } = buildDistillPrompt({
+        title: 'Test',
+        meetingId: 'g_1',
+        transcript: 'x'
+      })
+      expect(system).toMatch(/2 to 5 claims|2-5 claims|2–5 claims/)
+    })
+
+    it('passes meeting metadata into the user prompt', () => {
+      const { user } = buildDistillPrompt({
+        title: 'KMSmcp sync',
+        meetingId: 'gx_42',
+        date: '2026-04-30',
+        transcript: 'transcript here'
+      })
+      expect(user).toContain('KMSmcp sync')
+      expect(user).toContain('gx_42')
+      expect(user).toContain('2026-04-30')
+      expect(user).toContain('transcript here')
+    })
+  })
+
+  describe('parseDistilledResponse', () => {
+    const validResponse = JSON.stringify({
+      summary: 'A short summary of the meeting.',
+      claims: [
+        {
+          type: 'decision',
+          content: 'We decided to ship feature X next week.',
+          confidence: 'firm',
+          topics: ['shipping'],
+          people: ['Rich']
+        },
+        {
+          type: 'context',
+          content: 'Q3 traffic is up 30% so capacity matters.',
+          confidence: 'tentative',
+          topics: ['capacity'],
+          people: []
+        }
+      ]
+    })
+
+    it('parses a well-formed response', () => {
+      const out = parseDistilledResponse(validResponse)
+      expect(out.summary).toContain('short summary')
+      expect(out.claims).toHaveLength(2)
+      expect(out.claims[0].type).toBe('decision')
+      expect(out.claims[0].confidence).toBe('firm')
+    })
+
+    it('strips ```json fences', () => {
+      const wrapped = '```json\n' + validResponse + '\n```'
+      const out = parseDistilledResponse(wrapped)
+      expect(out.claims).toHaveLength(2)
+    })
+
+    it('strips bare ``` fences', () => {
+      const wrapped = '```\n' + validResponse + '\n```'
+      const out = parseDistilledResponse(wrapped)
+      expect(out.claims).toHaveLength(2)
+    })
+
+    it('extracts JSON when leading prose is present', () => {
+      const messy = 'Here is the JSON output:\n' + validResponse + '\nLet me know!'
+      const out = parseDistilledResponse(messy)
+      expect(out.summary).toContain('short summary')
+    })
+
+    it('throws on empty input', () => {
+      expect(() => parseDistilledResponse('')).toThrow(/Empty/)
+      expect(() => parseDistilledResponse('   ')).toThrow(/Empty/)
+    })
+
+    it('throws on invalid JSON', () => {
+      expect(() => parseDistilledResponse('{ not valid')).toThrow(/not valid JSON/)
+    })
+
+    it('throws on missing summary', () => {
+      const bad = JSON.stringify({ claims: [{ type: 'decision', content: 'x', confidence: 'firm', topics: [], people: [] }] })
+      expect(() => parseDistilledResponse(bad)).toThrow(/summary/)
+    })
+
+    it('throws on zero claims', () => {
+      const bad = JSON.stringify({ summary: 'foo', claims: [] })
+      expect(() => parseDistilledResponse(bad)).toThrow(/zero claims/)
+    })
+
+    it('soft-caps to 5 claims when more are returned', () => {
+      const sevenClaims = Array.from({ length: 7 }, (_, i) => ({
+        type: 'context',
+        content: `claim ${i}`,
+        confidence: 'firm',
+        topics: [],
+        people: []
+      }))
+      const tooMany = JSON.stringify({ summary: 'x', claims: sevenClaims })
+      const out = parseDistilledResponse(tooMany)
+      expect(out.claims).toHaveLength(5)
+    })
+
+    it('rejects invalid claim types', () => {
+      const bad = JSON.stringify({
+        summary: 'x',
+        claims: [{ type: 'yolo', content: 'x', confidence: 'firm', topics: [], people: [] }]
+      })
+      expect(() => parseDistilledResponse(bad)).toThrow(/invalid type/)
+    })
+
+    it('rejects invalid confidence values', () => {
+      const bad = JSON.stringify({
+        summary: 'x',
+        claims: [{ type: 'decision', content: 'x', confidence: 'maybe', topics: [], people: [] }]
+      })
+      expect(() => parseDistilledResponse(bad)).toThrow(/invalid confidence/)
+    })
+
+    it('coerces missing/invalid topics + people to empty arrays', () => {
+      const data = JSON.stringify({
+        summary: 'x',
+        claims: [{
+          type: 'decision',
+          content: 'y',
+          confidence: 'firm',
+          topics: ['a', 1, 'b'],
+          people: 'not-an-array'
+        }]
+      })
+      const out = parseDistilledResponse(data)
+      expect(out.claims[0].topics).toEqual(['a', 'b'])
+      expect(out.claims[0].people).toEqual([])
+    })
+  })
+
+  describe('mapClaimTypeToContentType', () => {
+    it('maps all six OB1 types', () => {
+      expect(mapClaimTypeToContentType('decision')).toBe('insight')
+      expect(mapClaimTypeToContentType('brainstorm')).toBe('insight')
+      expect(mapClaimTypeToContentType('preference')).toBe('memory')
+      expect(mapClaimTypeToContentType('context')).toBe('memory')
+      expect(mapClaimTypeToContentType('learning')).toBe('fact')
+      expect(mapClaimTypeToContentType('reference')).toBe('procedure')
+    })
+
+    it('falls back to memory on unknown types', () => {
+      expect(mapClaimTypeToContentType('unknown-future-type')).toBe('memory')
+    })
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// CLI parsing
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('parseArgs', () => {
+  it('applies sensible defaults', () => {
+    const opts = parseArgs([])
+    expect(opts.timeRange).toBe('last_30_days')
+    expect(opts.kmsUrl).toMatch(/^http/)
+    expect(opts.dryRun).toBe(false)
+  })
+
+  it('parses --input and --dry-run', () => {
+    const opts = parseArgs(['--input', '/tmp/foo.json', '--dry-run'])
+    expect(opts.input).toBe('/tmp/foo.json')
+    expect(opts.dryRun).toBe(true)
+  })
+
+  it('parses --max-meetings', () => {
+    const opts = parseArgs(['--max-meetings', '7'])
+    expect(opts.maxMeetings).toBe(7)
+  })
+
+  it('parses --bearer-token', () => {
+    const opts = parseArgs(['--bearer-token', 'tok-123'])
+    expect(opts.bearerToken).toBe('tok-123')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// Sync log
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('sync log', () => {
+  let tmpDir: string
+  let logPath: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'granola-import-test-'))
+    logPath = join(tmpDir, '.kms-granola-sync.json')
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('returns empty log when file does not exist', () => {
+    expect(existsSync(logPath)).toBe(false)
+    const log = loadSyncLog(logPath)
+    expect(log.completed).toEqual([])
+  })
+
+  it('reads previously-stored completed IDs', () => {
+    writeFileSync(logPath, JSON.stringify({ completed: ['m1', 'm2'], lastRun: '2026-01-01' }))
+    const log = loadSyncLog(logPath)
+    expect(log.completed).toEqual(['m1', 'm2'])
+  })
+
+  it('returns empty on malformed file (no throw)', () => {
+    writeFileSync(logPath, 'not json at all')
+    const log = loadSyncLog(logPath)
+    expect(log.completed).toEqual([])
+  })
+
+  it('returns empty on file with wrong schema', () => {
+    writeFileSync(logPath, JSON.stringify({ wrong: 'shape' }))
+    const log = loadSyncLog(logPath)
+    expect(log.completed).toEqual([])
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// FileGranolaSource
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('FileGranolaSource', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'granola-source-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('reads meetings from a JSON file', async () => {
+    const path = join(tmpDir, 'm.json')
+    writeFileSync(path, JSON.stringify([
+      { id: 'g_1', title: 'A', transcript: 'hi', date: '2026-04-30' },
+      { id: 'g_2', title: 'B', transcript: 'bye' }
+    ]))
+    const src = new FileGranolaSource(path)
+    const meetings = await src.list()
+    expect(meetings).toHaveLength(2)
+    expect(meetings[0]).toEqual({ id: 'g_1', title: 'A', transcript: 'hi', date: '2026-04-30' })
+    expect(meetings[1]).toEqual({ id: 'g_2', title: 'B', transcript: 'bye', date: undefined })
+  })
+
+  it('throws on missing file', async () => {
+    const src = new FileGranolaSource(join(tmpDir, 'nope.json'))
+    await expect(src.list()).rejects.toThrow(/not found/)
+  })
+
+  it('throws on non-array top-level', async () => {
+    const path = join(tmpDir, 'm.json')
+    writeFileSync(path, JSON.stringify({ not: 'an array' }))
+    const src = new FileGranolaSource(path)
+    await expect(src.list()).rejects.toThrow(/array/)
+  })
+
+  it('throws when a meeting is missing required fields', async () => {
+    const path = join(tmpDir, 'm.json')
+    writeFileSync(path, JSON.stringify([
+      { id: 'g_1', title: 'A' }  // no transcript
+    ]))
+    const src = new FileGranolaSource(path)
+    await expect(src.list()).rejects.toThrow(/required/)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// processMeeting + runImport — wired to fakes
+// ─────────────────────────────────────────────────────────────────────────
+
+class FakeGranolaSource implements GranolaSource {
+  constructor(private meetings: any[]) {}
+  async list() { return this.meetings as any }
+}
+
+class FakeDistiller implements DistillerLike {
+  constructor(private overrides: Partial<DistilledMeeting> = {}, private throwOn?: string) {}
+  async distill(meeting: any): Promise<DistilledMeeting> {
+    if (this.throwOn && meeting.id === this.throwOn) {
+      throw new Error('haiku exploded')
+    }
+    return {
+      summary: this.overrides.summary ?? `summary for ${meeting.title}`,
+      claims: this.overrides.claims ?? [
+        { type: 'decision', content: 'A decision.', confidence: 'firm', topics: [], people: [] },
+        { type: 'context', content: 'A context.', confidence: 'tentative', topics: [], people: [] }
+      ]
+    }
+  }
+}
+
+/**
+ * A FakeMcpClient that records calls and returns canned responses keyed by
+ * call sequence. Drop-in replacement for MinimalMcpClient (duck-typed via
+ * the `callTool` method).
+ */
+class FakeMcpClient {
+  public calls: Array<{ name: string; args: any }> = []
+  private responses: any[]
+  private idCounter = 0
+
+  constructor(responses?: any[]) {
+    this.responses = responses ?? []
+  }
+
+  async callTool(name: string, args: any) {
+    this.calls.push({ name, args })
+    if (this.responses.length > 0) {
+      return this.responses.shift()
+    }
+    // Default: succeed with a fresh id.
+    return {
+      success: true,
+      id: `kms-id-${++this.idCounter}`,
+      storageDecision: { primary: 'graph', secondary: ['mem0'], cacheStrategy: 'L2', reasoning: 'fake' },
+      cached: true,
+      performance: { routingTime: 1, storageTime: 1, totalTime: 2 }
+    }
+  }
+
+  async initialize() { /* noop */ }
+  async close() { /* noop */ }
+}
+
+describe('processMeeting', () => {
+  it('skips a meeting already in the sync log', async () => {
+    const meeting = { id: 'm1', title: 'A', transcript: 'hi' }
+    const result = await processMeeting(meeting, {
+      source: new FakeGranolaSource([]),
+      distiller: new FakeDistiller(),
+      kms: new FakeMcpClient() as any,
+      opts: { ...defaultOpts(), dryRun: false },
+      log: { completed: ['m1'] }
+    })
+    expect(result.status).toBe('skipped')
+    expect(result.reason).toContain('sync log')
+  })
+
+  it('writes summary + N claim entries on the happy path', async () => {
+    const meeting = { id: 'm2', title: 'B', transcript: 'hello world' }
+    const kms = new FakeMcpClient()
+    const result = await processMeeting(meeting, {
+      source: new FakeGranolaSource([]),
+      distiller: new FakeDistiller(),
+      kms: kms as any,
+      opts: { ...defaultOpts(), dryRun: false },
+      log: { completed: [] }
+    })
+    expect(result.status).toBe('ok')
+    expect(result.summaryEntryId).toBe('kms-id-1')
+    expect(result.claimEntryIds).toEqual(['kms-id-2', 'kms-id-3'])
+
+    // Verify dual-write contract
+    expect(kms.calls).toHaveLength(3) // 1 summary + 2 claims
+    const [summary, claim0, claim1] = kms.calls
+    expect(summary.name).toBe('unified_store')
+    expect(summary.args.contentType).toBe('memory')
+    expect(summary.args.metadata.subject).toBe('Granola.B')
+    expect(summary.args.metadata.source).toBe('granola')
+    expect(summary.args.metadata.granola_meeting_id).toBe('m2')
+    expect(summary.args.metadata.source_doc).toBe('granola://m2')
+
+    expect(claim0.args.metadata.related_to).toEqual(['kms-id-1'])
+    expect(claim0.args.metadata.source_doc).toBe('granola://m2')
+    expect(claim0.args.metadata.subject).toBe('Granola.B.claim_0')
+    expect(claim0.args.contentType).toBe('insight')   // decision → insight
+    expect(claim1.args.contentType).toBe('memory')    // context → memory
+  })
+
+  it('handles dedup_required on summary write — counts as dedup_refused, not failed', async () => {
+    const meeting = { id: 'm3', title: 'C', transcript: 'x' }
+    const kms = new FakeMcpClient([
+      {
+        status: 'dedup_required',
+        candidates: [{ id: 'existing-1', similarity: 0.92 }],
+        message: 'dup found',
+        retry_with: [],
+        band: 'refuse',
+        thresholds: { refuse: 0.88, confirm: 0.78 }
+      }
+    ])
+    const result = await processMeeting(meeting, {
+      source: new FakeGranolaSource([]),
+      distiller: new FakeDistiller(),
+      kms: kms as any,
+      opts: { ...defaultOpts(), dryRun: false },
+      log: { completed: [] }
+    })
+    expect(result.status).toBe('dedup_refused')
+    expect(result.candidates?.[0]?.id).toBe('existing-1')
+    // Critically: we did NOT proceed to write claims when summary refused
+    expect(kms.calls).toHaveLength(1)
+  })
+
+  it('handles distillation failure (failed, with reason)', async () => {
+    const meeting = { id: 'm4', title: 'D', transcript: 'x' }
+    const kms = new FakeMcpClient()
+    const result = await processMeeting(meeting, {
+      source: new FakeGranolaSource([]),
+      distiller: new FakeDistiller({}, 'm4'),
+      kms: kms as any,
+      opts: { ...defaultOpts(), dryRun: false },
+      log: { completed: [] }
+    })
+    expect(result.status).toBe('failed')
+    expect(result.reason).toContain('haiku exploded')
+    // No KMS calls — distillation gates the write path
+    expect(kms.calls).toHaveLength(0)
+  })
+
+  it('continues past a single claim failure (counts meeting as ok if summary landed)', async () => {
+    const meeting = { id: 'm5', title: 'E', transcript: 'x' }
+    const kms = new FakeMcpClient([
+      // 1: summary success
+      { success: true, id: 'sum-1', storageDecision: {}, cached: false, performance: {} },
+      // 2: claim 0 success
+      { success: true, id: 'claim-0', storageDecision: {}, cached: false, performance: {} },
+      // 3: claim 1 dedup_refused (non-fatal)
+      { status: 'dedup_required', candidates: [{ id: 'existing' }], message: 'dup' }
+    ])
+    const result = await processMeeting(meeting, {
+      source: new FakeGranolaSource([]),
+      distiller: new FakeDistiller(),
+      kms: kms as any,
+      opts: { ...defaultOpts(), dryRun: false },
+      log: { completed: [] }
+    })
+    expect(result.status).toBe('ok')
+    expect(result.summaryEntryId).toBe('sum-1')
+    expect(result.claimEntryIds).toEqual(['claim-0'])  // only the one that landed
+  })
+
+  it('dry-run path skips KMS calls entirely', async () => {
+    const meeting = { id: 'm6', title: 'F', transcript: 'x' }
+    const kms = new FakeMcpClient()
+    const result = await processMeeting(meeting, {
+      source: new FakeGranolaSource([]),
+      distiller: new FakeDistiller(),
+      kms: kms as any,
+      opts: { ...defaultOpts(), dryRun: true },
+      log: { completed: [] }
+    })
+    expect(result.status).toBe('ok')
+    expect(kms.calls).toHaveLength(0)
+  })
+})
+
+describe('runImport', () => {
+  let tmpDir: string
+  let logPath: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'granola-runimport-test-'))
+    logPath = join(tmpDir, '.kms-granola-sync.json')
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('rolls forward across mixed outcomes (skipped + ok + dedup_refused + failed)', async () => {
+    const meetings = [
+      { id: 'm-skip',   title: 'skip',  transcript: 'x' },
+      { id: 'm-ok',     title: 'ok',    transcript: 'y' },
+      { id: 'm-dedup',  title: 'dedup', transcript: 'z' },
+      { id: 'm-fail',   title: 'fail',  transcript: 'w' }
+    ]
+    const kms = new FakeMcpClient([
+      // m-ok: summary + 2 claims (3 calls)
+      { success: true, id: 'sum-ok', storageDecision: {}, cached: false, performance: {} },
+      { success: true, id: 'claim-0', storageDecision: {}, cached: false, performance: {} },
+      { success: true, id: 'claim-1', storageDecision: {}, cached: false, performance: {} },
+      // m-dedup: summary returns dedup_required (1 call, no claim writes)
+      { status: 'dedup_required', candidates: [{ id: 'existing' }], message: 'dup' }
+      // m-fail: distiller throws — no KMS calls
+    ])
+
+    const opts = { ...defaultOpts(), syncLogPath: logPath, dryRun: false }
+    const log = { completed: ['m-skip'] }
+
+    const report = await runImport({
+      source: new FakeGranolaSource(meetings),
+      distiller: new FakeDistiller({}, 'm-fail'),
+      kms: kms as any,
+      opts,
+      log
+    })
+
+    expect(report.totalMeetings).toBe(4)
+    expect(report.summaries).toBe(1)         // only m-ok
+    expect(report.claims).toBe(2)            // 2 claims for m-ok
+    expect(report.skipped).toEqual([{ id: 'm-skip', title: 'skip' }])
+    expect(report.dedupRefused).toHaveLength(1)
+    expect(report.dedupRefused[0].id).toBe('m-dedup')
+    expect(report.failed).toHaveLength(1)
+    expect(report.failed[0].id).toBe('m-fail')
+
+    // Sync log was persisted with the new ok'd id
+    const savedLog = JSON.parse(readFileSync(logPath, 'utf-8'))
+    expect(savedLog.completed).toContain('m-skip')
+    expect(savedLog.completed).toContain('m-ok')
+    // failed and dedup-refused must NOT be added (so they retry on next run)
+    expect(savedLog.completed).not.toContain('m-fail')
+    expect(savedLog.completed).not.toContain('m-dedup')
+  })
+
+  it('respects --max-meetings cap', async () => {
+    const meetings = Array.from({ length: 10 }, (_, i) => ({
+      id: `m_${i}`, title: `M${i}`, transcript: 't'
+    }))
+    const kms = new FakeMcpClient()
+    const opts = { ...defaultOpts(), syncLogPath: logPath, maxMeetings: 3, dryRun: false }
+    const log = { completed: [] }
+    const report = await runImport({
+      source: new FakeGranolaSource(meetings),
+      distiller: new FakeDistiller(),
+      kms: kms as any,
+      opts,
+      log
+    })
+    expect(report.totalMeetings).toBe(3)
+    expect(report.summaries).toBe(3)
+    expect(report.claims).toBe(6) // 2 claims per meeting
+  })
+
+  it('survives a Granola-source data error per-meeting via processMeeting boundary', async () => {
+    // The FileGranolaSource throws at .list() time on bad files (validated above).
+    // For per-meeting failures inside the loop, the failure mode is "distiller
+    // exploded for this transcript" — already covered by m-fail in the
+    // mixed-outcomes test. This test pins down the contract: a thrown
+    // distiller does not blow up sibling meetings.
+    const meetings = [
+      { id: 'a', title: 'A', transcript: 'x' },
+      { id: 'b', title: 'B', transcript: 'y' },
+      { id: 'c', title: 'C', transcript: 'z' }
+    ]
+    const kms = new FakeMcpClient()
+    const report = await runImport({
+      source: new FakeGranolaSource(meetings),
+      distiller: new FakeDistiller({}, 'b'),  // only "b" fails
+      kms: kms as any,
+      opts: { ...defaultOpts(), syncLogPath: logPath, dryRun: false },
+      log: { completed: [] }
+    })
+    expect(report.summaries).toBe(2)         // a + c
+    expect(report.failed).toHaveLength(1)
+    expect(report.failed[0].id).toBe('b')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// MinimalMcpClient — only the things that don't need a live server
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('MinimalMcpClient', () => {
+  it('throws if callTool is invoked before initialize', async () => {
+    const c = new MinimalMcpClient('http://localhost:1', null)
+    await expect(c.callTool('any', {})).rejects.toThrow(/not initialized/)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────
+
+function defaultOpts(): any {
+  return {
+    timeRange: 'last_30_days',
+    kmsUrl: 'http://localhost:8180/mcp',
+    syncLogPath: '/tmp/test-sync.json',
+    userId: 'test-user',
+    anthropicModel: 'claude-haiku-4-5',
+    dryRun: true
+  }
+}

--- a/src/__tests__/import-granola.test.ts
+++ b/src/__tests__/import-granola.test.ts
@@ -440,6 +440,13 @@ describe('processMeeting', () => {
     expect(claim0.args.metadata.subject).toBe('Granola.B.claim_0')
     expect(claim0.args.contentType).toBe('insight')   // decision → insight
     expect(claim1.args.contentType).toBe('memory')    // context → memory
+    // First-class relationships link should also be present (DERIVED_FROM summary)
+    expect(claim0.args.relationships).toEqual([
+      { targetId: 'kms-id-1', type: 'DERIVED_FROM', strength: 1.0 }
+    ])
+    expect(claim1.args.relationships).toEqual([
+      { targetId: 'kms-id-1', type: 'DERIVED_FROM', strength: 1.0 }
+    ])
   })
 
   it('handles dedup_required on summary write — counts as dedup_refused, not failed', async () => {

--- a/src/scripts/granola-distill-prompt.ts
+++ b/src/scripts/granola-distill-prompt.ts
@@ -1,0 +1,220 @@
+/**
+ * Granola → KMS distillation prompt and types.
+ *
+ * The Haiku 4.5 (claude-haiku-4-5) call must return a JSON object matching
+ * `DistilledMeeting`. The prompt enforces:
+ *   - One ~200-word `summary` (the whole-meeting entry's content)
+ *   - 2–5 `claims`, each a self-contained typed thought (OB1 6-type taxonomy)
+ *   - The OB1 "curate, don't dump" principle: each claim must stand alone
+ *     without the original transcript context.
+ *
+ * Kept as a separate module so it can be unit-tested without a network call,
+ * and so the prompt text can be reviewed/diffed independently of the importer
+ * driver.
+ */
+
+/**
+ * OB1 6-type taxonomy. The mapping to KMSmcp's contentType enum
+ * (memory|insight|fact|procedure|pattern|relationship) lives in
+ * `mapClaimTypeToContentType` below.
+ */
+export type Ob1ClaimType =
+  | 'decision'
+  | 'preference'
+  | 'learning'
+  | 'context'
+  | 'brainstorm'
+  | 'reference'
+
+/** Distillation confidence — separate from the numeric KMS confidence field. */
+export type DistilledConfidence = 'firm' | 'tentative' | 'exploring'
+
+export interface DistilledClaim {
+  /** OB1 type. Maps to KMSmcp contentType; see `mapClaimTypeToContentType`. */
+  type: Ob1ClaimType
+  /** Self-contained, ~1–3 sentence statement. Must make sense in isolation. */
+  content: string
+  /** firm | tentative | exploring. */
+  confidence: DistilledConfidence
+  /** Free-form topic tags (e.g. ["KMSmcp", "dedup-gate"]). */
+  topics: string[]
+  /** Names of people referenced (e.g. ["Rich", "Kathy"]). Empty if none. */
+  people: string[]
+}
+
+export interface DistilledMeeting {
+  /** ~200-word whole-meeting summary used as the Granola.<title> entry body. */
+  summary: string
+  /** 2–5 self-contained typed thoughts. */
+  claims: DistilledClaim[]
+}
+
+/**
+ * Map OB1 claim types to KMSmcp contentTypes.
+ *
+ * decision / brainstorm → 'insight' (creative/decisional thinking)
+ * preference            → 'memory'  (Mem0-shaped personal pattern)
+ * learning              → 'fact'    (verified knowledge)
+ * context               → 'memory'  (situational/episodic)
+ * reference             → 'procedure' (pointers to external how-to)
+ *
+ * If the OB1 type is unrecognized (forward-compatibility), default to 'memory'.
+ */
+export function mapClaimTypeToContentType(
+  ob1Type: Ob1ClaimType | string
+): 'memory' | 'insight' | 'fact' | 'procedure' | 'pattern' | 'relationship' {
+  switch (ob1Type) {
+    case 'decision':
+    case 'brainstorm':
+      return 'insight'
+    case 'preference':
+    case 'context':
+      return 'memory'
+    case 'learning':
+      return 'fact'
+    case 'reference':
+      return 'procedure'
+    default:
+      return 'memory'
+  }
+}
+
+/**
+ * Build the distillation system + user prompt pair.
+ *
+ * The system prompt locks the schema and the curate-don't-dump rule. The user
+ * prompt is just the meeting metadata + transcript.
+ */
+export function buildDistillPrompt(meeting: {
+  title: string
+  meetingId: string
+  date?: string
+  transcript: string
+}): { system: string; user: string } {
+  const system = `You distill meeting transcripts into structured JSON for a personal knowledge management system.
+
+Return ONLY a JSON object matching this shape (no prose, no code fences):
+
+{
+  "summary": string,        // ~200 words. Whole-meeting summary. NOT the raw transcript. Include who, what, why.
+  "claims": [
+    {
+      "type": "decision" | "preference" | "learning" | "context" | "brainstorm" | "reference",
+      "content": string,    // 1-3 self-contained sentences.
+      "confidence": "firm" | "tentative" | "exploring",
+      "topics": string[],   // short topic tags
+      "people": string[]    // people mentioned by name
+    }
+  ]
+}
+
+Rules:
+1. Produce 2 to 5 claims. Fewer is fine if the meeting was thin; never produce more than 5.
+2. Each claim must be a self-contained statement that makes sense without the original transcript context.
+3. Curate, don't dump. Skip pleasantries, scheduling chatter, and content that won't matter in 6 months.
+4. Use "decision" for committed choices, "preference" for stated likes/dislikes/ways-of-working, "learning" for new factual knowledge, "context" for situational background that informs future decisions, "brainstorm" for ideas not yet committed, "reference" for pointers to external resources/how-to.
+5. "confidence" reflects how firm the speaker(s) sounded: "firm" = decided/known, "tentative" = leaning toward, "exploring" = still mulling.
+6. Output MUST be valid JSON. No markdown. No commentary. No trailing text.`
+
+  const dateLine = meeting.date ? `\nDate: ${meeting.date}` : ''
+  const user = `Meeting title: ${meeting.title}
+Meeting ID: ${meeting.meetingId}${dateLine}
+
+Transcript:
+${meeting.transcript}`
+
+  return { system, user }
+}
+
+/**
+ * Parse and validate a Haiku response. Throws on malformed JSON or schema
+ * violations (so the importer driver can log + skip the meeting cleanly).
+ *
+ * Strips common LLM artifacts: ```json fences, leading/trailing prose, BOM.
+ */
+export function parseDistilledResponse(raw: string): DistilledMeeting {
+  if (typeof raw !== 'string' || raw.trim().length === 0) {
+    throw new Error('Empty distillation response')
+  }
+
+  // Strip BOM
+  let text = raw.replace(/^﻿/, '').trim()
+
+  // Strip ```json ... ``` fences if Haiku wrapped them despite instructions
+  const fenceMatch = text.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i)
+  if (fenceMatch) {
+    text = fenceMatch[1].trim()
+  }
+
+  // If there's leading prose, try to find the first { and last }
+  if (!text.startsWith('{')) {
+    const first = text.indexOf('{')
+    const last = text.lastIndexOf('}')
+    if (first >= 0 && last > first) {
+      text = text.slice(first, last + 1)
+    }
+  }
+
+  let parsed: any
+  try {
+    parsed = JSON.parse(text)
+  } catch (e) {
+    throw new Error(
+      `Distillation response is not valid JSON: ${e instanceof Error ? e.message : String(e)}`
+    )
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('Distillation response is not an object')
+  }
+  if (typeof parsed.summary !== 'string' || parsed.summary.trim().length === 0) {
+    throw new Error('Distillation response missing string `summary`')
+  }
+  if (!Array.isArray(parsed.claims)) {
+    throw new Error('Distillation response missing `claims` array')
+  }
+  if (parsed.claims.length === 0) {
+    throw new Error('Distillation response has zero claims (need 2–5)')
+  }
+  if (parsed.claims.length > 5) {
+    // Soft-cap: keep first 5 rather than fail the whole meeting.
+    parsed.claims = parsed.claims.slice(0, 5)
+  }
+
+  const validTypes: Ob1ClaimType[] = [
+    'decision',
+    'preference',
+    'learning',
+    'context',
+    'brainstorm',
+    'reference'
+  ]
+  const validConfidence: DistilledConfidence[] = ['firm', 'tentative', 'exploring']
+
+  const claims: DistilledClaim[] = parsed.claims.map((c: any, i: number) => {
+    if (!c || typeof c !== 'object') {
+      throw new Error(`Claim ${i} is not an object`)
+    }
+    if (!validTypes.includes(c.type)) {
+      throw new Error(`Claim ${i} has invalid type: ${c.type}`)
+    }
+    if (typeof c.content !== 'string' || c.content.trim().length === 0) {
+      throw new Error(`Claim ${i} has empty content`)
+    }
+    if (!validConfidence.includes(c.confidence)) {
+      throw new Error(`Claim ${i} has invalid confidence: ${c.confidence}`)
+    }
+    return {
+      type: c.type,
+      content: c.content.trim(),
+      confidence: c.confidence,
+      topics: Array.isArray(c.topics) ? c.topics.filter((t: any) => typeof t === 'string') : [],
+      people: Array.isArray(c.people) ? c.people.filter((p: any) => typeof p === 'string') : []
+    }
+  })
+
+  return {
+    summary: parsed.summary.trim(),
+    claims
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `scripts/import-granola.ts`: turns Granola meetings into KMS entries via the **dual-write pattern** (one whole-meeting summary + 2–5 OB1-typed key-claim entries per meeting), all routed through `unified_store` so the dedup gate catches duplicate meetings naturally.
- Distillation prompt + JSON parser extracted to `src/scripts/granola-distill-prompt.ts` (testable in isolation; locks OB1 6-type taxonomy + curate-don't-dump rule).
- Adds `@anthropic-ai/sdk@^0.40.1` (matches mem0ai's peer dep) for Haiku 4.5 distillation.
- 40 new tests, all 119 tests in the suite still pass.

## Dual-write contract (per meeting)

**Summary entry**: `contentType=memory`, `source=personal`, `metadata={subject:"Granola.<title>", source:"granola", granola_meeting_id, meeting_date, source_doc:"granola://<id>"}`

**Claim entries** (2–5 per meeting): `contentType` mapped from OB1 type (`decision|brainstorm` → `insight`, `preference|context` → `memory`, `learning` → `fact`, `reference` → `procedure`), each with `metadata.related_to=[summary_id]` and shared `source_doc`.

## Architecture

- **Pluggable `GranolaSource`** — `FileGranolaSource` (read meetings from a pre-dumped JSON file) is the v1 input mode. Direct claude.ai Granola MCP can plug in later via the same seam.
- **`MinimalMcpClient`** does the StreamableHTTP initialize → tools/call dance against the live KMS at `http://localhost:8180/mcp`.
- **Auth**: `KMS_BEARER_TOKEN` env (preferred for one-off runs) OR Auth0 client_credentials via `OAUTH_*` env vars when running under doppler.
- **Resumable**: `~/.kms-granola-sync.json` saved after every successful meeting; failed/dedup-refused meetings retry on next run.
- **Dedup gate**: when `unified_store` returns `status='dedup_required'`, the meeting is logged as `dedup_refused` (counted distinct from `failed`) and the run rolls forward — exactly what we want for re-runs against an already-imported corpus.

## Operator usage

```bash
# 1. Have your Claude Code session dump meetings from Granola MCP to a JSON file:
#    [{ "id": "...", "title": "...", "date": "...", "transcript": "..." }, ...]

# 2. Run the importer (with bearer token):
KMS_BEARER_TOKEN=... ANTHROPIC_API_KEY=... \
  npm run import:granola -- --input ~/granola-dump.json

# Or with doppler-managed OAuth client_credentials:
doppler run --project ry-local --config dev_personal -- \
  ANTHROPIC_API_KEY=... npm run import:granola -- --input ~/granola-dump.json

# Smoke test (no network):
npm run import:granola:dry-run -- --input ~/granola-dump.json
```

## Ambiguities resolved

- **Granola MCP access**: The Granola MCP at claude.ai is a session-bound remote MCP, not directly callable from a CLI. Resolved by introducing the `GranolaSource` abstraction and shipping `FileGranolaSource` as v1: a Claude Code session uses Granola MCP to dump meetings to JSON, then the script consumes the JSON. Direct MCP fetch is a future plug-in.
- **OAuth in CLI**: Live KMS has `OAUTH_ENABLED=true`. Supports both `KMS_BEARER_TOKEN` env (one-off runs) and Auth0 `client_credentials` flow (unattended runs under doppler). The `--internal-direct` mode mentioned in the spec wasn't needed — HTTP path works fine.
- **OB1 → KMSmcp contentType mapping**: Made explicit in `mapClaimTypeToContentType`. `decision`/`brainstorm` → `insight`, `preference`/`context` → `memory`, `learning` → `fact`, `reference` → `procedure`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] `npx jest` — all 119 tests pass (40 new)
- [x] `--help` and `--dry-run` smoke tests pass
- [x] Resumability verified (sync log skip)
- [ ] End-to-end against live KMS at port 8180 (requires bearer token or doppler env — operator validation)
- [ ] End-to-end against real Anthropic API with Haiku 4.5 (requires `ANTHROPIC_API_KEY` — operator validation)
- [ ] Verify dedup gate refuses on re-import of the same corpus (requires real upstream sparrowdb fix — see CLAUDE.md "Known limitation" about parameter-binding for f32 vector inserts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)