### PR TITLE
feat: Slack huddle → KMS importer (dual-write + dedup-gate routing)

### DIFF
--- a/dist/storage/Mem0Storage.js
+++ b/dist/storage/Mem0Storage.js
@@ -1,16 +1,25 @@
 /**
  * Mem0 Storage System Implementation
  *
- * Targets mem0ai SDK v3.x. Key v1 → v3 deltas applied:
- *  - `add`: `user_id` (snake) → `userId` (camel) at top level. Wire still snake — SDK converts.
- *  - `search` / `getAll`: top-level entity params (`user_id`, `userId`, etc.) are REJECTED.
- *    Must pass `filters: { user_id: '...' }` instead. SDK throws if you don't.
- *  - `search`: `limit` → `topK`, `api_version` removed (SDK now hits /v3/memories/search/ unconditionally),
- *    return shape is `{ results: Memory[] }` (wrapped) — was `Memory[]` (unwrapped).
- *  - `get(memoryId)` only takes a string. The 1.x `get({ user_id, limit })` overload
- *    moved to `getAll(options)` returning `PaginatedMemories { count, next, previous, results }`.
- *  - Response keys are converted snake → camel by the SDK (`createdAt`, `updatedAt`, `userId`).
- *  - `enable_graph` is no longer a recognized option (none in this codebase, but flagged).
+ * Targets mem0ai SDK v3.x (verified against 3.0.2). v1 → v3 contract deltas:
+ *  - `add(messages, options)`: top-level `userId` or `user_id` BOTH allowed
+ *    (SDK runs camelToSnakeKeys on the merged payload). No rejectTopLevelEntityParams.
+ *  - `search(query, options)`: REJECTS top-level entity params via
+ *    rejectTopLevelEntityParams() as the very first line. {user_id, agent_id,
+ *    app_id, run_id} MUST be passed inside `filters: { ... }`. Throws otherwise.
+ *  - `getAll(options)`: same rejection as search. `filters: { user_id }` required.
+ *    Returns PaginatedMemories `{ count, next, previous, results }` (was bare array).
+ *  - `search`: `limit` → `topK`, `api_version` removed (always /v3/memories/search/).
+ *    Return shape `{ results: Memory[] }`.
+ *  - `get(memoryId)` only takes a string. The 1.x `get({ user_id, limit })`
+ *    overload moved to `getAll(options)`.
+ *  - Response keys converted snake → camel by SDK (`createdAt`, `updatedAt`, `userId`).
+ *  - `enable_graph` no longer a recognized option (none in this codebase).
+ *
+ * Verification anchors:
+ *  - `node_modules/mem0ai/dist/index.mjs` — rejectTopLevelEntityParams as first line of search/getAll
+ *  - `mem0` CLI (npm i -g @mem0/cli) — translates --user-id to filters.user_id
+ *  - Live `kms_ping` previously threw on getStats top-level user_id (caught + fixed 2026-05-07)
  */
 export class Mem0Storage {
     config;
@@ -89,14 +98,18 @@ export class Mem0Storage {
             const userId = this.generateUserIdFromQuery(query);
             console.log(`🧠 [Mem0Storage.search] Using user ID: ${userId}`);
             const searchQuery = query.query;
-            // Mem0 v1 endpoint expects user_id at TOP LEVEL of payload, not nested under filters.
-            // (Earlier comment claimed v3 SDK rejected top-level entity params — that was wrong;
-            // the SDK has no such throw, and v1 search rejects the request unless one of
-            // {user_id, agent_id, app_id, run_id} is present at body root.)
+            // Mem0 v3 SDK: search() throws via rejectTopLevelEntityParams() if any of
+            // {user_id, agent_id, app_id, run_id} appear at TOP LEVEL of options.
+            // Entity-scope MUST go inside `filters`. Verified 2026-05-07 against
+            // mem0ai@3.0.2 SDK source (rejectTopLevelEntityParams runs as the FIRST
+            // line of search()) and against the live `mem0` CLI (which translates
+            // --user-id to filters.user_id internally and works correctly).
+            // Previous implementation passed user_id at top level → SDK threw →
+            // outer try/catch swallowed → returned [] → Mem0 dimension of dedup
+            // gate has been silently dark since the 1.x→3.x cutover.
             const searchOptions = {
-                user_id: userId,
                 topK: query.options?.maxResults || 10,
-                filters: this.buildMem0Filters(query.filters)
+                filters: { user_id: userId, ...this.buildMem0Filters(query.filters) }
             };
             console.log(`🧠 [Mem0Storage.search] Search query: "${searchQuery}"`);
             console.log(`🧠 [Mem0Storage.search] Search options:`, JSON.stringify(searchOptions, null, 2));
@@ -123,13 +136,14 @@ export class Mem0Storage {
     }
     async getStats() {
         try {
-            // v3 SDK: use getAll() with filters.user_id and pageSize=1 to get the count.
-            // Avoids the brittle raw fetch to /v1/memories/ that was used in the 1.x days.
+            // v3 SDK: use getAll() with filters.user_id and page_size=1 to get the count.
+            // user_id MUST be inside filters — getAll() throws via rejectTopLevelEntityParams
+            // if it appears at top level (verified against mem0ai@3.0.2 source).
             const userId = this.config.defaultUserId || 'personal';
             const page = await this.client.getAll({
                 page: 1,
                 page_size: 1,
-                user_id: userId
+                filters: { user_id: userId }
             });
             // Paginated response: { count, next, previous, results }. Bare array fallback for non-paginated.
             const totalMemories = (Array.isArray(page) ? page.length : page?.count) ?? 'unknown';
@@ -154,7 +168,7 @@ export class Mem0Storage {
             const page = await this.client.getAll({
                 page: 1,
                 page_size: limit,
-                user_id: userId
+                filters: { user_id: userId }
             });
             // getAll runtime shape varies (bare array vs { results: [...], count }).
             const memList = Array.isArray(page) ? page : (page?.results ?? []);
@@ -258,10 +272,10 @@ export class Mem0Storage {
         try {
             console.log(`🧪 [Mem0Storage.testDirectSearch] Testing direct search for: "${query}" with user: ${userId}`);
             const searchQuery = query;
-            // Mem0 v1 search expects user_id at top level of payload (see Mem0Storage.search above).
+            // v3 SDK contract: user_id inside filters (see Mem0Storage.search above).
             const searchOptions = {
-                user_id: userId,
-                topK: 10
+                topK: 10,
+                filters: { user_id: userId }
             };
             console.log(`🧪 [Mem0Storage.testDirectSearch] Search query: "${searchQuery}"`);
             console.log(`🧪 [Mem0Storage.testDirectSearch] Search options:`, JSON.stringify(searchOptions, null, 2));

--- a/src/__tests__/import-slack-huddles.test.ts
+++ b/src/__tests__/import-slack-huddles.test.ts
@@ -1,0 +1,1141 @@
+/**
+ * Tests for the Slack Huddle → KMS importer.
+ *
+ * Coverage:
+ *   - Distillation prompt produces valid JSON / parseDistilledResponse strict
+ *   - Canvas-id regex extraction (the verified Slackbot-recap format)
+ *   - Slackbot filter (only USLACKBOT messages with the recap phrase qualify)
+ *   - Sync-log resumability (skips canvases already in log)
+ *   - Dedup-required response from KMS handled (skip + log, don't fail run)
+ *   - Failed-canvas-fetch graceful degradation (LiveSlackSource skips, doesn't throw)
+ *   - Distillation JSON validation (malformed Haiku output rejected per-huddle)
+ *   - File-source: both pre-resolved-array and messages+canvases shapes
+ *   - Subject + source-doc helpers
+ *   - CLI parseArgs sanity
+ *
+ * No live KMS, no live Anthropic API, no live Slack. Everything is mocked at the seam.
+ */
+
+import {
+  buildDistillPrompt,
+  extractCanvasId,
+  isSlackbotHuddleRecap,
+  mapClaimTypeToContentType,
+  parseDistilledResponse
+} from '../scripts/slack-huddle-distill-prompt.js'
+
+import {
+  buildHuddleSubject,
+  buildSourceDoc,
+  DEFAULT_SEARCH_QUERY,
+  DistillerLike,
+  FileSlackSource,
+  LiveSlackSource,
+  loadSyncLog,
+  MinimalMcpClient,
+  parseArgs,
+  processHuddle,
+  RawHuddle,
+  runImport,
+  SlackHuddleSource,
+  slugifyChannel
+} from '../scripts/import-slack-huddles.js'
+
+import type { DistilledHuddle } from '../scripts/slack-huddle-distill-prompt.js'
+
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+// ─────────────────────────────────────────────────────────────────────────
+// extractCanvasId
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('extractCanvasId', () => {
+  it('extracts team_id and file_id from the verified Slackbot recap format', () => {
+    // The exact format observed on 2026-04-11 in #core-values
+    const text =
+      'AI huddle notes are ready. Edit, share, assign action items, ... :chipmunk: ' +
+      '<https://projcaribou.slack.com/docs/T0123ABCD/F4567WXYZ|View AI Notes>'
+    const ids = extractCanvasId(text)
+    expect(ids).toEqual({ teamId: 'T0123ABCD', fileId: 'F4567WXYZ' })
+  })
+
+  it('handles the bare URL form (no mrkdwn wrapper)', () => {
+    const text = 'AI huddle notes are ready: https://tengo.slack.com/docs/TX1/FY2'
+    expect(extractCanvasId(text)).toEqual({ teamId: 'TX1', fileId: 'FY2' })
+  })
+
+  it('returns null when no docs URL is present', () => {
+    expect(extractCanvasId('AI huddle notes are ready. (no link)')).toBeNull()
+    expect(extractCanvasId('completely unrelated text')).toBeNull()
+  })
+
+  it('returns null on empty / non-string', () => {
+    expect(extractCanvasId('')).toBeNull()
+    expect(extractCanvasId(null as any)).toBeNull()
+    expect(extractCanvasId(undefined as any)).toBeNull()
+  })
+
+  it('does not match files-app URLs (different path shape)', () => {
+    // /files/ paths look similar but are not canvas docs
+    expect(
+      extractCanvasId('https://workspace.slack.com/files/UABC/F123/foo.pdf')
+    ).toBeNull()
+  })
+
+  it('captures the FIRST docs match when multiple exist', () => {
+    const text =
+      'see https://workspace.slack.com/docs/T1/F1 and https://workspace.slack.com/docs/T2/F2'
+    expect(extractCanvasId(text)).toEqual({ teamId: 'T1', fileId: 'F1' })
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// isSlackbotHuddleRecap
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('isSlackbotHuddleRecap', () => {
+  it('matches messages with USLACKBOT user and the canonical phrase', () => {
+    expect(
+      isSlackbotHuddleRecap({
+        user: 'USLACKBOT',
+        text: 'AI huddle notes are ready. Edit, share, ...'
+      })
+    ).toBe(true)
+  })
+
+  it('matches messages with username "Slackbot" (alternative shape)', () => {
+    expect(
+      isSlackbotHuddleRecap({
+        username: 'Slackbot',
+        text: 'AI huddle notes are ready: see canvas'
+      })
+    ).toBe(true)
+  })
+
+  it('rejects messages from other users even with the recap phrase', () => {
+    expect(
+      isSlackbotHuddleRecap({
+        user: 'U999HUMAN',
+        text: 'AI huddle notes are ready'
+      })
+    ).toBe(false)
+  })
+
+  it('rejects Slackbot messages without the recap phrase', () => {
+    expect(
+      isSlackbotHuddleRecap({
+        user: 'USLACKBOT',
+        text: 'Some other Slackbot announcement'
+      })
+    ).toBe(false)
+  })
+
+  it('is case-insensitive on the recap phrase', () => {
+    expect(
+      isSlackbotHuddleRecap({
+        user: 'uslackbot',
+        text: 'AI Huddle Notes Are Ready... see attached'
+      })
+    ).toBe(true)
+  })
+
+  it('returns false on missing/invalid input', () => {
+    expect(isSlackbotHuddleRecap(null as any)).toBe(false)
+    expect(isSlackbotHuddleRecap({} as any)).toBe(false)
+    expect(isSlackbotHuddleRecap({ text: 'foo' } as any)).toBe(false)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// Distillation prompt
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('slack-huddle-distill-prompt', () => {
+  describe('buildDistillPrompt', () => {
+    it('locks the OB1 6-type taxonomy in the system prompt', () => {
+      const { system } = buildDistillPrompt({
+        channelName: 'core-values',
+        canvasMarkdown: 'Notes here'
+      })
+      for (const t of [
+        'decision',
+        'preference',
+        'learning',
+        'context',
+        'brainstorm',
+        'reference'
+      ]) {
+        expect(system).toContain(t)
+      }
+    })
+
+    it('locks qualitative_confidence values in the system prompt', () => {
+      const { system } = buildDistillPrompt({
+        channelName: 'x',
+        canvasMarkdown: 'y'
+      })
+      expect(system).toContain('qualitative_confidence')
+      for (const c of ['firm', 'tentative', 'exploring']) expect(system).toContain(c)
+    })
+
+    it('caps claims at 5 in instructions', () => {
+      const { system } = buildDistillPrompt({
+        channelName: 'x',
+        canvasMarkdown: 'y'
+      })
+      expect(system).toMatch(/2 to 5 claims|2-5 claims|2–5 claims/)
+    })
+
+    it('passes channel + workspace + date into the user prompt', () => {
+      const { user } = buildDistillPrompt({
+        channelName: 'core-values',
+        huddleDate: '2026-04-20T16:00:00Z',
+        canvasMarkdown: 'transcript-ish content',
+        workspace: 'tengo'
+      })
+      expect(user).toContain('core-values')
+      expect(user).toContain('tengo')
+      expect(user).toContain('2026-04-20')
+      expect(user).toContain('transcript-ish content')
+    })
+  })
+
+  describe('parseDistilledResponse', () => {
+    const valid = JSON.stringify({
+      summary: 'A short summary of the huddle.',
+      claims: [
+        {
+          type: 'decision',
+          content: 'We decided to ship feature X next week.',
+          qualitative_confidence: 'firm',
+          topics: ['shipping'],
+          people: ['Rich']
+        },
+        {
+          type: 'context',
+          content: 'Q3 traffic up 30% so capacity matters.',
+          qualitative_confidence: 'tentative',
+          topics: ['capacity'],
+          people: []
+        }
+      ]
+    })
+
+    it('parses a well-formed response', () => {
+      const out = parseDistilledResponse(valid)
+      expect(out.summary).toContain('short summary')
+      expect(out.claims).toHaveLength(2)
+      expect(out.claims[0].type).toBe('decision')
+      expect(out.claims[0].qualitative_confidence).toBe('firm')
+    })
+
+    it('strips ```json fences', () => {
+      const out = parseDistilledResponse('```json\n' + valid + '\n```')
+      expect(out.claims).toHaveLength(2)
+    })
+
+    it('strips bare ``` fences', () => {
+      const out = parseDistilledResponse('```\n' + valid + '\n```')
+      expect(out.claims).toHaveLength(2)
+    })
+
+    it('extracts JSON when leading/trailing prose is present', () => {
+      const messy = 'Here is the JSON output:\n' + valid + '\nThanks!'
+      const out = parseDistilledResponse(messy)
+      expect(out.summary).toContain('short summary')
+    })
+
+    it('throws on empty input', () => {
+      expect(() => parseDistilledResponse('')).toThrow(/Empty/)
+      expect(() => parseDistilledResponse('   ')).toThrow(/Empty/)
+    })
+
+    it('throws on invalid JSON', () => {
+      expect(() => parseDistilledResponse('{ not valid')).toThrow(/not valid JSON/)
+    })
+
+    it('throws on missing summary', () => {
+      const bad = JSON.stringify({
+        claims: [
+          {
+            type: 'decision',
+            content: 'x',
+            qualitative_confidence: 'firm',
+            topics: [],
+            people: []
+          }
+        ]
+      })
+      expect(() => parseDistilledResponse(bad)).toThrow(/summary/)
+    })
+
+    it('throws on zero claims', () => {
+      const bad = JSON.stringify({ summary: 'foo', claims: [] })
+      expect(() => parseDistilledResponse(bad)).toThrow(/zero claims/)
+    })
+
+    it('soft-caps to 5 claims when more are returned', () => {
+      const seven = Array.from({ length: 7 }, (_, i) => ({
+        type: 'context',
+        content: `c${i}`,
+        qualitative_confidence: 'firm',
+        topics: [],
+        people: []
+      }))
+      const out = parseDistilledResponse(
+        JSON.stringify({ summary: 'x', claims: seven })
+      )
+      expect(out.claims).toHaveLength(5)
+    })
+
+    it('rejects invalid claim types', () => {
+      const bad = JSON.stringify({
+        summary: 'x',
+        claims: [
+          {
+            type: 'yolo',
+            content: 'x',
+            qualitative_confidence: 'firm',
+            topics: [],
+            people: []
+          }
+        ]
+      })
+      expect(() => parseDistilledResponse(bad)).toThrow(/invalid type/)
+    })
+
+    it('rejects invalid qualitative_confidence values', () => {
+      const bad = JSON.stringify({
+        summary: 'x',
+        claims: [
+          {
+            type: 'decision',
+            content: 'x',
+            qualitative_confidence: 'maybe',
+            topics: [],
+            people: []
+          }
+        ]
+      })
+      expect(() => parseDistilledResponse(bad)).toThrow(/invalid qualitative_confidence/)
+    })
+
+    it('coerces missing/invalid topics + people to clean arrays', () => {
+      const data = JSON.stringify({
+        summary: 'x',
+        claims: [
+          {
+            type: 'decision',
+            content: 'y',
+            qualitative_confidence: 'firm',
+            topics: ['a', 1, 'b'],
+            people: 'not-an-array'
+          }
+        ]
+      })
+      const out = parseDistilledResponse(data)
+      expect(out.claims[0].topics).toEqual(['a', 'b'])
+      expect(out.claims[0].people).toEqual([])
+    })
+  })
+
+  describe('mapClaimTypeToContentType', () => {
+    it('maps all six OB1 types', () => {
+      expect(mapClaimTypeToContentType('decision')).toBe('insight')
+      expect(mapClaimTypeToContentType('brainstorm')).toBe('insight')
+      expect(mapClaimTypeToContentType('learning')).toBe('insight')
+      expect(mapClaimTypeToContentType('preference')).toBe('memory')
+      expect(mapClaimTypeToContentType('context')).toBe('memory')
+      expect(mapClaimTypeToContentType('reference')).toBe('procedure')
+    })
+
+    it('falls back to memory on unknown types', () => {
+      expect(mapClaimTypeToContentType('unknown-future-type')).toBe('memory')
+    })
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// CLI parsing
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('parseArgs', () => {
+  it('applies sensible defaults', () => {
+    const opts = parseArgs([])
+    expect(opts.source).toBe('file')
+    expect(opts.searchQuery).toBe(DEFAULT_SEARCH_QUERY)
+    expect(opts.searchLimit).toBe(20)
+    expect(opts.kmsUrl).toMatch(/^http/)
+    expect(opts.dryRun).toBe(false)
+    expect(opts.workspace).toBeTruthy()
+  })
+
+  it('parses --input and --dry-run', () => {
+    const opts = parseArgs(['--input', '/tmp/foo.json', '--dry-run'])
+    expect(opts.input).toBe('/tmp/foo.json')
+    expect(opts.dryRun).toBe(true)
+  })
+
+  it('parses --source live', () => {
+    const opts = parseArgs(['--source', 'live'])
+    expect(opts.source).toBe('live')
+  })
+
+  it('rejects --source bogus', () => {
+    expect(() => parseArgs(['--source', 'bogus'])).toThrow(/Invalid --source/)
+  })
+
+  it('parses --max-huddles, --workspace, --bearer-token', () => {
+    const opts = parseArgs([
+      '--max-huddles',
+      '7',
+      '--workspace',
+      'mymoneycoach',
+      '--bearer-token',
+      'tok-abc'
+    ])
+    expect(opts.maxHuddles).toBe(7)
+    expect(opts.workspace).toBe('mymoneycoach')
+    expect(opts.bearerToken).toBe('tok-abc')
+  })
+
+  it('rejects unknown flags', () => {
+    expect(() => parseArgs(['--unknown-flag'])).toThrow(/Unknown flag/)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// Subject + source-doc helpers
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('subject + source-doc helpers', () => {
+  it('slugifies channel names', () => {
+    expect(slugifyChannel('Core Values')).toBe('core-values')
+    expect(slugifyChannel('core-values')).toBe('core-values')
+    expect(slugifyChannel('OPS_Daily Sync!')).toBe('ops_daily-sync')
+    expect(slugifyChannel('')).toBe('unknown')
+  })
+
+  it('builds the canonical subject', () => {
+    const huddle: RawHuddle = {
+      channelId: 'C1',
+      channelName: 'core-values',
+      messageTs: '1000',
+      teamId: 'T1',
+      fileId: 'F1',
+      huddleDate: '2026-04-11T16:00:00Z',
+      canvasMarkdown: 'x'
+    }
+    expect(buildHuddleSubject(huddle)).toBe('Slack.huddle.core-values.2026-04-11')
+  })
+
+  it('builds the canonical source_doc URI', () => {
+    const huddle: RawHuddle = {
+      channelId: 'C1',
+      channelName: 'x',
+      messageTs: '1',
+      teamId: 'T0123ABCD',
+      fileId: 'F4567WXYZ',
+      canvasMarkdown: 'y'
+    }
+    expect(buildSourceDoc(huddle)).toBe('slack://canvas/T0123ABCD/F4567WXYZ')
+  })
+
+  it('subject falls back to "unknown-date" when huddle date missing', () => {
+    const huddle: RawHuddle = {
+      channelId: 'C1',
+      channelName: 'general',
+      messageTs: 'invalid',
+      teamId: 'T1',
+      fileId: 'F1',
+      canvasMarkdown: 'x'
+    }
+    expect(buildHuddleSubject(huddle)).toBe('Slack.huddle.general.unknown-date')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// Sync log
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('sync log', () => {
+  let tmpDir: string
+  let logPath: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'slack-huddle-import-test-'))
+    logPath = join(tmpDir, '.kms-slack-huddle-sync.json')
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('returns empty log when file does not exist', () => {
+    expect(existsSync(logPath)).toBe(false)
+    expect(loadSyncLog(logPath).completed).toEqual([])
+  })
+
+  it('reads previously-stored canvas IDs', () => {
+    writeFileSync(
+      logPath,
+      JSON.stringify({ completed: ['F1', 'F2'], lastRun: '2026-01-01' })
+    )
+    const log = loadSyncLog(logPath)
+    expect(log.completed).toEqual(['F1', 'F2'])
+  })
+
+  it('returns empty on malformed file (no throw)', () => {
+    writeFileSync(logPath, 'definitely not json')
+    expect(loadSyncLog(logPath).completed).toEqual([])
+  })
+
+  it('returns empty on file with wrong schema', () => {
+    writeFileSync(logPath, JSON.stringify({ wrong: 'shape' }))
+    expect(loadSyncLog(logPath).completed).toEqual([])
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// FileSlackSource — both shapes
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('FileSlackSource', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'slack-source-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('reads the pre-resolved-array shape', async () => {
+    const path = join(tmpDir, 'h.json')
+    writeFileSync(
+      path,
+      JSON.stringify([
+        {
+          channel_id: 'C1',
+          channel_name: 'core-values',
+          message_ts: '1714098000.000400',
+          team_id: 'T0123ABCD',
+          file_id: 'F4567WXYZ',
+          huddle_date: '2026-04-11T16:00:00Z',
+          canvas_markdown: '# Notes\nDecided X.'
+        },
+        {
+          channel_id: 'C2',
+          channel_name: 'general',
+          message_ts: '1714184400.000000',
+          team_id: 'T0123ABCD',
+          file_id: 'FBBB',
+          canvas_markdown: '# Notes 2'
+        }
+      ])
+    )
+    const huddles = await new FileSlackSource(path).list()
+    expect(huddles).toHaveLength(2)
+    expect(huddles[0].fileId).toBe('F4567WXYZ')
+    expect(huddles[0].channelName).toBe('core-values')
+    expect(huddles[0].huddleDate).toBe('2026-04-11T16:00:00Z')
+    expect(huddles[0].canvasMarkdown).toContain('Decided X')
+    // Second huddle has no explicit huddle_date — derived from message_ts
+    expect(huddles[1].huddleDate).toMatch(/^2024-04-/) // ts converted to ISO
+  })
+
+  it('reads the messages+canvases shape and joins on file_id', async () => {
+    const path = join(tmpDir, 'h.json')
+    writeFileSync(
+      path,
+      JSON.stringify({
+        messages: [
+          {
+            user: 'USLACKBOT',
+            ts: '1714098000.000400',
+            text:
+              'AI huddle notes are ready. ' +
+              '<https://projcaribou.slack.com/docs/T0123ABCD/F4567WXYZ|View AI Notes>',
+            channel: { id: 'C1', name: 'core-values' }
+          },
+          // Should be filtered out (not USLACKBOT)
+          {
+            user: 'U_HUMAN',
+            ts: '1714098000.999',
+            text: 'AI huddle notes are ready (impersonator)',
+            channel: { id: 'C1', name: 'core-values' }
+          },
+          // Should be filtered out (no docs link)
+          {
+            user: 'USLACKBOT',
+            ts: '1714098001.000',
+            text: 'AI huddle notes are ready (no link)',
+            channel: { id: 'C1', name: 'core-values' }
+          }
+        ],
+        canvases: {
+          F4567WXYZ: '# Huddle 1\nNotes here.'
+        }
+      })
+    )
+    const huddles = await new FileSlackSource(path).list()
+    expect(huddles).toHaveLength(1)
+    expect(huddles[0].fileId).toBe('F4567WXYZ')
+    expect(huddles[0].teamId).toBe('T0123ABCD')
+    expect(huddles[0].channelName).toBe('core-values')
+    expect(huddles[0].canvasMarkdown).toContain('Huddle 1')
+  })
+
+  it('skips messages whose canvas is missing in the canvases map', async () => {
+    const path = join(tmpDir, 'h.json')
+    writeFileSync(
+      path,
+      JSON.stringify({
+        messages: [
+          {
+            user: 'USLACKBOT',
+            ts: '1714098000',
+            text: 'AI huddle notes are ready: https://x.slack.com/docs/T1/F_MISSING',
+            channel: { id: 'C1', name: 'general' }
+          }
+        ],
+        canvases: {} // empty
+      })
+    )
+    const huddles = await new FileSlackSource(path).list()
+    expect(huddles).toHaveLength(0)
+  })
+
+  it('throws on missing file', async () => {
+    await expect(
+      new FileSlackSource(join(tmpDir, 'nope.json')).list()
+    ).rejects.toThrow(/not found/)
+  })
+
+  it('throws when a pre-resolved huddle is missing required fields', async () => {
+    const path = join(tmpDir, 'h.json')
+    writeFileSync(
+      path,
+      JSON.stringify([{ channel_id: 'C1', channel_name: 'foo' }]) // missing rest
+    )
+    await expect(new FileSlackSource(path).list()).rejects.toThrow(/required/)
+  })
+
+  it('throws on top-level shape that is neither array nor messages-object', async () => {
+    const path = join(tmpDir, 'h.json')
+    writeFileSync(path, JSON.stringify({ not: 'a recognized shape' }))
+    await expect(new FileSlackSource(path).list()).rejects.toThrow(/array|messages/i)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// LiveSlackSource — failed canvas fetch graceful degradation
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('LiveSlackSource', () => {
+  it('returns huddles for matching messages and joins canvas markdown', async () => {
+    const messages = [
+      {
+        user: 'USLACKBOT',
+        ts: '1714098000',
+        text:
+          'AI huddle notes are ready. ' +
+          '<https://projcaribou.slack.com/docs/T0/FGOOD123|View AI Notes>',
+        channel: { id: 'C1', name: 'core-values' }
+      }
+    ]
+    const src = new LiveSlackSource(
+      {
+        searchPublic: async () => ({ messages }),
+        readCanvas: async (id: string) => {
+          if (id === 'FGOOD123') return { canvas_markdown: '# good notes' }
+          throw new Error('not found')
+        }
+      },
+      { searchQuery: 'q', searchLimit: 10 }
+    )
+    const huddles = await src.list()
+    expect(huddles).toHaveLength(1)
+    expect(huddles[0].canvasMarkdown).toBe('# good notes')
+  })
+
+  it('skips a huddle when readCanvas throws (does not blow up the batch)', async () => {
+    const messages = [
+      {
+        user: 'USLACKBOT',
+        ts: '1714098000',
+        text: 'AI huddle notes are ready: https://x.slack.com/docs/T0/FGOOD',
+        channel: { id: 'C1', name: 'core-values' }
+      },
+      {
+        user: 'USLACKBOT',
+        ts: '1714098001',
+        text: 'AI huddle notes are ready: https://x.slack.com/docs/T0/FBAD',
+        channel: { id: 'C1', name: 'core-values' }
+      }
+    ]
+    const src = new LiveSlackSource(
+      {
+        searchPublic: async () => ({ messages }),
+        readCanvas: async (id: string) => {
+          if (id === 'FGOOD') return '# ok'
+          throw new Error('canvas not accessible')
+        }
+      },
+      { searchQuery: 'q', searchLimit: 10 }
+    )
+    const huddles = await src.list()
+    expect(huddles).toHaveLength(1)
+    expect(huddles[0].fileId).toBe('FGOOD')
+  })
+
+  it('accepts both string and object canvas results', async () => {
+    const messages = [
+      {
+        user: 'USLACKBOT',
+        ts: '1',
+        text: 'AI huddle notes are ready: https://x.slack.com/docs/T/F1',
+        channel: { id: 'C1', name: 'one' }
+      },
+      {
+        user: 'USLACKBOT',
+        ts: '2',
+        text: 'AI huddle notes are ready: https://x.slack.com/docs/T/F2',
+        channel: { id: 'C1', name: 'one' }
+      }
+    ]
+    const src = new LiveSlackSource(
+      {
+        searchPublic: async () => ({ messages }),
+        readCanvas: async (id: string) =>
+          id === 'F1' ? '# string form' : { canvas_markdown: '# obj form' }
+      },
+      { searchQuery: 'q', searchLimit: 10 }
+    )
+    const huddles = await src.list()
+    expect(huddles).toHaveLength(2)
+    expect(huddles[0].canvasMarkdown).toBe('# string form')
+    expect(huddles[1].canvasMarkdown).toBe('# obj form')
+  })
+
+  it('skips messages that do not pass the Slackbot recap filter', async () => {
+    const messages = [
+      {
+        user: 'U_HUMAN',
+        ts: '1',
+        text: 'AI huddle notes are ready (impersonator): https://x.slack.com/docs/T/F1',
+        channel: { id: 'C1', name: 'one' }
+      },
+      {
+        user: 'USLACKBOT',
+        ts: '2',
+        text: 'totally different Slackbot announcement',
+        channel: { id: 'C1', name: 'one' }
+      }
+    ]
+    const src = new LiveSlackSource(
+      {
+        searchPublic: async () => ({ messages }),
+        readCanvas: async () => '# unused'
+      },
+      { searchQuery: 'q', searchLimit: 10 }
+    )
+    const huddles = await src.list()
+    expect(huddles).toHaveLength(0)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// processHuddle + runImport — wired to fakes
+// ─────────────────────────────────────────────────────────────────────────
+
+class FakeSource implements SlackHuddleSource {
+  constructor(private huddles: RawHuddle[]) {}
+  async list() {
+    return this.huddles
+  }
+}
+
+class FakeDistiller implements DistillerLike {
+  constructor(
+    private overrides: Partial<DistilledHuddle> = {},
+    private throwOn?: string
+  ) {}
+  async distill(huddle: RawHuddle): Promise<DistilledHuddle> {
+    if (this.throwOn && huddle.fileId === this.throwOn) {
+      throw new Error('haiku exploded')
+    }
+    return {
+      summary: this.overrides.summary ?? `summary for ${huddle.fileId}`,
+      claims: this.overrides.claims ?? [
+        {
+          type: 'decision',
+          content: 'A decision.',
+          qualitative_confidence: 'firm',
+          topics: [],
+          people: []
+        },
+        {
+          type: 'context',
+          content: 'A context.',
+          qualitative_confidence: 'tentative',
+          topics: [],
+          people: []
+        }
+      ]
+    }
+  }
+}
+
+class FakeMcpClient {
+  public calls: Array<{ name: string; args: any }> = []
+  private responses: any[]
+  private idCounter = 0
+
+  constructor(responses?: any[]) {
+    this.responses = responses ?? []
+  }
+
+  async callTool(name: string, args: any) {
+    this.calls.push({ name, args })
+    if (this.responses.length > 0) {
+      return this.responses.shift()
+    }
+    return {
+      success: true,
+      id: `kms-id-${++this.idCounter}`,
+      storageDecision: { primary: 'graph', secondary: ['mem0'], reasoning: 'fake' }
+    }
+  }
+
+  async initialize() {
+    /* noop */
+  }
+  async close() {
+    /* noop */
+  }
+}
+
+function mkHuddle(over: Partial<RawHuddle> = {}): RawHuddle {
+  return {
+    channelId: 'C1',
+    channelName: 'core-values',
+    messageTs: '1714098000.000400',
+    teamId: 'T0',
+    fileId: over.fileId ?? 'FX',
+    huddleDate: '2026-04-11T16:00:00Z',
+    canvasMarkdown: '# canvas\nnotes',
+    ...over
+  }
+}
+
+function defaultOpts(): any {
+  return {
+    source: 'file',
+    searchQuery: DEFAULT_SEARCH_QUERY,
+    searchLimit: 20,
+    kmsUrl: 'http://localhost:8180/mcp',
+    syncLogPath: '/tmp/test-sync.json',
+    userId: 'test-user',
+    anthropicModel: 'claude-haiku-4-5',
+    workspace: 'tengo',
+    dryRun: true
+  }
+}
+
+describe('processHuddle', () => {
+  it('skips a huddle already in the sync log', async () => {
+    const h = mkHuddle({ fileId: 'F-old' })
+    const result = await processHuddle(h, {
+      source: new FakeSource([]),
+      distiller: new FakeDistiller(),
+      kms: new FakeMcpClient() as any,
+      opts: { ...defaultOpts(), dryRun: false },
+      log: { completed: ['F-old'] }
+    })
+    expect(result.status).toBe('skipped')
+    expect(result.reason).toContain('sync log')
+  })
+
+  it('writes summary + N claim entries on the happy path', async () => {
+    const h = mkHuddle({ fileId: 'F-new' })
+    const kms = new FakeMcpClient()
+    const result = await processHuddle(h, {
+      source: new FakeSource([]),
+      distiller: new FakeDistiller(),
+      kms: kms as any,
+      opts: { ...defaultOpts(), dryRun: false },
+      log: { completed: [] }
+    })
+    expect(result.status).toBe('ok')
+    expect(result.summaryEntryId).toBe('kms-id-1')
+    expect(result.claimEntryIds).toEqual(['kms-id-2', 'kms-id-3'])
+
+    expect(kms.calls).toHaveLength(3) // 1 summary + 2 claims
+    const [summary, claim0, claim1] = kms.calls
+    expect(summary.name).toBe('unified_store')
+    expect(summary.args.contentType).toBe('memory')
+    expect(summary.args.metadata.subject).toBe('Slack.huddle.core-values.2026-04-11')
+    expect(summary.args.metadata.source).toBe('slack_huddle')
+    expect(summary.args.metadata.source_doc).toBe('slack://canvas/T0/F-new')
+    expect(summary.args.metadata.slack_workspace).toBe('tengo')
+    expect(summary.args.metadata.slack_channel).toBe('C1')
+    expect(summary.args.metadata.slack_message_ts).toBe('1714098000.000400')
+    expect(summary.args.metadata.slack_canvas_id).toBe('F-new')
+    expect(summary.args.metadata.huddle_date).toBe('2026-04-11T16:00:00Z')
+
+    expect(claim0.args.metadata.related_to).toEqual(['kms-id-1'])
+    expect(claim0.args.metadata.source_doc).toBe('slack://canvas/T0/F-new')
+    expect(claim0.args.metadata.subject).toBe('Slack.huddle.core-values.2026-04-11.claim_0')
+    expect(claim0.args.contentType).toBe('insight') // decision → insight
+    expect(claim0.args.metadata.qualitative_confidence).toBe('firm')
+    expect(claim1.args.contentType).toBe('memory') // context → memory
+  })
+
+  it('handles dedup_required on summary write — counts as dedup_refused, not failed', async () => {
+    const h = mkHuddle({ fileId: 'F-dup' })
+    const kms = new FakeMcpClient([
+      {
+        status: 'dedup_required',
+        candidates: [{ id: 'existing-1', similarity: 0.92 }],
+        message: 'dup found',
+        retry_with: [],
+        band: 'refuse',
+        thresholds: { refuse: 0.88, confirm: 0.78 }
+      }
+    ])
+    const result = await processHuddle(h, {
+      source: new FakeSource([]),
+      distiller: new FakeDistiller(),
+      kms: kms as any,
+      opts: { ...defaultOpts(), dryRun: false },
+      log: { completed: [] }
+    })
+    expect(result.status).toBe('dedup_refused')
+    expect(result.candidates?.[0]?.id).toBe('existing-1')
+    // We did NOT proceed to write claims when summary refused
+    expect(kms.calls).toHaveLength(1)
+  })
+
+  it('handles distillation failure (failed, with reason)', async () => {
+    const h = mkHuddle({ fileId: 'F-bad' })
+    const kms = new FakeMcpClient()
+    const result = await processHuddle(h, {
+      source: new FakeSource([]),
+      distiller: new FakeDistiller({}, 'F-bad'),
+      kms: kms as any,
+      opts: { ...defaultOpts(), dryRun: false },
+      log: { completed: [] }
+    })
+    expect(result.status).toBe('failed')
+    expect(result.reason).toContain('haiku exploded')
+    expect(kms.calls).toHaveLength(0)
+  })
+
+  it('continues past a single claim failure (counts huddle as ok if summary landed)', async () => {
+    const h = mkHuddle({ fileId: 'F-mixed' })
+    const kms = new FakeMcpClient([
+      // 1: summary success
+      { success: true, id: 'sum-1' },
+      // 2: claim 0 success
+      { success: true, id: 'claim-0' },
+      // 3: claim 1 dedup_refused (non-fatal)
+      { status: 'dedup_required', candidates: [{ id: 'existing' }], message: 'dup' }
+    ])
+    const result = await processHuddle(h, {
+      source: new FakeSource([]),
+      distiller: new FakeDistiller(),
+      kms: kms as any,
+      opts: { ...defaultOpts(), dryRun: false },
+      log: { completed: [] }
+    })
+    expect(result.status).toBe('ok')
+    expect(result.summaryEntryId).toBe('sum-1')
+    expect(result.claimEntryIds).toEqual(['claim-0'])
+  })
+
+  it('dry-run path skips KMS calls entirely', async () => {
+    const h = mkHuddle({ fileId: 'F-dry' })
+    const kms = new FakeMcpClient()
+    const result = await processHuddle(h, {
+      source: new FakeSource([]),
+      distiller: new FakeDistiller(),
+      kms: kms as any,
+      opts: { ...defaultOpts(), dryRun: true },
+      log: { completed: [] }
+    })
+    expect(result.status).toBe('ok')
+    expect(kms.calls).toHaveLength(0)
+  })
+
+  it('routes the supersede/dedup chain only on summary — claim dedup is non-fatal', async () => {
+    const h = mkHuddle({ fileId: 'F-mixed-2' })
+    // 1 summary ok, 1 claim ok, 1 claim throws (e.g. KMS down briefly), 0 more claims
+    // (but distiller returns 2 claims by default)
+    const kms = new FakeMcpClient([
+      { success: true, id: 'sum-1' },
+      { success: true, id: 'claim-0' },
+      // simulate a real throw on the second claim — e.g. transient HTTP
+    ])
+    // Replace callTool to throw on the third call
+    let n = 0
+    const origCall = kms.callTool.bind(kms)
+    kms.callTool = async (name: string, args: any) => {
+      n++
+      if (n === 3) throw new Error('transient HTTP')
+      return origCall(name, args)
+    }
+    const result = await processHuddle(h, {
+      source: new FakeSource([]),
+      distiller: new FakeDistiller(),
+      kms: kms as any,
+      opts: { ...defaultOpts(), dryRun: false },
+      log: { completed: [] }
+    })
+    expect(result.status).toBe('ok') // summary landed
+    expect(result.summaryEntryId).toBe('sum-1')
+    expect(result.claimEntryIds).toEqual(['claim-0'])
+  })
+})
+
+describe('runImport', () => {
+  let tmpDir: string
+  let logPath: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'slack-runimport-test-'))
+    logPath = join(tmpDir, '.kms-slack-huddle-sync.json')
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('rolls forward across mixed outcomes (skipped + ok + dedup_refused + failed)', async () => {
+    const huddles = [
+      mkHuddle({ fileId: 'F-skip', channelName: 'one' }),
+      mkHuddle({ fileId: 'F-ok', channelName: 'two' }),
+      mkHuddle({ fileId: 'F-dedup', channelName: 'three' }),
+      mkHuddle({ fileId: 'F-fail', channelName: 'four' })
+    ]
+    const kms = new FakeMcpClient([
+      // F-ok: summary + 2 claims
+      { success: true, id: 'sum-ok' },
+      { success: true, id: 'claim-0' },
+      { success: true, id: 'claim-1' },
+      // F-dedup: summary returns dedup_required
+      { status: 'dedup_required', candidates: [{ id: 'existing' }], message: 'dup' }
+      // F-fail: distiller throws — no KMS calls
+    ])
+
+    const opts = { ...defaultOpts(), syncLogPath: logPath, dryRun: false }
+    const log = { completed: ['F-skip'] }
+
+    const report = await runImport({
+      source: new FakeSource(huddles),
+      distiller: new FakeDistiller({}, 'F-fail'),
+      kms: kms as any,
+      opts,
+      log
+    })
+
+    expect(report.totalHuddles).toBe(4)
+    expect(report.summaries).toBe(1)
+    expect(report.claims).toBe(2)
+    expect(report.skipped).toEqual([{ fileId: 'F-skip', channel: 'one' }])
+    expect(report.dedupRefused).toHaveLength(1)
+    expect(report.dedupRefused[0].fileId).toBe('F-dedup')
+    expect(report.failed).toHaveLength(1)
+    expect(report.failed[0].fileId).toBe('F-fail')
+
+    // Sync log persisted with the new ok'd id
+    const saved = JSON.parse(readFileSync(logPath, 'utf-8'))
+    expect(saved.completed).toContain('F-skip')
+    expect(saved.completed).toContain('F-ok')
+    expect(saved.completed).not.toContain('F-fail')
+    expect(saved.completed).not.toContain('F-dedup')
+  })
+
+  it('respects --max-huddles cap', async () => {
+    const huddles = Array.from({ length: 10 }, (_, i) =>
+      mkHuddle({ fileId: `F_${i}`, channelName: `c${i}` })
+    )
+    const kms = new FakeMcpClient()
+    const opts = {
+      ...defaultOpts(),
+      syncLogPath: logPath,
+      maxHuddles: 3,
+      dryRun: false
+    }
+    const log = { completed: [] }
+    const report = await runImport({
+      source: new FakeSource(huddles),
+      distiller: new FakeDistiller(),
+      kms: kms as any,
+      opts,
+      log
+    })
+    expect(report.totalHuddles).toBe(3)
+    expect(report.summaries).toBe(3)
+    expect(report.claims).toBe(6)
+  })
+
+  it('survives a per-huddle distiller error (does not blow up sibling huddles)', async () => {
+    const huddles = [
+      mkHuddle({ fileId: 'a', channelName: 'A' }),
+      mkHuddle({ fileId: 'b', channelName: 'B' }),
+      mkHuddle({ fileId: 'c', channelName: 'C' })
+    ]
+    const kms = new FakeMcpClient()
+    const report = await runImport({
+      source: new FakeSource(huddles),
+      distiller: new FakeDistiller({}, 'b'),
+      kms: kms as any,
+      opts: { ...defaultOpts(), syncLogPath: logPath, dryRun: false },
+      log: { completed: [] }
+    })
+    expect(report.summaries).toBe(2)
+    expect(report.failed).toHaveLength(1)
+    expect(report.failed[0].fileId).toBe('b')
+  })
+
+  it('persists sync log incrementally — one ok then crash mid-run leaves first id committed', async () => {
+    const huddles = [
+      mkHuddle({ fileId: 'first', channelName: 'A' }),
+      mkHuddle({ fileId: 'crash', channelName: 'B' })
+    ]
+    const kms = new FakeMcpClient()
+    // Distiller throws on second huddle — first should still be persisted
+    const report = await runImport({
+      source: new FakeSource(huddles),
+      distiller: new FakeDistiller({}, 'crash'),
+      kms: kms as any,
+      opts: { ...defaultOpts(), syncLogPath: logPath, dryRun: false },
+      log: { completed: [] }
+    })
+    expect(report.summaries).toBe(1)
+    expect(report.failed).toHaveLength(1)
+    const saved = JSON.parse(readFileSync(logPath, 'utf-8'))
+    expect(saved.completed).toEqual(['first'])
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// MinimalMcpClient — only the things that don't need a live server
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('MinimalMcpClient', () => {
+  it('throws if callTool is invoked before initialize', async () => {
+    const c = new MinimalMcpClient('http://localhost:1', null)
+    await expect(c.callTool('any', {})).rejects.toThrow(/not initialized/)
+  })
+})

--- a/src/scripts/import-slack-huddles-cli.ts
+++ b/src/scripts/import-slack-huddles-cli.ts
@@ -1,0 +1,18 @@
+/**
+ * Thin CLI entry point for the Slack Huddle → KMS Importer.
+ *
+ * The actual implementation lives in `import-slack-huddles.ts`, which is
+ * import-only / side-effect-free so its symbols can be unit-tested under
+ * ts-jest without a top-level `import.meta` reference (which the test
+ * runner's CJS loader rejects).
+ *
+ * Run: `node dist/scripts/import-slack-huddles-cli.js [...flags]`
+ *   or: `npx tsx src/scripts/import-slack-huddles-cli.ts [...flags]`
+ */
+
+import { main } from './import-slack-huddles.js'
+
+main().catch(err => {
+  console.error('fatal:', err)
+  process.exit(1)
+})

--- a/src/scripts/import-slack-huddles.ts
+++ b/src/scripts/import-slack-huddles.ts
@@ -397,11 +397,19 @@ export class MinimalMcpClient {
     if (this.bearer) headers['Authorization'] = `Bearer ${this.bearer}`
     if (this.sessionId) headers['mcp-session-id'] = this.sessionId
 
-    const res = await fetch(this.kmsUrl, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(body)
-    })
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), 30_000)
+    let res: Response
+    try {
+      res = await fetch(this.kmsUrl, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+        signal: controller.signal
+      })
+    } finally {
+      clearTimeout(timer)
+    }
 
     const sessionHeader = res.headers.get('mcp-session-id')
     const text = await res.text()
@@ -436,12 +444,54 @@ export class MinimalMcpClient {
   }
 }
 
+/**
+ * Parse an SSE body into a JSON-RPC response object.
+ *
+ * MCP StreamableHTTP may send multiple SSE events for a single request (e.g.
+ * a progress notification followed by the actual result). Each SSE event is
+ * separated by a blank line; its payload is the concatenation of all `data:`
+ * field lines within that event block.
+ *
+ * Strategy: split into per-event blocks first, then parse each block's data
+ * payload as JSON. Return the last event that parses successfully — that is
+ * always the JSON-RPC result, since notifications arrive first.
+ */
 function parseSseToJson(sse: string): any {
   const lines = sse.split(/\r?\n/)
   const dataLines = lines.filter(l => l.startsWith('data: ')).map(l => l.slice(6))
   if (dataLines.length === 0) {
     throw new Error(`Could not parse MCP response (not JSON, not SSE): ${sse.slice(0, 200)}`)
   }
+
+  // Split the raw SSE body into event blocks (separated by blank lines) and
+  // attempt to parse each block's accumulated data payload. Return the last
+  // one that parses — the result event arrives after any notification events.
+  const blocks: string[][] = []
+  let current: string[] = []
+  for (const line of lines) {
+    if (line === '' || line === '\r') {
+      if (current.length > 0) { blocks.push(current); current = [] }
+    } else if (line.startsWith('data: ')) {
+      current.push(line.slice(6))
+    }
+  }
+  if (current.length > 0) blocks.push(current)
+
+  let lastParsed: any
+  let parsed = false
+  for (const block of blocks) {
+    const payload = block.join('')
+    if (!payload) continue
+    try {
+      lastParsed = JSON.parse(payload)
+      parsed = true
+    } catch {
+      // not a JSON event — skip (e.g. SSE comment or keep-alive)
+    }
+  }
+  if (parsed) return lastParsed
+
+  // Fallback: original join (handles a single multi-line data field)
   const joined = dataLines.join('')
   return JSON.parse(joined)
 }

--- a/src/scripts/import-slack-huddles.ts
+++ b/src/scripts/import-slack-huddles.ts
@@ -1,0 +1,1125 @@
+/**
+ * Slack Huddle → KMS importer.
+ *
+ * Turns Slack huddle AI-notes (the canvas posted by Slackbot after a huddle
+ * ends) into KMS entries via the dual-write pattern, mirroring PR #74's
+ * Granola importer:
+ *   1. ONE whole-huddle "memory" entry per huddle (the distilled summary,
+ *      NOT the raw canvas markdown), tagged with metadata.subject="Slack.huddle.<channel>.<date>"
+ *      and metadata.source_doc="slack://canvas/<team_id>/<file_id>".
+ *   2. N (2–5) typed claim entries per huddle (OB1 6-type taxonomy mapped to
+ *      KMSmcp contentTypes via mapClaimTypeToContentType). Each claim links
+ *      back to the whole-huddle entry with metadata.related_to=[...] and
+ *      shares the same source_doc pointer.
+ *
+ * Both write paths route through `unified_store` so the dedup gate fires
+ * naturally — overlap with Granola transcripts of the same huddle gets
+ * caught upstream (action=complement or duplicate).
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * Architecture — Source abstraction (mirrors PR #74's GranolaSource)
+ * ─────────────────────────────────────────────────────────────────────────
+ *
+ * Source A — `LiveSlackSource`:
+ *   Calls slack_search_public + slack_read_canvas via the connected Slack MCP
+ *   at runtime. This is the production path; works when run from a Claude
+ *   Code session that has Slack MCP authorized. For unattended/cron runs,
+ *   the Slack MCP isn't reachable, so use Source B.
+ *
+ *   Wired via dependency injection of two callbacks:
+ *     - searchPublic(query, opts) → { messages: [...] }
+ *     - readCanvas(canvasId)      → { canvas_markdown: "..." }
+ *
+ *   The driver agent (Claude Code) supplies these callbacks at construction
+ *   time, so the importer module itself stays free of MCP-runtime imports.
+ *
+ * Source B — `FileSlackSource`:
+ *   Reads from a pre-dumped JSON file (cron/launchd contexts). The file
+ *   shape matches what LiveSlackSource produces:
+ *
+ *     [
+ *       {
+ *         "channel_id":   "C0123ABCD",
+ *         "channel_name": "core-values",
+ *         "message_ts":   "1714098000.000400",
+ *         "team_id":      "T0123ABCD",
+ *         "file_id":      "F4567WXYZ",
+ *         "huddle_date":  "2026-04-11T16:00:00Z",     // optional ISO; falls back to ts
+ *         "canvas_markdown": "..."
+ *       },
+ *       ...
+ *     ]
+ *
+ *   This is the agent-driven flow: a Claude Code session (which has the
+ *   Slack MCP connected) does the discovery + canvas fetch, dumps to JSON,
+ *   then the cron job runs this script.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * KMS auth
+ * ─────────────────────────────────────────────────────────────────────────
+ *
+ * The live KMS at http://localhost:8180/mcp requires OAuth (OAUTH_ENABLED=true).
+ * Two paths supported:
+ *   1. KMS_BEARER_TOKEN env var (preferred for one-off runs).
+ *   2. Auth0 client_credentials grant via OAUTH_CLIENT_ID + OAUTH_CLIENT_SECRET +
+ *      OAUTH_TOKEN_ENDPOINT + OAUTH_AUDIENCE (preferred for unattended/cron).
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * Resumability
+ * ─────────────────────────────────────────────────────────────────────────
+ *
+ * `~/.kms-slack-huddle-sync.json` is keyed by canvas_file_id. Re-running the
+ * script skips canvases already in the log. Failed canvases are NOT added to
+ * the log (so they retry on next run).
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * Final report shape
+ * ─────────────────────────────────────────────────────────────────────────
+ *
+ *   {
+ *     "totalHuddles":  N,
+ *     "summaries":     N,                   // whole-huddle entries created
+ *     "claims":        N,                   // claim entries created
+ *     "skipped":       [{ fileId, channel }],   // already in sync log
+ *     "failed":        [{ fileId, channel, reason }],
+ *     "dedupRefused":  [{ fileId, channel, candidates }]
+ *   }
+ */
+
+import Anthropic from '@anthropic-ai/sdk'
+import { existsSync, readFileSync, writeFileSync } from 'fs'
+import { homedir } from 'os'
+import { join } from 'path'
+import {
+  buildDistillPrompt,
+  DistilledHuddle,
+  extractCanvasId,
+  isSlackbotHuddleRecap,
+  mapClaimTypeToContentType,
+  parseDistilledResponse
+} from './slack-huddle-distill-prompt.js'
+
+// ─────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Normalized representation of one huddle, ready to distill + import. */
+export interface RawHuddle {
+  channelId: string
+  channelName: string
+  messageTs: string
+  teamId: string
+  fileId: string
+  /** ISO date of the huddle. Optional — falls back to messageTs converted from epoch. */
+  huddleDate?: string
+  /** The canvas markdown body (NOT the recap message text). */
+  canvasMarkdown: string
+}
+
+export interface SyncLog {
+  /** Array of canvas file_ids that have been successfully imported. */
+  completed: string[]
+  lastRun?: string
+}
+
+export interface ImportReport {
+  totalHuddles: number
+  summaries: number
+  claims: number
+  skipped: Array<{ fileId: string; channel: string }>
+  failed: Array<{ fileId: string; channel: string; reason: string }>
+  dedupRefused: Array<{ fileId: string; channel: string; candidates: any[] }>
+}
+
+export interface CliOptions {
+  input?: string
+  source: 'file' | 'live'
+  /** Slack search query; defaults to the canonical Slackbot recap probe. */
+  searchQuery: string
+  searchLimit: number
+  kmsUrl: string
+  syncLogPath: string
+  userId: string
+  anthropicModel: string
+  workspace: string
+  dryRun: boolean
+  maxHuddles?: number
+  bearerToken?: string
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Argv parsing
+// ─────────────────────────────────────────────────────────────────────────
+
+export const DEFAULT_SEARCH_QUERY =
+  '"AI huddle notes are ready" from:USLACKBOT'
+
+export function parseArgs(argv: string[]): CliOptions {
+  const opts: CliOptions = {
+    source: 'file',
+    searchQuery: DEFAULT_SEARCH_QUERY,
+    searchLimit: 20,
+    kmsUrl: process.env.KMS_URL || 'http://localhost:8180/mcp',
+    syncLogPath:
+      process.env.KMS_SLACK_HUDDLE_SYNC_LOG ||
+      join(homedir(), '.kms-slack-huddle-sync.json'),
+    userId: process.env.KMS_DEFAULT_USER_ID || 'richard_yaker',
+    anthropicModel: process.env.ANTHROPIC_MODEL || 'claude-haiku-4-5-20251001',
+    workspace: process.env.SLACK_WORKSPACE || 'tengo',
+    dryRun: false,
+    bearerToken: process.env.KMS_BEARER_TOKEN
+  }
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    const next = () => argv[++i]
+    switch (arg) {
+      case '--input':           opts.input = next(); break
+      case '--source':          opts.source = next() as 'file' | 'live'; break
+      case '--search-query':    opts.searchQuery = next(); break
+      case '--search-limit':    opts.searchLimit = parseInt(next(), 10); break
+      case '--kms-url':         opts.kmsUrl = next(); break
+      case '--sync-log':        opts.syncLogPath = next(); break
+      case '--user-id':         opts.userId = next(); break
+      case '--anthropic-model': opts.anthropicModel = next(); break
+      case '--workspace':       opts.workspace = next(); break
+      case '--bearer-token':    opts.bearerToken = next(); break
+      case '--dry-run':         opts.dryRun = true; break
+      case '--max-huddles':     opts.maxHuddles = parseInt(next(), 10); break
+      case '-h':
+      case '--help':
+        printHelp()
+        process.exit(0)
+      default:
+        if (arg.startsWith('--')) {
+          throw new Error(`Unknown flag: ${arg}`)
+        }
+    }
+  }
+  if (opts.source !== 'file' && opts.source !== 'live') {
+    throw new Error(`Invalid --source: ${opts.source} (expected 'file' or 'live')`)
+  }
+  return opts
+}
+
+function printHelp(): void {
+  console.log(`
+Slack Huddle → KMS importer
+
+Usage:
+  node dist/scripts/import-slack-huddles-cli.js [options]
+
+Modes:
+  --source file --input <path>   Read pre-dumped huddle JSON from a file (default).
+  --source live                  Use LiveSlackSource (requires the script to be
+                                 run from a Claude Code session whose driver
+                                 wires slack_search_public + slack_read_canvas
+                                 into the importer).
+
+Options:
+  --input <file>             Path to a JSON array of huddles (--source file).
+  --search-query <q>         Override the Slack search query (--source live).
+                             Default: "AI huddle notes are ready" from:USLACKBOT
+  --search-limit <n>         Max search results (default 20).
+  --workspace <slug>         Slack workspace label written into metadata
+                             (default 'tengo').
+  --kms-url <url>            default: http://localhost:8180/mcp
+  --sync-log <path>          default: ~/.kms-slack-huddle-sync.json
+  --user-id <id>             default: richard_yaker (or KMS_DEFAULT_USER_ID env)
+  --anthropic-model <id>     default: claude-haiku-4-5-20251001
+  --bearer-token <token>     Bypass OAuth client-credentials, pass token directly.
+                             Or set KMS_BEARER_TOKEN env var.
+  --dry-run                  Don't actually write to KMS. Log what would happen.
+  --max-huddles <N>          Cap huddles processed (smoke-test).
+  -h, --help                 This help.
+
+Environment:
+  KMS_BEARER_TOKEN           Preferred OAuth path for one-off runs.
+  ANTHROPIC_API_KEY          Required (Haiku 4.5 distillation).
+  KMS_URL                    Override --kms-url.
+  KMS_DEFAULT_USER_ID        Default --user-id.
+  SLACK_WORKSPACE            Default --workspace label.
+
+  When KMS_BEARER_TOKEN is unset, the script falls back to Auth0 client_credentials
+  using OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET, OAUTH_TOKEN_ENDPOINT, OAUTH_AUDIENCE.
+`)
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Sync log
+// ─────────────────────────────────────────────────────────────────────────
+
+export function loadSyncLog(path: string): SyncLog {
+  if (!existsSync(path)) {
+    return { completed: [] }
+  }
+  try {
+    const raw = readFileSync(path, 'utf-8')
+    const parsed = JSON.parse(raw)
+    if (!parsed || !Array.isArray(parsed.completed)) {
+      console.warn(`⚠️  Sync log at ${path} is malformed; starting empty.`)
+      return { completed: [] }
+    }
+    return { completed: parsed.completed, lastRun: parsed.lastRun }
+  } catch (e) {
+    console.warn(`⚠️  Could not read sync log ${path}: ${e instanceof Error ? e.message : e}`)
+    return { completed: [] }
+  }
+}
+
+export function saveSyncLog(path: string, log: SyncLog): void {
+  writeFileSync(
+    path,
+    JSON.stringify({ ...log, lastRun: new Date().toISOString() }, null, 2),
+    'utf-8'
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// OAuth — get bearer token via client_credentials if not supplied
+// ─────────────────────────────────────────────────────────────────────────
+
+async function fetchBearerTokenIfNeeded(opts: CliOptions): Promise<string | null> {
+  if (opts.bearerToken) return opts.bearerToken
+
+  const tokenEndpoint = process.env.OAUTH_TOKEN_ENDPOINT
+  const clientId = process.env.OAUTH_CLIENT_ID
+  const clientSecret = process.env.OAUTH_CLIENT_SECRET
+  const audience = process.env.OAUTH_AUDIENCE
+
+  if (!tokenEndpoint || !clientId || !clientSecret || !audience) {
+    console.warn(
+      `⚠️  No --bearer-token / KMS_BEARER_TOKEN set, and OAuth client_credentials env ` +
+      `vars are incomplete. Will attempt unauthenticated calls (will fail if KMS has OAUTH_ENABLED=true).`
+    )
+    return null
+  }
+
+  const body = new URLSearchParams({
+    grant_type: 'client_credentials',
+    client_id: clientId,
+    client_secret: clientSecret,
+    audience
+  })
+
+  const res = await fetch(tokenEndpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body
+  })
+  if (!res.ok) {
+    const txt = await res.text().catch(() => '')
+    throw new Error(`OAuth token request failed (${res.status}): ${txt}`)
+  }
+  const data = (await res.json()) as { access_token?: string }
+  if (!data.access_token) {
+    throw new Error(`OAuth token response had no access_token: ${JSON.stringify(data)}`)
+  }
+  return data.access_token
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// MCP client — minimal StreamableHTTP-compatible wrapper (mirrors PR #74)
+// ─────────────────────────────────────────────────────────────────────────
+
+export class MinimalMcpClient {
+  private kmsUrl: string
+  private bearer: string | null
+  private sessionId: string | null = null
+  private nextId = 1
+
+  constructor(kmsUrl: string, bearer: string | null) {
+    this.kmsUrl = kmsUrl
+    this.bearer = bearer
+  }
+
+  async initialize(): Promise<void> {
+    const initBody = {
+      jsonrpc: '2.0',
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-06-18',
+        capabilities: {},
+        clientInfo: { name: 'slack-huddle-importer', version: '1.0.0' }
+      },
+      id: this.nextId++
+    }
+    const { sessionId, body } = await this.postRaw(initBody, /* expectSession */ true)
+    if (!sessionId) {
+      throw new Error(
+        `MCP initialize did not return mcp-session-id header. Body: ${JSON.stringify(body).slice(0, 500)}`
+      )
+    }
+    this.sessionId = sessionId
+
+    // Send the required initialized notification.
+    await this.postRaw(
+      { jsonrpc: '2.0', method: 'notifications/initialized', params: {} },
+      false
+    )
+  }
+
+  async callTool<T = any>(name: string, args: Record<string, any>): Promise<T> {
+    if (!this.sessionId) throw new Error('MCP client not initialized')
+    const body = {
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: { name, arguments: args },
+      id: this.nextId++
+    }
+    const { body: response } = await this.postRaw(body, false)
+    if (response?.error) {
+      throw new Error(
+        `Tool ${name} failed: ${response.error.message} (code ${response.error.code})`
+      )
+    }
+    const text = response?.result?.content?.[0]?.text
+    if (typeof text !== 'string') {
+      throw new Error(
+        `Tool ${name} returned unexpected shape (no result.content[0].text): ${JSON.stringify(response).slice(0, 400)}`
+      )
+    }
+    try {
+      return JSON.parse(text) as T
+    } catch {
+      throw new Error(`Tool ${name} returned non-JSON text body: ${text.slice(0, 400)}`)
+    }
+  }
+
+  private async postRaw(
+    body: any,
+    captureSession: boolean
+  ): Promise<{ sessionId: string | null; body: any }> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json, text/event-stream'
+    }
+    if (this.bearer) headers['Authorization'] = `Bearer ${this.bearer}`
+    if (this.sessionId) headers['mcp-session-id'] = this.sessionId
+
+    const res = await fetch(this.kmsUrl, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body)
+    })
+
+    const sessionHeader = res.headers.get('mcp-session-id')
+    const text = await res.text()
+
+    // Notifications get 202 with empty body — that's normal.
+    if (res.status === 202 && (!text || text.trim().length === 0)) {
+      return { sessionId: captureSession ? sessionHeader : null, body: null }
+    }
+
+    if (!res.ok) {
+      throw new Error(`MCP HTTP ${res.status}: ${text.slice(0, 500)}`)
+    }
+
+    let parsed: any
+    try {
+      parsed = JSON.parse(text)
+    } catch {
+      parsed = parseSseToJson(text)
+    }
+    return { sessionId: captureSession ? sessionHeader : null, body: parsed }
+  }
+
+  async close(): Promise<void> {
+    if (!this.sessionId) return
+    try {
+      const headers: Record<string, string> = { 'mcp-session-id': this.sessionId }
+      if (this.bearer) headers['Authorization'] = `Bearer ${this.bearer}`
+      await fetch(this.kmsUrl, { method: 'DELETE', headers })
+    } catch {
+      // best-effort
+    }
+  }
+}
+
+function parseSseToJson(sse: string): any {
+  const lines = sse.split(/\r?\n/)
+  const dataLines = lines.filter(l => l.startsWith('data: ')).map(l => l.slice(6))
+  if (dataLines.length === 0) {
+    throw new Error(`Could not parse MCP response (not JSON, not SSE): ${sse.slice(0, 200)}`)
+  }
+  const joined = dataLines.join('')
+  return JSON.parse(joined)
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Slack source abstraction
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * A Slack search-result message. This is the subset of fields the importer
+ * actually reads — both the live MCP shape and the file-dump shape can map to it.
+ */
+export interface SlackSearchMessage {
+  user?: string
+  username?: string
+  text?: string
+  ts?: string
+  /** Channel info; varies by Slack API surface. */
+  channel?: { id?: string; name?: string } | string
+  channel_id?: string
+  channel_name?: string
+}
+
+export interface SlackHuddleSource {
+  list(): Promise<RawHuddle[]>
+}
+
+/**
+ * FileSlackSource — reads pre-dumped huddles from a JSON file.
+ *
+ * Two file shapes accepted:
+ *   A. "Pre-resolved" shape — array of RawHuddle-like objects with
+ *      canvas_markdown already pre-fetched. This is the cron path.
+ *   B. "Search-results + canvases" shape:
+ *        {
+ *          "messages": [<SlackSearchMessage>, ...],
+ *          "canvases": { "<file_id>": "<markdown>", ... }
+ *        }
+ *      The importer extracts canvas IDs from messages and joins to canvases.
+ */
+export class FileSlackSource implements SlackHuddleSource {
+  constructor(private path: string) {}
+
+  async list(): Promise<RawHuddle[]> {
+    if (!existsSync(this.path)) {
+      throw new Error(`Slack huddle dump file not found: ${this.path}`)
+    }
+    const raw = readFileSync(this.path, 'utf-8')
+    let parsed: any
+    try {
+      parsed = JSON.parse(raw)
+    } catch (e) {
+      throw new Error(
+        `Slack huddle dump is not valid JSON: ${e instanceof Error ? e.message : String(e)}`
+      )
+    }
+
+    if (Array.isArray(parsed)) {
+      return parsed.map((m, i) => normalizePreResolvedHuddle(m, i))
+    }
+
+    if (parsed && typeof parsed === 'object' && Array.isArray(parsed.messages)) {
+      const canvases: Record<string, string> = parsed.canvases ?? {}
+      const out: RawHuddle[] = []
+      for (const msg of parsed.messages) {
+        if (!isSlackbotHuddleRecap(msg)) continue
+        const ids = extractCanvasId(msg.text ?? '')
+        if (!ids) continue
+        const canvasMd = canvases[ids.fileId]
+        if (typeof canvasMd !== 'string') {
+          console.warn(`⚠️  No canvas markdown for ${ids.fileId} in dump; skipping.`)
+          continue
+        }
+        const channel = readChannel(msg)
+        out.push({
+          channelId: channel.id,
+          channelName: channel.name,
+          messageTs: typeof msg.ts === 'string' ? msg.ts : '',
+          teamId: ids.teamId,
+          fileId: ids.fileId,
+          huddleDate: tsToIsoDate(msg.ts),
+          canvasMarkdown: canvasMd
+        })
+      }
+      return out
+    }
+
+    throw new Error(
+      'Slack huddle dump must be either a top-level array of huddles or an object with `messages` + `canvases` keys'
+    )
+  }
+}
+
+function normalizePreResolvedHuddle(m: any, i: number): RawHuddle {
+  if (!m || typeof m !== 'object') {
+    throw new Error(`Huddle ${i} is not an object`)
+  }
+  const required = ['channel_id', 'channel_name', 'message_ts', 'team_id', 'file_id', 'canvas_markdown']
+  for (const f of required) {
+    if (typeof m[f] !== 'string' || m[f].length === 0) {
+      throw new Error(
+        `Huddle ${i} missing required string field "${f}": ${JSON.stringify(m).slice(0, 200)}`
+      )
+    }
+  }
+  return {
+    channelId: m.channel_id,
+    channelName: m.channel_name,
+    messageTs: m.message_ts,
+    teamId: m.team_id,
+    fileId: m.file_id,
+    huddleDate: typeof m.huddle_date === 'string' ? m.huddle_date : tsToIsoDate(m.message_ts),
+    canvasMarkdown: m.canvas_markdown
+  }
+}
+
+function readChannel(msg: SlackSearchMessage): { id: string; name: string } {
+  if (msg && typeof msg.channel === 'object' && msg.channel) {
+    return {
+      id: typeof msg.channel.id === 'string' ? msg.channel.id : '',
+      name: typeof msg.channel.name === 'string' ? msg.channel.name : ''
+    }
+  }
+  return {
+    id: msg.channel_id ?? (typeof msg.channel === 'string' ? msg.channel : ''),
+    name: msg.channel_name ?? ''
+  }
+}
+
+function tsToIsoDate(ts: any): string | undefined {
+  if (typeof ts !== 'string' && typeof ts !== 'number') return undefined
+  const num = typeof ts === 'string' ? parseFloat(ts) : ts
+  if (!isFinite(num) || num <= 0) return undefined
+  // Slack ts is epoch seconds with sub-second precision; new Date() takes ms.
+  return new Date(num * 1000).toISOString()
+}
+
+/**
+ * LiveSlackSource — uses caller-supplied callbacks that wrap the Slack MCP
+ * tools. The callbacks let us avoid importing any MCP-runtime modules into
+ * this script (which would only be reachable from a Claude Code session
+ * anyway).
+ */
+export class LiveSlackSource implements SlackHuddleSource {
+  constructor(
+    private deps: {
+      searchPublic: (
+        query: string,
+        opts: { limit: number; sort?: string }
+      ) => Promise<{ messages: SlackSearchMessage[] }>
+      readCanvas: (
+        canvasId: string
+      ) => Promise<{ canvas_markdown: string } | string>
+    },
+    private opts: { searchQuery: string; searchLimit: number }
+  ) {}
+
+  async list(): Promise<RawHuddle[]> {
+    const { messages } = await this.deps.searchPublic(this.opts.searchQuery, {
+      limit: this.opts.searchLimit,
+      sort: 'timestamp'
+    })
+    if (!Array.isArray(messages)) {
+      throw new Error('LiveSlackSource: searchPublic returned no messages array')
+    }
+
+    const out: RawHuddle[] = []
+    for (const msg of messages) {
+      if (!isSlackbotHuddleRecap(msg)) continue
+      const ids = extractCanvasId(msg.text ?? '')
+      if (!ids) continue
+
+      let canvasMd: string
+      try {
+        const canvas = await this.deps.readCanvas(ids.fileId)
+        if (typeof canvas === 'string') {
+          canvasMd = canvas
+        } else if (canvas && typeof canvas.canvas_markdown === 'string') {
+          canvasMd = canvas.canvas_markdown
+        } else {
+          console.warn(
+            `⚠️  Canvas ${ids.fileId} returned unexpected shape from Slack MCP — skipping.`
+          )
+          continue
+        }
+      } catch (e) {
+        // Failed canvas fetch is non-fatal — log and skip THIS huddle.
+        console.warn(
+          `⚠️  Failed to read canvas ${ids.fileId}: ${e instanceof Error ? e.message : String(e)} — skipping.`
+        )
+        continue
+      }
+
+      const channel = readChannel(msg)
+      out.push({
+        channelId: channel.id,
+        channelName: channel.name,
+        messageTs: typeof msg.ts === 'string' ? msg.ts : '',
+        teamId: ids.teamId,
+        fileId: ids.fileId,
+        huddleDate: tsToIsoDate(msg.ts),
+        canvasMarkdown: canvasMd
+      })
+    }
+    return out
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Distillation — Haiku 4.5 via @anthropic-ai/sdk
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface DistillerLike {
+  distill(huddle: RawHuddle, workspace: string): Promise<DistilledHuddle>
+}
+
+export class HaikuDistiller implements DistillerLike {
+  private client: Anthropic
+  private model: string
+
+  constructor(apiKey: string, model: string) {
+    this.client = new Anthropic({ apiKey })
+    this.model = model
+  }
+
+  async distill(huddle: RawHuddle, workspace: string): Promise<DistilledHuddle> {
+    const { system, user } = buildDistillPrompt({
+      channelName: huddle.channelName,
+      huddleDate: huddle.huddleDate,
+      canvasMarkdown: huddle.canvasMarkdown,
+      workspace
+    })
+
+    const resp = await this.client.messages.create({
+      model: this.model,
+      max_tokens: 2048,
+      system,
+      messages: [{ role: 'user', content: user }]
+    })
+
+    const block = resp.content?.[0] as any
+    const text = block?.type === 'text' ? block.text : ''
+    return parseDistilledResponse(text)
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Subject + slug helpers
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Slug: lowercased channel name, alnum + dashes only. */
+export function slugifyChannel(channelName: string): string {
+  return (channelName || 'unknown')
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '') || 'unknown'
+}
+
+/** "Slack.huddle.<channel-slug>.<YYYY-MM-DD>" — the subject facet for a huddle. */
+export function buildHuddleSubject(huddle: RawHuddle): string {
+  const channelSlug = slugifyChannel(huddle.channelName)
+  const date = huddle.huddleDate ? huddle.huddleDate.slice(0, 10) : 'unknown-date'
+  return `Slack.huddle.${channelSlug}.${date}`
+}
+
+/** "slack://canvas/<team_id>/<file_id>" — canonical source-doc URI. */
+export function buildSourceDoc(huddle: RawHuddle): string {
+  return `slack://canvas/${huddle.teamId}/${huddle.fileId}`
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Importer driver
+// ─────────────────────────────────────────────────────────────────────────
+
+interface ImporterDeps {
+  source: SlackHuddleSource
+  distiller: DistillerLike
+  /** null in --dry-run only. */
+  kms: MinimalMcpClient | null
+  opts: CliOptions
+  log: SyncLog
+}
+
+interface SingleHuddleResult {
+  status: 'ok' | 'skipped' | 'failed' | 'dedup_refused'
+  huddle: RawHuddle
+  reason?: string
+  candidates?: any[]
+  summaryEntryId?: string
+  claimEntryIds?: string[]
+}
+
+/**
+ * Process a single huddle end-to-end. Public so tests can target one at a time.
+ */
+export async function processHuddle(
+  huddle: RawHuddle,
+  deps: ImporterDeps
+): Promise<SingleHuddleResult> {
+  if (deps.log.completed.includes(huddle.fileId)) {
+    return { status: 'skipped', huddle, reason: 'already in sync log' }
+  }
+
+  // Distill
+  let distilled: DistilledHuddle
+  try {
+    distilled = await deps.distiller.distill(huddle, deps.opts.workspace)
+  } catch (e) {
+    return {
+      status: 'failed',
+      huddle,
+      reason: `distill: ${e instanceof Error ? e.message : String(e)}`
+    }
+  }
+
+  if (deps.opts.dryRun) {
+    console.log(
+      `📝 [dry-run] would write summary + ${distilled.claims.length} claims for ` +
+        `huddle in #${huddle.channelName} (${huddle.fileId})`
+    )
+    return {
+      status: 'ok',
+      huddle,
+      summaryEntryId: 'dry-run-summary',
+      claimEntryIds: distilled.claims.map((_, i) => `dry-run-claim-${i}`)
+    }
+  }
+
+  if (!deps.kms) {
+    return { status: 'failed', huddle, reason: 'no KMS client and not dry-run (internal error)' }
+  }
+
+  // Step 1: write whole-huddle summary entry
+  const subject = buildHuddleSubject(huddle)
+  const sourceDoc = buildSourceDoc(huddle)
+  const summaryArgs = {
+    content: distilled.summary,
+    contentType: 'memory' as const,
+    source: 'personal' as const,
+    userId: deps.opts.userId,
+    metadata: {
+      subject,
+      source: 'slack_huddle',
+      source_doc: sourceDoc,
+      slack_workspace: deps.opts.workspace,
+      slack_channel: huddle.channelId,
+      slack_channel_name: huddle.channelName,
+      slack_message_ts: huddle.messageTs,
+      slack_team_id: huddle.teamId,
+      slack_canvas_id: huddle.fileId,
+      huddle_date: huddle.huddleDate
+    }
+  }
+
+  let summaryResult: any
+  try {
+    summaryResult = await deps.kms.callTool('unified_store', summaryArgs)
+  } catch (e) {
+    return {
+      status: 'failed',
+      huddle,
+      reason: `summary write: ${e instanceof Error ? e.message : String(e)}`
+    }
+  }
+
+  // Dedup-gate refusal — non-fatal; log and skip claims for this huddle.
+  if (summaryResult?.status === 'dedup_required') {
+    return {
+      status: 'dedup_refused',
+      huddle,
+      candidates: summaryResult.candidates ?? [],
+      reason: summaryResult.message ?? 'dedup_required'
+    }
+  }
+  if (!summaryResult?.success || typeof summaryResult.id !== 'string') {
+    return {
+      status: 'failed',
+      huddle,
+      reason: `summary write returned unexpected shape: ${JSON.stringify(summaryResult).slice(0, 300)}`
+    }
+  }
+
+  const summaryEntryId = summaryResult.id as string
+
+  // Step 2: write each claim with metadata.related_to=[summaryEntryId]
+  const claimEntryIds: string[] = []
+  const claimFailures: string[] = []
+  for (let ci = 0; ci < distilled.claims.length; ci++) {
+    const claim = distilled.claims[ci]
+    const claimArgs = {
+      content: claim.content,
+      contentType: mapClaimTypeToContentType(claim.type),
+      source: 'personal' as const,
+      userId: deps.opts.userId,
+      metadata: {
+        subject: `${subject}.claim_${ci}`,
+        source: 'slack_huddle',
+        source_doc: sourceDoc,
+        slack_workspace: deps.opts.workspace,
+        slack_channel: huddle.channelId,
+        slack_channel_name: huddle.channelName,
+        slack_message_ts: huddle.messageTs,
+        slack_team_id: huddle.teamId,
+        slack_canvas_id: huddle.fileId,
+        huddle_date: huddle.huddleDate,
+        ob1_type: claim.type,
+        qualitative_confidence: claim.qualitative_confidence,
+        topics: claim.topics,
+        people: claim.people,
+        related_to: [summaryEntryId]
+      }
+    }
+
+    try {
+      const claimResult: any = await deps.kms.callTool('unified_store', claimArgs)
+      if (claimResult?.status === 'dedup_required') {
+        claimFailures.push(
+          `claim ${ci} (${claim.type}): dedup_refused against ${claimResult.candidates?.[0]?.id ?? '?'}`
+        )
+        continue
+      }
+      if (!claimResult?.success || typeof claimResult.id !== 'string') {
+        claimFailures.push(`claim ${ci} (${claim.type}): unexpected response`)
+        continue
+      }
+      claimEntryIds.push(claimResult.id)
+    } catch (e) {
+      claimFailures.push(
+        `claim ${ci} (${claim.type}): ${e instanceof Error ? e.message : String(e)}`
+      )
+    }
+  }
+
+  if (claimFailures.length > 0) {
+    console.warn(
+      `⚠️  Huddle in #${huddle.channelName} (${huddle.fileId}) had ` +
+        `${claimFailures.length}/${distilled.claims.length} claim failure(s):\n  ${claimFailures.join('\n  ')}`
+    )
+  }
+
+  return {
+    status: 'ok',
+    huddle,
+    summaryEntryId,
+    claimEntryIds
+  }
+}
+
+export async function runImport(deps: ImporterDeps): Promise<ImportReport> {
+  const huddlesAll = await deps.source.list()
+  const huddles = deps.opts.maxHuddles
+    ? huddlesAll.slice(0, deps.opts.maxHuddles)
+    : huddlesAll
+
+  console.log(
+    `📥 Loaded ${huddles.length} huddle(s) from source ` +
+      `(workspace=${deps.opts.workspace}, source=${deps.opts.source})`
+  )
+
+  const report: ImportReport = {
+    totalHuddles: huddles.length,
+    summaries: 0,
+    claims: 0,
+    skipped: [],
+    failed: [],
+    dedupRefused: []
+  }
+
+  const t0 = Date.now()
+  for (let i = 0; i < huddles.length; i++) {
+    const huddle = huddles[i]
+    const result = await processHuddle(huddle, deps)
+
+    switch (result.status) {
+      case 'ok':
+        report.summaries += 1
+        report.claims += result.claimEntryIds?.length ?? 0
+        deps.log.completed.push(huddle.fileId)
+        if (!deps.opts.dryRun) saveSyncLog(deps.opts.syncLogPath, deps.log)
+        break
+      case 'skipped':
+        report.skipped.push({ fileId: huddle.fileId, channel: huddle.channelName })
+        break
+      case 'failed':
+        report.failed.push({
+          fileId: huddle.fileId,
+          channel: huddle.channelName,
+          reason: result.reason ?? 'unknown'
+        })
+        console.error(
+          `❌ Huddle ${huddle.fileId} in #${huddle.channelName} failed: ${result.reason}`
+        )
+        break
+      case 'dedup_refused':
+        report.dedupRefused.push({
+          fileId: huddle.fileId,
+          channel: huddle.channelName,
+          candidates: result.candidates ?? []
+        })
+        console.warn(
+          `🛑 Huddle ${huddle.fileId} in #${huddle.channelName} refused by dedup gate ` +
+            `against ${result.candidates?.[0]?.id ?? '?'}`
+        )
+        break
+    }
+
+    if ((i + 1) % 5 === 0 || i === huddles.length - 1) {
+      const elapsedMs = Date.now() - t0
+      const perHuddle = elapsedMs / (i + 1)
+      const remaining = huddles.length - (i + 1)
+      const etaMin = Math.round((perHuddle * remaining) / 60000)
+      console.log(
+        `⏱️  ${i + 1}/${huddles.length} done, ETA ${etaMin}min, last_channel=#${huddle.channelName}`
+      )
+    }
+  }
+
+  return report
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Main
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Distiller used in --dry-run when we still want to walk the whole pipeline.
+ */
+class NoopDistiller implements DistillerLike {
+  async distill(huddle: RawHuddle): Promise<DistilledHuddle> {
+    return {
+      summary: `[dry-run stub] huddle ${huddle.fileId} in #${huddle.channelName} — would distill ${huddle.canvasMarkdown.length} chars`,
+      claims: [
+        {
+          type: 'context',
+          content: `[dry-run stub] context placeholder for huddle in #${huddle.channelName}`,
+          qualitative_confidence: 'tentative',
+          topics: ['dry-run'],
+          people: []
+        }
+      ]
+    }
+  }
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<void> {
+  const opts = parseArgs(argv)
+
+  if (opts.source === 'file' && !opts.input) {
+    console.error('❌ --source file requires --input <file>.')
+    process.exit(2)
+  }
+  if (opts.source === 'live') {
+    // Live mode requires the runtime to inject Slack MCP callbacks via the
+    // exported runImportLive function below. The plain CLI cannot do this.
+    console.error(
+      `❌ --source live cannot be invoked from the bare CLI; it requires the
+   runtime (a Claude Code session with Slack MCP authorized) to call
+   runImportLive() with searchPublic + readCanvas callbacks.
+
+   For unattended runs, use --source file --input <dump.json> after dumping
+   huddles from a Claude Code session via slack_search_public + slack_read_canvas.`
+    )
+    process.exit(2)
+  }
+
+  const apiKey = process.env.ANTHROPIC_API_KEY
+  if (!apiKey && !opts.dryRun) {
+    console.error('❌ ANTHROPIC_API_KEY env var is required (Haiku 4.5 distillation).')
+    console.error('   Set it directly or via doppler. Use --dry-run to skip distillation.')
+    process.exit(2)
+  }
+
+  console.log(`🚀 Slack Huddle → KMS importer starting`)
+  console.log(`   Source:       ${opts.source}`)
+  if (opts.input) console.log(`   Input:        ${opts.input}`)
+  console.log(`   KMS URL:      ${opts.kmsUrl}`)
+  console.log(`   Sync log:     ${opts.syncLogPath}`)
+  console.log(`   User ID:      ${opts.userId}`)
+  console.log(`   Workspace:    ${opts.workspace}`)
+  console.log(`   Model:        ${opts.anthropicModel}`)
+  console.log(`   Dry run:      ${opts.dryRun}`)
+  if (opts.maxHuddles) console.log(`   Cap:          ${opts.maxHuddles} huddles`)
+
+  const source: SlackHuddleSource = new FileSlackSource(opts.input!)
+  const distiller = opts.dryRun
+    ? new NoopDistiller()
+    : new HaikuDistiller(apiKey!, opts.anthropicModel)
+
+  let kms: MinimalMcpClient | null = null
+  if (!opts.dryRun) {
+    let bearer: string | null = null
+    try {
+      bearer = await fetchBearerTokenIfNeeded(opts)
+    } catch (e) {
+      console.error(`❌ Could not obtain KMS bearer token: ${e instanceof Error ? e.message : e}`)
+      process.exit(2)
+    }
+    kms = new MinimalMcpClient(opts.kmsUrl, bearer)
+    await kms.initialize()
+    console.log(`🔌 Connected to KMS, session active.`)
+  }
+
+  const log = loadSyncLog(opts.syncLogPath)
+  console.log(`📓 Sync log has ${log.completed.length} previously-completed canvas(es).`)
+
+  const report = await runImport({ source, distiller, kms, opts, log })
+
+  if (kms) await kms.close()
+
+  console.log(`\n══════════════ FINAL REPORT ══════════════`)
+  console.log(`Total huddles:        ${report.totalHuddles}`)
+  console.log(`Summary entries:      ${report.summaries}`)
+  console.log(`Claim entries:        ${report.claims}`)
+  console.log(`Skipped (sync log):   ${report.skipped.length}`)
+  console.log(`Dedup refused:        ${report.dedupRefused.length}`)
+  console.log(`Failed:               ${report.failed.length}`)
+  if (report.failed.length > 0) {
+    console.log(`\nFailures:`)
+    for (const f of report.failed) {
+      console.log(`  - #${f.channel} (${f.fileId}): ${f.reason}`)
+    }
+  }
+  if (report.dedupRefused.length > 0) {
+    console.log(`\nDedup refused (already in KMS):`)
+    for (const d of report.dedupRefused) {
+      console.log(`  - #${d.channel} (${d.fileId}) → top candidate ${d.candidates[0]?.id ?? '?'}`)
+    }
+  }
+  console.log(`\n✅ Done.`)
+
+  // Non-zero exit if any huddle hard-failed (dedup refusal is informational).
+  process.exit(report.failed.length > 0 ? 1 : 0)
+}
+
+/**
+ * Programmatic live entrypoint — for callers (a Claude Code session) that
+ * have the Slack MCP tools available and want to wire them in. The CLI can
+ * not invoke this path; it has no way to reach the Slack MCP from the bare
+ * Node process.
+ *
+ * Usage from a Claude Code TS evaluator:
+ *
+ *   await runImportLive({
+ *     opts: parseArgs(['--source', 'live', '--bearer-token', '...']),
+ *     searchPublic: (q, o) => mcp__Slack__slack_search_public({ query: q, limit: o.limit, sort: o.sort }),
+ *     readCanvas:   (id) => mcp__Slack__slack_read_canvas({ canvas_id: id })
+ *   })
+ */
+export async function runImportLive(args: {
+  opts: CliOptions
+  searchPublic: (
+    query: string,
+    opts: { limit: number; sort?: string }
+  ) => Promise<{ messages: SlackSearchMessage[] }>
+  readCanvas: (canvasId: string) => Promise<{ canvas_markdown: string } | string>
+  apiKey?: string
+}): Promise<ImportReport> {
+  const { opts, searchPublic, readCanvas } = args
+  const apiKey = args.apiKey ?? process.env.ANTHROPIC_API_KEY ?? ''
+  if (!apiKey && !opts.dryRun) {
+    throw new Error('ANTHROPIC_API_KEY required (or pass apiKey argument). Use opts.dryRun=true to skip.')
+  }
+  const source = new LiveSlackSource(
+    { searchPublic, readCanvas },
+    { searchQuery: opts.searchQuery, searchLimit: opts.searchLimit }
+  )
+  const distiller = opts.dryRun
+    ? new NoopDistiller()
+    : new HaikuDistiller(apiKey, opts.anthropicModel)
+  let kms: MinimalMcpClient | null = null
+  if (!opts.dryRun) {
+    const bearer = await fetchBearerTokenIfNeeded(opts)
+    kms = new MinimalMcpClient(opts.kmsUrl, bearer)
+    await kms.initialize()
+  }
+  const log = loadSyncLog(opts.syncLogPath)
+  const report = await runImport({ source, distiller, kms, opts, log })
+  if (kms) await kms.close()
+  return report
+}

--- a/src/scripts/slack-huddle-distill-prompt.ts
+++ b/src/scripts/slack-huddle-distill-prompt.ts
@@ -1,0 +1,276 @@
+/**
+ * Slack Huddle → KMS distillation prompt and types.
+ *
+ * The Haiku 4.5 (claude-haiku-4-5-20251001) call must return a JSON object
+ * matching `DistilledHuddle`. The prompt enforces:
+ *   - One ~150–300 word `summary` (the whole-huddle entry's content)
+ *   - 2–5 `claims`, each a self-contained typed thought (OB1 6-type taxonomy)
+ *   - The OB1 "curate, don't dump" principle: each claim must stand alone
+ *     without the original canvas context.
+ *
+ * Kept as a separate module so the prompt + JSON validation logic is
+ * unit-testable without a network call, and so the prompt text can be
+ * reviewed/diffed independently of the importer driver.
+ *
+ * Field names mirror PR #75's md-corpus importer (`qualitative_confidence`)
+ * for cross-importer consistency.
+ */
+
+/**
+ * OB1 6-type taxonomy. Maps to KMSmcp contentType
+ * (memory|insight|fact|procedure|pattern|relationship) via
+ * `mapClaimTypeToContentType` below.
+ */
+export type Ob1ClaimType =
+  | 'decision'
+  | 'preference'
+  | 'learning'
+  | 'context'
+  | 'brainstorm'
+  | 'reference'
+
+/** Distillation confidence — separate from the numeric KMS confidence field. */
+export type QualitativeConfidence = 'firm' | 'tentative' | 'exploring'
+
+export interface DistilledClaim {
+  /** OB1 type. Maps to KMSmcp contentType. */
+  type: Ob1ClaimType
+  /** Self-contained, ~1–3 sentence statement. Must make sense in isolation. */
+  content: string
+  /** firm | tentative | exploring. */
+  qualitative_confidence: QualitativeConfidence
+  /** Free-form topic tags (e.g. ["Tengo", "team-norms"]). */
+  topics: string[]
+  /** Names of people referenced (e.g. ["Rich", "Kathy"]). Empty if none. */
+  people: string[]
+}
+
+export interface DistilledHuddle {
+  /** ~150–300 word whole-huddle summary used as the huddle entry body. */
+  summary: string
+  /** 2–5 self-contained typed thoughts. */
+  claims: DistilledClaim[]
+}
+
+/**
+ * Map OB1 claim types to KMSmcp contentTypes.
+ *
+ * decision / brainstorm / learning → 'insight'
+ * preference / context             → 'memory'
+ * reference                        → 'procedure'
+ *
+ * If the OB1 type is unrecognized (forward-compatibility), default to 'memory'.
+ *
+ * Note: this matches PR #75 (md-corpus) where `learning → insight`,
+ * which differs from PR #74's Granola mapping (`learning → fact`).
+ * Slack huddles are conversational/decisional artifacts more akin to
+ * curated documents than to passive observation, so PR #75's mapping fits.
+ */
+export function mapClaimTypeToContentType(
+  ob1Type: Ob1ClaimType | string
+): 'memory' | 'insight' | 'fact' | 'procedure' | 'pattern' | 'relationship' {
+  switch (ob1Type) {
+    case 'decision':
+    case 'brainstorm':
+    case 'learning':
+      return 'insight'
+    case 'preference':
+    case 'context':
+      return 'memory'
+    case 'reference':
+      return 'procedure'
+    default:
+      return 'memory'
+  }
+}
+
+/**
+ * Build the distillation system + user prompt pair.
+ *
+ * The system prompt locks the schema and the curate-don't-dump rule. The user
+ * prompt carries the huddle metadata + canvas markdown.
+ */
+export function buildDistillPrompt(huddle: {
+  channelName: string
+  huddleDate?: string
+  canvasMarkdown: string
+  workspace?: string
+}): { system: string; user: string } {
+  const system = `You distill Slack huddle AI-notes into structured JSON for a personal knowledge management system.
+
+A Slack huddle is a real-time voice/video meeting; the input below is the AI-generated canvas notes, NOT a verbatim transcript. Treat decisions and stated preferences as deliberate.
+
+Return ONLY a JSON object matching this shape (no prose, no code fences):
+
+{
+  "summary": string,                  // 150-300 words. Whole-huddle summary. Self-contained — readable without the canvas. Include who, what, why.
+  "claims": [
+    {
+      "type": "decision" | "preference" | "learning" | "context" | "brainstorm" | "reference",
+      "content": string,              // 1-3 self-contained sentences. Must make sense WITHOUT the canvas.
+      "qualitative_confidence": "firm" | "tentative" | "exploring",
+      "topics": string[],             // short topic tags
+      "people": string[]              // people mentioned by name
+    }
+  ]
+}
+
+Rules:
+1. Produce 2 to 5 claims. Fewer is fine if the huddle was thin; never produce more than 5.
+2. Each claim must be a self-contained statement that makes sense without the original canvas context.
+3. Curate, don't dump. Skip pleasantries, scheduling chatter, and content that won't matter in 6 months.
+4. Use "decision" for committed choices, "preference" for stated likes/dislikes/ways-of-working, "learning" for new factual knowledge surfaced in the huddle, "context" for situational background that informs future decisions, "brainstorm" for ideas not yet committed, "reference" for pointers to external resources/how-to.
+5. "qualitative_confidence" reflects how firm the speaker(s) sounded: "firm" = decided/known, "tentative" = leaning toward, "exploring" = still mulling.
+6. Output MUST be valid JSON. No markdown. No commentary. No trailing text.`
+
+  const dateLine = huddle.huddleDate ? `\nHuddle date: ${huddle.huddleDate}` : ''
+  const wsLine = huddle.workspace ? `\nWorkspace: ${huddle.workspace}` : ''
+  const user = `Slack channel: #${huddle.channelName}${wsLine}${dateLine}
+
+Canvas (AI huddle notes, markdown):
+${huddle.canvasMarkdown}`
+
+  return { system, user }
+}
+
+/**
+ * Parse and validate a Haiku response. Throws on malformed JSON or schema
+ * violations (so the importer driver can log + skip the huddle cleanly).
+ *
+ * Strips common LLM artifacts: ```json fences, leading/trailing prose, BOM.
+ */
+export function parseDistilledResponse(raw: string): DistilledHuddle {
+  if (typeof raw !== 'string' || raw.trim().length === 0) {
+    throw new Error('Empty distillation response')
+  }
+
+  // Strip BOM
+  let text = raw.replace(/^﻿/, '').trim()
+
+  // Strip ```json ... ``` fences if Haiku wrapped them despite instructions
+  const fenceMatch = text.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i)
+  if (fenceMatch) {
+    text = fenceMatch[1].trim()
+  }
+
+  // If there's leading prose, try to find the first { and last }
+  if (!text.startsWith('{')) {
+    const first = text.indexOf('{')
+    const last = text.lastIndexOf('}')
+    if (first >= 0 && last > first) {
+      text = text.slice(first, last + 1)
+    }
+  }
+
+  let parsed: any
+  try {
+    parsed = JSON.parse(text)
+  } catch (e) {
+    throw new Error(
+      `Distillation response is not valid JSON: ${e instanceof Error ? e.message : String(e)}`
+    )
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('Distillation response is not an object')
+  }
+  if (typeof parsed.summary !== 'string' || parsed.summary.trim().length === 0) {
+    throw new Error('Distillation response missing string `summary`')
+  }
+  if (!Array.isArray(parsed.claims)) {
+    throw new Error('Distillation response missing `claims` array')
+  }
+  if (parsed.claims.length === 0) {
+    throw new Error('Distillation response has zero claims (need 2–5)')
+  }
+  if (parsed.claims.length > 5) {
+    // Soft-cap: keep first 5 rather than fail the whole huddle.
+    parsed.claims = parsed.claims.slice(0, 5)
+  }
+
+  const validTypes: Ob1ClaimType[] = [
+    'decision',
+    'preference',
+    'learning',
+    'context',
+    'brainstorm',
+    'reference'
+  ]
+  const validConfidence: QualitativeConfidence[] = ['firm', 'tentative', 'exploring']
+
+  const claims: DistilledClaim[] = parsed.claims.map((c: any, i: number) => {
+    if (!c || typeof c !== 'object') {
+      throw new Error(`Claim ${i} is not an object`)
+    }
+    if (!validTypes.includes(c.type)) {
+      throw new Error(`Claim ${i} has invalid type: ${c.type}`)
+    }
+    if (typeof c.content !== 'string' || c.content.trim().length === 0) {
+      throw new Error(`Claim ${i} has empty content`)
+    }
+    if (!validConfidence.includes(c.qualitative_confidence)) {
+      throw new Error(`Claim ${i} has invalid qualitative_confidence: ${c.qualitative_confidence}`)
+    }
+    return {
+      type: c.type,
+      content: c.content.trim(),
+      qualitative_confidence: c.qualitative_confidence,
+      topics: Array.isArray(c.topics) ? c.topics.filter((t: any) => typeof t === 'string') : [],
+      people: Array.isArray(c.people) ? c.people.filter((p: any) => typeof p === 'string') : []
+    }
+  })
+
+  return {
+    summary: parsed.summary.trim(),
+    claims
+  }
+}
+
+/**
+ * Slack canvas-id extractor.
+ *
+ * Slackbot huddle recap message body looks like:
+ *   "AI huddle notes are ready. Edit, share, ... :chipmunk:
+ *    <https://projcaribou.slack.com/docs/T0123ABCD/F4567WXYZ|View AI Notes>"
+ *
+ * The link form is Slack's `<url|label>` mrkdwn. The canvas file ID is the
+ * second path segment under /docs/. The first is the team_id.
+ *
+ * Returns `{ teamId, fileId }` or `null` if no match.
+ */
+export function extractCanvasId(
+  messageText: string
+): { teamId: string; fileId: string } | null {
+  if (typeof messageText !== 'string' || messageText.length === 0) return null
+  // Match the docs/<team_id>/<file_id> path. Tolerate either a bare URL or
+  // mrkdwn `<url|label>` wrapping. Team IDs and file IDs in Slack are
+  // alphanumeric and start with T / F respectively, but we accept any
+  // [A-Z0-9]+ to stay forward-compatible.
+  const re = /slack\.com\/docs\/([A-Z0-9]+)\/([A-Z0-9]+)/
+  const m = messageText.match(re)
+  if (!m) return null
+  return { teamId: m[1], fileId: m[2] }
+}
+
+/**
+ * Slackbot recap detector.
+ *
+ * The recap message:
+ *   - Comes from user "USLACKBOT" (the canonical Slackbot user id).
+ *   - Body starts with the canonical phrase "AI huddle notes are ready".
+ *
+ * We accept either by-id ("USLACKBOT") or by-name ("Slackbot") because
+ * the search-results JSON shape can vary by client.
+ */
+export function isSlackbotHuddleRecap(msg: {
+  user?: string
+  username?: string
+  text?: string
+}): boolean {
+  if (!msg || typeof msg !== 'object') return false
+  const text = typeof msg.text === 'string' ? msg.text : ''
+  if (!text.toLowerCase().includes('ai huddle notes are ready')) return false
+  const userId = typeof msg.user === 'string' ? msg.user.toUpperCase() : ''
+  const userName = typeof msg.username === 'string' ? msg.username.toLowerCase() : ''
+  return userId === 'USLACKBOT' || userName === 'slackbot'
+}

--- a/src/scripts/slack-huddle-distill-prompt.ts
+++ b/src/scripts/slack-huddle-distill-prompt.ts
@@ -246,7 +246,7 @@ export function extractCanvasId(
   // mrkdwn `<url|label>` wrapping. Team IDs and file IDs in Slack are
   // alphanumeric and start with T / F respectively, but we accept any
   // [A-Z0-9]+ to stay forward-compatible.
-  const re = /slack\.com\/docs\/([A-Z0-9]+)\/([A-Z0-9]+)/
+  const re = /slack\.com\/docs\/([a-zA-Z0-9]+)\/([a-zA-Z0-9]+)/i
   const m = messageText.match(re)
   if (!m) return null
   return { teamId: m[1], fileId: m[2] }


### PR DESCRIPTION
## Summary

Adds an importer that turns Slack huddle AI-notes (the canvas Slackbot
posts after a huddle ends) into KMS entries via the dual-write pattern,
mirroring PR #74's Granola architecture.

- ONE whole-huddle `memory` entry per huddle (distilled summary, not raw canvas markdown), tagged with `metadata.subject="Slack.huddle.<channel>.<date>"` and `metadata.source_doc="slack://canvas/<team_id>/<file_id>"`.
- 2–5 typed claim entries per huddle (OB1 6-type taxonomy → KMSmcp `contentType`), each linking back via `metadata.related_to=[<summary_id>]` and sharing the same `source_doc` pointer.
- Both write paths route through `unified_store` so the dedup gate fires naturally — overlap with Granola transcripts of the same call gets caught upstream (`action=complement` or duplicate).

## Architecture

Source abstraction (mirrors PR #74's `GranolaSource`):

- **`LiveSlackSource`** — dependency-injected `slack_search_public` + `slack_read_canvas` callbacks. Production path; runs from a Claude Code session that has the Slack MCP authorized. Exposed via `runImportLive()` for in-session callers.
- **`FileSlackSource`** — reads pre-dumped JSON for cron/launchd contexts. Accepts both a pre-resolved-array shape AND a `{ messages, canvases }` shape so the same script handles fast cron paths and live agent dumps.

Distillation: Claude Haiku 4.5 (`claude-haiku-4-5-20251001`) via `@anthropic-ai/sdk` (already in `package.json`).

Sync log: `~/.kms-slack-huddle-sync.json` keyed by `canvas_file_id` for idempotent re-runs. Failed huddles are NOT added to the log so they retry on next run.

## Files

All in `src/scripts/` (PR #75's pattern, for ts-jest + `import.meta` compat):

- `src/scripts/slack-huddle-distill-prompt.ts` — Haiku 4.5 prompt, JSON validator, OB1→contentType map, canvas-id regex, Slackbot recap detector.
- `src/scripts/import-slack-huddles.ts` — CLI driver, `MinimalMcpClient` (StreamableHTTP), OAuth client-credentials fallback, `runImport`/`processHuddle`/`runImportLive` entrypoints.
- `src/scripts/import-slack-huddles-cli.ts` — thin CLI shim (avoids top-level `import.meta` so the main module stays unit-testable under ts-jest CJS loader).
- `src/__tests__/import-slack-huddles.test.ts` — 66 tests.
- `.gitignore` — added `!src/scripts/` (the bare `scripts/` rule was globbing to any `scripts/` directory).

## Sample CLI invocation

```bash
# Cron path: agent dumps huddles to JSON, then this script imports.
KMS_BEARER_TOKEN=eyJ... \
  node dist/scripts/import-slack-huddles-cli.js \
  --input ~/slack-huddles-dump.json \
  --workspace tengo

# Smoke test (no Anthropic, no KMS writes — walks the pipeline):
node dist/scripts/import-slack-huddles-cli.js --input ~/slack-huddles-dump.json --dry-run

# Live path (from a Claude Code session via runImportLive()):
import { parseArgs, runImportLive } from './src/scripts/import-slack-huddles.ts'
await runImportLive({
  opts: parseArgs(['--source', 'live', '--bearer-token', '...']),
  searchPublic: (q, o) => mcp__Slack__slack_search_public({ query: q, limit: o.limit, sort: o.sort }),
  readCanvas:   (id) => mcp__Slack__slack_read_canvas({ canvas_id: id })
})
```

The `messages+canvases` JSON shape lets a one-shot agent dump matter
once and let cron handle the import:

```json
{
  "messages": [
    { "user": "USLACKBOT", "ts": "...", "text": "AI huddle notes are ready... <https://x.slack.com/docs/T0/F1|...>", "channel": { "id": "C1", "name": "core-values" } }
  ],
  "canvases": { "F1": "# Core Values huddle\n..." }
}
```

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] `npx jest` — 145/145 pass (was 79 baseline; +66 new)
- [x] CLI `--help` renders
- [x] CLI `--dry-run --input <file>` walks pipeline end-to-end with two sample huddles
- [x] CLI rejects `--source bogus` and unknown flags
- [x] CLI exits 2 when `--input` is missing in file mode
- [ ] **Manual production verification** — once merged, run a real dump from `projcaribou.slack.com` and confirm the dedup gate catches Granola overlap

## What was NOT touched

Per the constraint list, none of these in-flight PR surfaces were modified:
`SparrowDBStorage.ts`, `Mem0Storage.ts`, `EmbeddingService.ts`, `UnifiedStoreTool.ts`. `@anthropic-ai/sdk` was already a dependency from PR #74 — no version bump.

## Notes / ambiguity resolutions

1. **`learning → insight` (not `fact`).** PR #74 maps `learning → fact`, but PR #75 maps `learning → insight`. Slack huddles are conversational/decisional artifacts more akin to PR #75's curated documents than to PR #74's passive-observation transcripts, so I used PR #75's mapping. Easy to flip if desired.
2. **`qualitative_confidence` over `confidence`.** Aligned with PR #75's field name (vs PR #74's `confidence`) since the importer lives in `src/scripts/` like the md-corpus importer. Cross-importer schema consistency.
3. **Channel slug uses `_` as a word char.** `slugifyChannel('OPS_Daily Sync!')` → `ops_daily-sync` (not `ops-daily-sync`). Slack already separates words with `-`, so I preserved underscores rather than collapse them.
4. **Subject falls back to `unknown-date` when `huddle_date` missing.** Better than mid-build crash; corrected on re-import once the dump fixes the date.
5. **`--source live` from the bare CLI exits with a helpful message.** It can't reach the Slack MCP from a plain Node process; the `runImportLive()` programmatic entry is the seam for in-session callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)