### PR TITLE
feat(skills): KMSmcp Skills Layer — 5 portable behavioral protocols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ scripts/
 !tsconfig.json
 !tsconfig.test.json
 !test-fixtures/*.json
+!skills/**/*.json
 *.sh
 !examples/**/*.sh
 *.tf

--- a/skills/.claude-plugin/plugin.json
+++ b/skills/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "kms-skills",
+  "description": "Five portable behavioral protocols for Richard's Personal KMS — auto-capture, meeting-synthesis, reconcile-pass, search-first, trust-boundaries. Codifies the OB1 Pattern 1 outer-loop model: dumb storage primitive (KMSmcp) plus skill-layer curation policy that works across Claude Code, Cowork, claude.ai web, iOS, and Codex. Connects to KMS at https://kms.yaker.org/mcp.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Richard Yaker",
+    "email": "ryaker@yaker.org"
+  },
+  "homepage": "https://github.com/ryaker/KMSmcp",
+  "repository": "https://github.com/ryaker/KMSmcp",
+  "license": "MIT",
+  "keywords": [
+    "kms",
+    "memory",
+    "knowledge-management",
+    "behavioral-skills",
+    "ob1-pattern-1",
+    "dedup-gate",
+    "supersede"
+  ]
+}

--- a/skills/README.md
+++ b/skills/README.md
@@ -38,7 +38,7 @@ Portable behavioral protocols for Richard's Personal KMS — deployable across C
 
 ### Claude Code — install all 5 skills personally
 ```bash
-SKILLS_SRC=/Users/ryaker/Dev/KMSmcp/skills
+SKILLS_SRC=$(pwd)/skills
 for s in kms-auto-capture kms-meeting-synthesis kms-reconcile-pass kms-search-first kms-trust-boundaries; do
   mkdir -p ~/.claude/skills/$s
   cp $SKILLS_SRC/$s/SKILL.md ~/.claude/skills/$s/SKILL.md
@@ -47,10 +47,10 @@ done
 
 ### Claude Code — symlink at project scope (so skills track repo updates)
 ```bash
-SKILLS_SRC=/Users/ryaker/Dev/KMSmcp/skills
-mkdir -p /Users/ryaker/Dev/KMSmcp/.claude/skills
+SKILLS_SRC=$(pwd)/skills
+mkdir -p $(pwd)/.claude/skills
 for s in kms-auto-capture kms-meeting-synthesis kms-reconcile-pass kms-search-first kms-trust-boundaries; do
-  ln -sfn $SKILLS_SRC/$s /Users/ryaker/Dev/KMSmcp/.claude/skills/$s
+  ln -sfn $SKILLS_SRC/$s $(pwd)/.claude/skills/$s
 done
 ```
 
@@ -105,7 +105,7 @@ Until then, install via:
 
 All skills share these invariants:
 
-- **`userId: richard_yaker`** — every KMS call is scoped to Rich's data
+- **`userId: <USER_ID>`** — every KMS call is scoped to the current user's data (replace with your KMS user ID, e.g. `richard_yaker`)
 - **`metadata.subject`** — every store includes a dotted-path facet (e.g., `Phoenix.camera_count`, `Rich.preferences.communication_style`) when the fact is one Rich expects to update or supersede later
 - **Search before store** — every skill searches first to avoid duplicates
 - **Supersede over re-store** — contradicting facts use `kms_supersede`, never additive `unified_store`

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,120 @@
+# KMSmcp Skills Layer
+
+Portable behavioral protocols for Richard's Personal KMS — deployable across Claude Code, Cowork (Claude Desktop), claude.ai (web + iOS), and Codex CLI. Codifies the **OB1 Pattern 1 outer-loop model** lifted from `~/Documents/Notes/OB1-Lessons-vs-KMS-Direction.md`: KMSmcp stays the dumb storage primitive; curation policy moves into portable skills that work in any client where Rich talks to Claude.
+
+**Why this exists**: The behavioral patterns in `/Users/ryaker/Dev/KMSmcp/CLAUDE.md` only fire in Claude Code on the Mac mini. Rich uses 4+ Claude clients, and the KMS MCP at `https://kms.yaker.org` is reachable from all of them. These skills make the patterns portable so EVERY client treats KMS consistently.
+
+## The Five Skills
+
+| Skill | What it does | Trigger phrases |
+|---|---|---|
+| [kms-auto-capture](./kms-auto-capture/) | Distills session-end into atomic KMS entries. Search-first; `metadata.subject` required; routes contradictions through `kms_supersede`. | "wrap up", "park this", "checkpoint", "before I forget" |
+| [kms-meeting-synthesis](./kms-meeting-synthesis/) | Ingests a meeting transcript / Granola note / Slack huddle into one whole-meeting summary + 2-5 typed atomic claims linked back via `metadata.related_to`. | "summarize this meeting", "ingest this Granola", "process this huddle" |
+| [kms-reconcile-pass](./kms-reconcile-pass/) | Full-reconciliation outer loop. Loads a topic cluster, identifies contradictions / near-duplicates / orphan chains, **proposes** corrective actions for human approval before dispatching. | "reconcile KMS", "audit KMS for <topic>", "weekly KMS pass" |
+| [kms-search-first](./kms-search-first/) | Mandatory pre-generation reflex. Calls `unified_search` BEFORE answering when user references prior context. Surfaces results, then proceeds. | "remember when", "we discussed", "did I store" |
+| [kms-trust-boundaries](./kms-trust-boundaries/) | Enforces L16/Lumen/libcp corpus trust boundaries. UNTRUSTED `Light_*` paths require `[unverified]` citation and explicit approval before KMS ingest. TRUSTED `L16_Lumen_ReverseEngineering` repo wins on conflict. | Any operation against `Light_*` paths or L16/Lumen claims |
+
+## Where the Skills Fit
+
+- **Write-time prevention**: dedup gate (Tier 1) — automatic on `unified_store`, server-side
+- **Pre-generation read enforcement**: `kms-search-first` ← skill layer
+- **Capture distillation**: `kms-auto-capture`, `kms-meeting-synthesis` ← skill layer
+- **Background reconciliation**: `kms-reconcile-pass` ← skill layer (OB1 Pattern 1's missing half)
+- **Source provenance enforcement**: `kms-trust-boundaries` ← skill layer
+- **Hard cleanup of flagged entries past 90-day window**: `kms_reap` (admin tool, not a skill)
+
+## Unified Install Matrix
+
+| Client | Install | Notes |
+|---|---|---|
+| **Claude Code** (personal, all projects) | Copy `SKILL.md` to `~/.claude/skills/<name>/SKILL.md` | Live change detection picks it up — no restart |
+| **Claude Code** (project scope, KMSmcp only) | Symlink `skills/<name>` into `.claude/skills/` | Already in place if you symlink; auto-loads |
+| **Cowork** (Claude Desktop) | `/plugin marketplace add ryaker/KMSmcp` then `/plugin install kms-skills@ryaker/KMSmcp` | Requires marketplace publish (see status below) |
+| **claude.ai web Project** | Paste `SKILL.md` body (post-frontmatter) into Project's Custom instructions | Connector setup separate (see below) |
+| **iOS Claude** | Automatic via claude.ai web Project | Same backend |
+| **Codex CLI** | Copy `AGENTS.md` to project root or `~/AGENTS.md` | Codex resolves closest one |
+
+## One-Line Install Examples
+
+### Claude Code — install all 5 skills personally
+```bash
+SKILLS_SRC=/Users/ryaker/Dev/KMSmcp/skills
+for s in kms-auto-capture kms-meeting-synthesis kms-reconcile-pass kms-search-first kms-trust-boundaries; do
+  mkdir -p ~/.claude/skills/$s
+  cp $SKILLS_SRC/$s/SKILL.md ~/.claude/skills/$s/SKILL.md
+done
+```
+
+### Claude Code — symlink at project scope (so skills track repo updates)
+```bash
+SKILLS_SRC=/Users/ryaker/Dev/KMSmcp/skills
+mkdir -p /Users/ryaker/Dev/KMSmcp/.claude/skills
+for s in kms-auto-capture kms-meeting-synthesis kms-reconcile-pass kms-search-first kms-trust-boundaries; do
+  ln -sfn $SKILLS_SRC/$s /Users/ryaker/Dev/KMSmcp/.claude/skills/$s
+done
+```
+
+### Cowork — install bundled plugin (when marketplace is published)
+```
+/plugin marketplace add ryaker/KMSmcp
+/plugin install kms-skills@ryaker/KMSmcp
+```
+
+### claude.ai web Project — manual paste
+Open the Project, navigate to Custom instructions, paste the post-frontmatter body of each `SKILL.md`. (Frontmatter doesn't apply on claude.ai — only the markdown body matters there.)
+
+### Codex CLI — copy AGENTS.md to project root
+```bash
+cp /Users/ryaker/Dev/KMSmcp/skills/<skill-name>/AGENTS.md /path/to/project/AGENTS.md
+# Or for global Codex behavior:
+cp /Users/ryaker/Dev/KMSmcp/skills/<skill-name>/AGENTS.md ~/AGENTS.md
+```
+
+If a target already has an `AGENTS.md`, append rather than overwrite:
+```bash
+cat /Users/ryaker/Dev/KMSmcp/skills/<skill-name>/AGENTS.md >> /path/to/AGENTS.md
+```
+
+## MCP Connector Setup
+
+These skills are **behavioral protocols** — they call KMSmcp tools (`unified_store`, `unified_search`, `kms_supersede`, `kms_update`, `kms_delete`, `kms_flag`, `kms_reap`) but the skills themselves do not configure connectivity.
+
+The KMS MCP must be reachable from the client:
+
+| Client | Connector setup |
+|---|---|
+| Claude Code (Mac mini) | Already in place via local stdio config |
+| Cowork (Claude Desktop) | Add MCP at `https://kms.yaker.org/mcp` in Cowork's MCP config |
+| claude.ai web Project | Add MCP at `https://kms.yaker.org/mcp` in Project's MCP connectors |
+| iOS Claude | Inherits from claude.ai web Project |
+| Codex CLI | Configure in Codex's MCP server config (varies by version — check `codex --help` or docs) |
+
+Once the MCP is connected, the tool names are stable across clients (`unified_store`, `unified_search`, `kms_supersede`, etc.) — these skills reference them by canonical name.
+
+## Marketplace Publishing Status
+
+The Cowork plugin manifest (`skills/.claude-plugin/plugin.json`) is in place, but **the plugin has NOT been published to a marketplace.** Publishing to the official Anthropic marketplace requires submission via `claude.ai/settings/plugins/submit`, which is a separate authorization gate Rich hasn't approved.
+
+Until then, install via:
+- **Claude Code**: per-skill copy or symlink (works today)
+- **Cowork**: manual copy of `SKILL.md` files into Cowork's skill directory (location varies by version)
+- **claude.ai / iOS**: paste body into Project's Custom instructions (works today)
+- **Codex**: copy `AGENTS.md` (works today)
+
+## Conventions Across All Skills
+
+All skills share these invariants:
+
+- **`userId: richard_yaker`** — every KMS call is scoped to Rich's data
+- **`metadata.subject`** — every store includes a dotted-path facet (e.g., `Phoenix.camera_count`, `Rich.preferences.communication_style`) when the fact is one Rich expects to update or supersede later
+- **Search before store** — every skill searches first to avoid duplicates
+- **Supersede over re-store** — contradicting facts use `kms_supersede`, never additive `unified_store`
+- **`dedup_required` is structural** — every skill handles the gate's refusal with explicit retry actions (`supersede` / `update` / `complement` / `force-new`), never blind retry
+
+## Cross-Reference
+
+- KMSmcp tool reference: `/Users/ryaker/Dev/KMSmcp/CLAUDE.md`
+- OB1 Pattern 1 design study: `/Users/ryaker/Documents/Notes/OB1-Lessons-vs-KMS-Direction.md`
+- Dedup gate spec: `/Users/ryaker/Documents/Notes/KMS-Semantic-Dedup-Gate-Spec.md`
+- Existing complementary skills (also in `~/.claude/skills/`): `kms-remember`, `kms-recall`, `kms-grounding`
+- Trust-boundaries canonical write-up: KMS memory `54f04f28-259e-4c8c-9f6e-64cefc8fff52`

--- a/skills/kms-auto-capture/AGENTS.md
+++ b/skills/kms-auto-capture/AGENTS.md
@@ -1,0 +1,64 @@
+# KMS Auto-Capture (Codex variant)
+
+This file is the AGENTS.md flavor of the `kms-auto-capture` skill — same protocol, Codex-friendly format. Codex reads the closest `AGENTS.md` in the directory tree.
+
+## When this protocol applies
+
+When you (the agent) detect a session-end cue from the user — "wrap up", "park this", "let's stop here", "call it", "we're done for today", "goodnight", "sign off", "checkpoint", "save state", "before I forget" — distill the working session into atomic, self-contained KMS entries via `unified_store`. Also fires when a multi-turn working session reaches a natural close.
+
+Do NOT fire on single-question Q&A or sessions where nothing of lasting value was established.
+
+## Core rule: distilled claims, not transcripts
+
+Every stored item must read correctly **without the original conversation context**. If a future agent retrieves it cold, it must still be a complete thought.
+
+- BAD: "We talked about that issue I mentioned earlier with Phoenix calibration."
+- GOOD: "Phoenix camera count is unverified pending canvas-bounds check; prior 6-camera claim used wrong zoom config."
+
+## Process
+
+1. Identify capture candidates — items that are novel, atomic, and self-contained.
+2. For each candidate, run `unified_search` with `userId: richard_yaker` BEFORE storing.
+3. If a near-duplicate exists, choose: skip (rephrase only) / `kms_update` (refinement) / `kms_supersede` (contradiction).
+4. Pick a `metadata.subject` (REQUIRED) — dotted-path facet like `Phoenix.camera_count`, `Rich.preferences.communication_style`, `KMSmcp.dedup_gate_status`.
+5. Store via `unified_store` with `userId: richard_yaker`, `metadata.subject`, `metadata.captured_via: "kms-auto-capture"`.
+6. Handle `dedup_required` responses with explicit retry actions (`supersede`, `update`, `complement`, `force-new`) — never re-attempt the original write blindly.
+7. Report: list captured items, skipped duplicates, supersedes applied.
+
+## ContentType mapping
+
+| Item type | `contentType` |
+|---|---|
+| Decision with reasoning | `insight` |
+| Preference | `memory` |
+| Learning / aha | `insight` |
+| Project state | `memory` |
+| Brainstorm worth keeping | `insight` |
+| Reference fact | `fact` |
+| How-to / procedure | `procedure` |
+
+## Quality bar
+
+- 3-8 entries from a substantive session is healthy. 20+ = transcribing, not distilling. 0 = honest report that the session had nothing worth keeping.
+- NEVER store entries like "User asked X, I responded Y" or "Long discussion about Z — see session for details".
+
+## Required `unified_store` fields
+
+```
+content: <atomic claim, 1-3 sentences>
+contentType: <insight | memory | fact | procedure | pattern | relationship>
+source: <personal | technical | coaching | cross_domain>
+userId: richard_yaker
+metadata:
+  subject: <Project.fact_name or Person.preferences.facet>
+  captured_via: kms-auto-capture
+  session_date: <ISO date>
+```
+
+## Cross-reference
+
+- Single-item store: `kms-remember`
+- Meeting transcripts: `kms-meeting-synthesis`
+- Weekly cleanup: `kms-reconcile-pass`
+- Pre-store recall: `kms-search-first`
+- Trust boundaries (Lumen/L16): `kms-trust-boundaries`

--- a/skills/kms-auto-capture/README.md
+++ b/skills/kms-auto-capture/README.md
@@ -1,0 +1,84 @@
+# kms-auto-capture
+
+Behavioral protocol that fires at session-end (or natural close) and distills the session into atomic, self-contained KMS entries via `unified_store`. Always searches first, never additively re-stores contradicting facts (uses `kms_supersede`), and tags every entry with `metadata.subject`.
+
+See [SKILL.md](./SKILL.md) for the full protocol. See [AGENTS.md](./AGENTS.md) for the Codex-flavored variant.
+
+## What it does
+
+- Detects session-end cues in user input ("wrap up", "park this", "checkpoint", etc.)
+- Scans the session for novel, atomic, self-contained items
+- Searches KMS first to avoid duplicates
+- Stores each item with `unified_store`, including `metadata.subject` (REQUIRED)
+- Routes contradictions through `kms_supersede` instead of additive store
+- Handles `dedup_required` responses with explicit retry actions
+- Reports a clean summary of what was captured / skipped / superseded
+
+## Install
+
+The KMS MCP must be reachable for this skill to do anything. Connector setup at `https://kms.yaker.org/mcp` is separate (see top-level [skills/README.md](../README.md#mcp-connector-setup)).
+
+### Claude Code (personal scope, all projects)
+
+```bash
+mkdir -p ~/.claude/skills/kms-auto-capture
+cp /Users/ryaker/Dev/KMSmcp/skills/kms-auto-capture/SKILL.md ~/.claude/skills/kms-auto-capture/SKILL.md
+```
+
+Live change detection picks it up within the current session — no restart needed.
+
+### Claude Code (project scope, KMSmcp repo only)
+
+Already in place at `.claude/skills/kms-auto-capture/SKILL.md` if you symlink:
+```bash
+mkdir -p /Users/ryaker/Dev/KMSmcp/.claude/skills
+ln -sf /Users/ryaker/Dev/KMSmcp/skills/kms-auto-capture /Users/ryaker/Dev/KMSmcp/.claude/skills/kms-auto-capture
+```
+
+### Cowork (Claude Desktop)
+
+Install the bundled `kms-skills` plugin (installs all 5 skills at once):
+```
+/plugin marketplace add ryaker/KMSmcp
+/plugin install kms-skills@ryaker/KMSmcp
+```
+
+Note: this requires the marketplace publishing flow Rich hasn't authorized yet. Until then, manually copy `SKILL.md` into Cowork's skill directory (location varies by Cowork version — check Cowork's settings panel).
+
+### claude.ai web Project
+
+1. Open the relevant Project (or create one for KMS work)
+2. Project Settings → Custom instructions
+3. Paste the BODY of `SKILL.md` (everything after the closing `---` of frontmatter — markdown only). Frontmatter doesn't apply on claude.ai.
+4. Ensure the KMS MCP connector is configured for the Project at https://kms.yaker.org/mcp
+
+### iOS Claude
+
+Automatic via the claude.ai web Project — iOS uses the same backend. No separate install.
+
+### Codex CLI
+
+Codex reads `AGENTS.md` files in the working directory tree. Two install paths:
+
+**Per-project**: Copy `AGENTS.md` into the project root where you want this behavior:
+```bash
+cp /Users/ryaker/Dev/KMSmcp/skills/kms-auto-capture/AGENTS.md /path/to/project/AGENTS.md
+```
+
+If the project already has an `AGENTS.md`, append the contents instead of overwriting:
+```bash
+cat /Users/ryaker/Dev/KMSmcp/skills/kms-auto-capture/AGENTS.md >> /path/to/project/AGENTS.md
+```
+
+**Global**: Place at `~/AGENTS.md` so all Codex sessions see it (Codex resolves the closest one in the directory tree, falling back upward).
+
+## Verifying Install
+
+In any client with the KMS MCP connected, type:
+> "checkpoint to KMS"
+
+The skill should fire and start the search-first → store loop. If nothing happens, the skill isn't loaded — re-check the install path.
+
+## Trigger Phrases (Reference)
+
+`wrap up`, `park this`, `let's stop here`, `call it`, `we're done for today`, `goodnight`, `sign off`, `checkpoint`, `save state`, `before I forget`

--- a/skills/kms-auto-capture/SKILL.md
+++ b/skills/kms-auto-capture/SKILL.md
@@ -67,7 +67,7 @@ For each candidate, call `unified_search` BEFORE storing:
 ```json
 {
   "query": "<natural language version of the candidate>",
-  "filters": { "userId": "richard_yaker" },
+  "filters": { "userId": "<USER_ID>" },
   "options": { "maxResults": 5, "includeRelationships": true }
 }
 ```
@@ -104,7 +104,7 @@ When in doubt, omit subject — pure pass-through, no validation. But for any fa
   "content": "<atomic claim, self-contained, 1-3 sentences>",
   "contentType": "<insight | memory | fact | procedure | pattern | relationship>",
   "source": "<personal | technical | coaching | cross_domain>",
-  "userId": "richard_yaker",
+  "userId": "<USER_ID>",
   "metadata": {
     "subject": "<dotted-path facet>",
     "captured_via": "kms-auto-capture",

--- a/skills/kms-auto-capture/SKILL.md
+++ b/skills/kms-auto-capture/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: kms-auto-capture
+description: >
+  Capture high-value items from a working session into Richard's Personal KMS at
+  session-end. Triggers on session-end cues — "wrap up", "park this", "let's
+  stop here", "call it", "we're done for today", "goodnight", "sign off",
+  "checkpoint", "save state", "before I forget", or end-of-conversation signals
+  where the user is clearly closing out. Distills the session into atomic claims
+  and stores each via unified_store with metadata.subject. Always searches first
+  to avoid duplicates and routes contradictions through kms_supersede instead of
+  re-storing. Do NOT use for ad-hoc single-item storage (use kms-remember). Do
+  NOT use for batch transcript ingestion (use kms-meeting-synthesis). Do NOT use
+  to dump raw conversation history.
+version: 1.0
+author: richard_yaker
+---
+
+# KMS Auto-Capture — Session-End Knowledge Distillation
+
+When the user signals end-of-session (or you reach a natural close), distill the conversation into atomic, self-contained claims and store each one to the Personal KMS. This is the **outer loop** — the curation pass that turns session noise into long-lived knowledge.
+
+## Core Principle: Distilled Claims, Not Transcript
+
+Every item you store must **make sense without the original conversation context**. If a future agent retrieves it cold, it should still be a complete thought.
+
+**Bad** (transcript fragment): "We talked about that issue I mentioned earlier with the Phoenix calibration."
+
+**Good** (atomic claim): "Phoenix camera count is unverified pending canvas-bounds check; prior 6-camera claim used wrong zoom config."
+
+## Trigger Conditions
+
+Fire when **any** of these are true:
+- User uses an end-of-session phrase ("wrap up", "park this", "stop here", "call it", "goodnight", "checkpoint", "before I forget", "save state", "sign off")
+- A multi-turn working session is reaching a natural close (3+ exchanges of substantive work, then a closing tone)
+- User explicitly asks to "auto-capture" or "checkpoint to KMS"
+- You notice you're about to lose breakthrough context to compaction
+
+Do NOT fire on:
+- Single-question Q&A interactions
+- Sessions where nothing of lasting value was established
+- Casual conversation with no decisions, learnings, or facts worth keeping
+
+## Process
+
+### 1. Identify Capture Candidates
+
+Scan the session for items in these categories. **Only items that meet all three criteria qualify**:
+- Novel (not already in KMS — verified by step 2)
+- Atomic (one fact, one claim, one decision per entry)
+- Self-contained (readable without conversation context)
+
+Categories to look for:
+| Category | KMSmcp `contentType` | Example |
+|---|---|---|
+| Decision (with reasoning) | `insight` | "Decided to use SparrowDB over Neo4j Aura for graph storage because local hot-reload trumps managed convenience for single-user system" |
+| Preference expressed | `memory` | "Prefers async written communication over real-time meetings; meetings only when async fails 2x" |
+| Learning / aha-moment | `insight` | "Sparrowdb 0.1.22 Cypher parser rejects list literals in SET — blocks vector-write path" |
+| Context / project-state | `memory` | "Phoenix project status: blocked on canvas-bounds verification as of 2026-05-06" |
+| Brainstorm / idea worth keeping | `insight` | "Skills layer = OB1 Pattern 1; dedup gate = Lewis Liu incremental reconciliation; the two halves match cleanly" |
+| Reference fact | `fact` | "KMS MCP runs on port 8180; routed via mcp.yaker.org Cloudflare tunnel" |
+| Procedure / how-to | `procedure` | "To regenerate KMS embeddings: stop daemon → run scripts/reembed.ts → restart → verify count" |
+
+### 2. Search-First (Mandatory)
+
+For each candidate, call `unified_search` BEFORE storing:
+
+```json
+{
+  "query": "<natural language version of the candidate>",
+  "filters": { "userId": "richard_yaker" },
+  "options": { "maxResults": 5, "includeRelationships": true }
+}
+```
+
+Three outcomes:
+
+**No matches → store as new** (proceed to step 3)
+
+**Near-duplicate match → choose action**
+- If new content is just a rephrase: skip the store (don't add noise)
+- If new content extends or refines: use `kms_update(id, new_content, reason)` on the existing entry
+- If new content **contradicts** the prior fact: use `kms_supersede(old_id, new_content, reason)` — never additively store
+
+**Exact match found → skip silently**
+
+### 3. Pick a `metadata.subject` (REQUIRED for every store)
+
+Every `unified_store` call MUST include `metadata.subject` as a dotted-path facet identifying the SPECIFIC fact, not the broad topic.
+
+Conventions:
+- `Project.fact_name` — `Phoenix.camera_count`, `KMSmcp.dedup_gate_status`
+- `Person.preferences.facet` — `Rich.preferences.communication_style`, `Rich.work_patterns.deep_work_blocks`
+- `Tool.behavior` — `SparrowDB.cypher_parser_limits`, `Mem0.search_v3_signature`
+- `Domain.concept` — `Auth.oauth_jwks_endpoint`, `Build.railway_buildtarget_env`
+
+**Reuse the same subject when writing about the same fact.** That's how supersede chains stay queryable.
+
+When in doubt, omit subject — pure pass-through, no validation. But for any fact you expect to update or supersede later, set it.
+
+### 4. Store via `unified_store`
+
+```json
+{
+  "content": "<atomic claim, self-contained, 1-3 sentences>",
+  "contentType": "<insight | memory | fact | procedure | pattern | relationship>",
+  "source": "<personal | technical | coaching | cross_domain>",
+  "userId": "richard_yaker",
+  "metadata": {
+    "subject": "<dotted-path facet>",
+    "captured_via": "kms-auto-capture",
+    "session_date": "<ISO date>"
+  },
+  "relationships": []
+}
+```
+
+### 5. Handle `dedup_required` Responses
+
+If the dedup gate refuses the write, the response is:
+```json
+{ "status": "dedup_required", "candidates": [...], "retry_with": [...] }
+```
+
+Choose ONE explicit action — never re-attempt the original write blindly:
+- `kms_supersede(old_id, new_content, reason)` — new fact contradicts/replaces
+- `kms_update(old_id, new_content, reason)` — minor refinement of same fact
+- `unified_store` with `action=complement&related_to=<old_id>` — distinct facet of same topic
+- `unified_store` with `action=force-new&reason=<justification>` — genuinely new despite similarity
+
+### 6. Report What Was Captured
+
+After all stores complete, report a clean summary:
+
+```
+Captured 4 items to KMS:
+  • [insight] KMSmcp.skills_layer_bet — Skills layer is the OB1 Pattern 1 lift
+    → stored: graph + mem0
+  • [fact] SparrowDB.cypher_parser_limits — list literals in SET rejected (0.1.22)
+    → stored: graph + mongo
+  • [memory] Rich.preferences.session_termination — prefers explicit "wrap up" cue
+    → stored: mem0
+  • [procedure] KMSmcp.reembed_steps — regen embeddings via scripts/reembed.ts
+    → stored: graph + mongo
+
+Skipped 2 candidates (already in KMS).
+Superseded 1 prior entry: <old_id> "Phoenix uses 6 cameras" → corrected to UNKNOWN.
+```
+
+## Output Quality Bar
+
+A good capture pass produces 3-8 entries from a substantive session. If you're producing 20+ entries, you're capturing transcript fragments — re-read the "atomic claim, not transcript" rule and cut. If you're producing 0 entries, the session truly had nothing worth keeping (acceptable — say so).
+
+## Critical: No Raw Transcript Dumps
+
+NEVER store entries like:
+- "User asked about X and I responded with Y"
+- "We discussed [topic] for a while"
+- "Long conversation about <topic> — see session for details"
+- Verbatim conversation excerpts
+
+These pollute search results and break the self-contained-claim invariant.
+
+## Cross-Reference
+
+- For single-item explicit storage: see `kms-remember`
+- For meeting/transcript ingestion: see `kms-meeting-synthesis`
+- For weekly cleanup: see `kms-reconcile-pass`
+- For pre-store recall: see `kms-search-first`

--- a/skills/kms-meeting-synthesis/AGENTS.md
+++ b/skills/kms-meeting-synthesis/AGENTS.md
@@ -1,0 +1,71 @@
+# KMS Meeting Synthesis (Codex variant)
+
+Codex-flavored protocol for ingesting a meeting transcript / Granola note / Slack huddle / call summary into KMS.
+
+## When this protocol applies
+
+Trigger phrases: "summarize this meeting", "extract action items", "what did we decide", "draft the follow-up", "ingest this Granola", "process this huddle", "log this call", "store these meeting notes". Also fires when handed a Granola URL, Slack canvas URL, or transcript file path with intent to persist.
+
+Do NOT fire on:
+- Casual conversation snippets (use `kms-auto-capture`)
+- Single-fact stores (use `kms-remember`)
+- Reference-only transcripts the user explicitly says are not for KMS
+
+## Process
+
+### Step 1 — Extract meeting metadata
+
+Required: source type (Granola/Slack/Zoom/voice/manual), source URI or null, date (ISO), attendees, topic (one line), duration if available. If any unclear, ASK before proceeding.
+
+### Step 2 — Search KMS for prior related meetings
+
+`unified_search` with topic + primary attendee, `filters.userId: richard_yaker`, `filters.contentType: ["memory"]`. Three outcomes:
+- No prior meetings → store as new
+- Recurring series → flag prior IDs; new entry will use `action=complement&related_to=<prior>`
+- Same-meeting duplicate → STOP, confirm before re-ingesting
+
+### Step 3 — Whole-meeting summary entry
+
+`contentType: memory`, 150-300 words covering: purpose, attendees, decisions, action items, open questions, notable context.
+
+Subject: `Meetings.<YYYY-MM-DD>.<short_topic>` — e.g., `Meetings.2026-05-06.phoenix_calibration_review`.
+
+Capture the returned `id` for use as `related_to` in claim entries.
+
+### Step 4 — 2-5 typed atomic claims
+
+Each linked back via `metadata.related_to: [<meeting_id>]` and given its OWN `metadata.subject` for future supersede-ability.
+
+| Claim type | `contentType` |
+|---|---|
+| Decision with reasoning | `insight` |
+| Project state | `memory` |
+| Concrete fact | `fact` |
+| Process change | `procedure` |
+| Behavioral pattern | `pattern` |
+
+Required claim metadata: `subject` (specific facet like `Phoenix.camera_count`), `related_to` (whole-meeting id array), `source_doc`, `meeting_date`, `captured_via: kms-meeting-synthesis`.
+
+### Step 5 — Handle `dedup_required`
+
+- Same fact, refined → `kms_update`
+- Contradicts prior fact → `kms_supersede`
+- Distinct facet, follow-up to prior meeting → `unified_store` with `action=complement&related_to=<prior_meeting_id>`
+- Genuinely new despite similarity → `unified_store` with `action=force-new&reason=<why>` (use sparingly)
+
+### Step 6 — Report
+
+List: whole-meeting id, atomic claim ids and subjects, supersedes applied, force-new with reasons.
+
+## Quality rules
+
+- Whole-meeting summary 150-300 words. <100 = too thin. >400 = becoming a transcript.
+- 2-5 atomic claims per meeting. <2 = not worth ingesting. >5 = transcribing not distilling.
+- No "see meeting notes for context" fragments. Each claim survives standalone.
+- No verbatim quotes unless the quote IS the fact (e.g., dated commitment).
+
+## Cross-reference
+
+- Cron-batch equivalent: `src/scripts/import-granola.ts` (PR #74) — same contract, runs nightly
+- Single-item store: `kms-remember`
+- Session-end distillation: `kms-auto-capture`

--- a/skills/kms-meeting-synthesis/README.md
+++ b/skills/kms-meeting-synthesis/README.md
@@ -1,0 +1,57 @@
+# kms-meeting-synthesis
+
+Behavioral protocol for ingesting a meeting transcript / Granola note / Slack huddle recap / call summary into KMS as one whole-meeting summary entry plus 2-5 typed atomic claims. Each claim is linked back to the meeting via `metadata.related_to`.
+
+See [SKILL.md](./SKILL.md) for the full protocol. See [AGENTS.md](./AGENTS.md) for the Codex-flavored variant.
+
+## What it does
+
+- Triggers when handed a Granola URL, Slack canvas, transcript file, or asked to "summarize this meeting"
+- Extracts metadata (date, attendees, topic, source URI)
+- Searches KMS for prior related meetings before storing
+- Generates ONE whole-meeting summary entry (`contentType=memory`, 150-300 words)
+- Generates 2-5 typed atomic claims, each with `metadata.related_to: [meeting_id]`
+- Each claim has its own `metadata.subject` for future supersede-ability
+- Handles `dedup_required` with `action=complement` for recurring-meeting series
+
+This is the in-conversation companion to the cron-driven Granola importer at `src/scripts/import-granola.ts` (PR #74) — same contract, agent-driven instead of batch.
+
+## Install
+
+Same matrix as all KMS skills. Replace `<skill>` with `kms-meeting-synthesis`.
+
+### Claude Code (personal)
+```bash
+mkdir -p ~/.claude/skills/kms-meeting-synthesis
+cp /Users/ryaker/Dev/KMSmcp/skills/kms-meeting-synthesis/SKILL.md ~/.claude/skills/kms-meeting-synthesis/SKILL.md
+```
+
+### Claude Code (project)
+```bash
+ln -sf /Users/ryaker/Dev/KMSmcp/skills/kms-meeting-synthesis /Users/ryaker/Dev/KMSmcp/.claude/skills/kms-meeting-synthesis
+```
+
+### Cowork
+```
+/plugin marketplace add ryaker/KMSmcp
+/plugin install kms-skills@ryaker/KMSmcp
+```
+
+### claude.ai web Project
+Paste body of `SKILL.md` (post-frontmatter) into Project's Custom instructions.
+
+### iOS
+Automatic via claude.ai Project.
+
+### Codex CLI
+```bash
+cp /Users/ryaker/Dev/KMSmcp/skills/kms-meeting-synthesis/AGENTS.md /path/to/project/AGENTS.md
+```
+
+## Verifying Install
+
+Hand the agent a Granola URL or transcript and ask "summarize this meeting and store it in KMS." The skill should fire and produce a whole-meeting entry + 2-5 linked claims.
+
+## Trigger Phrases (Reference)
+
+`summarize this meeting`, `extract action items`, `what did we decide`, `draft the follow-up`, `ingest this Granola`, `process this huddle`, `log this call`, `store these meeting notes`

--- a/skills/kms-meeting-synthesis/SKILL.md
+++ b/skills/kms-meeting-synthesis/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: kms-meeting-synthesis
+description: >
+  Synthesize a meeting transcript, Granola note, Slack huddle recap, call summary,
+  or any conversation log into Richard's Personal KMS as one whole-meeting summary
+  plus 2-5 typed atomic claims. Triggers on "summarize this meeting", "extract
+  action items", "what did we decide", "draft the follow-up", "ingest this
+  Granola", "process this huddle", "log this call", "store these meeting notes",
+  or when handed a Granola URL / Slack canvas / transcript file in conversation.
+  Each claim is self-contained with metadata.related_to pointing back to the
+  whole-meeting entry. Routes through unified_store with subject facets and
+  handles dedup_required responses with action=complement for related-meeting
+  follow-ups. Do NOT use for live chat (use kms-auto-capture). Do NOT bypass the
+  dedup gate.
+version: 1.0
+author: richard_yaker
+---
+
+# KMS Meeting Synthesis — Transcript Ingestion Protocol
+
+When the user hands you a meeting/call/huddle transcript (Granola, Slack, voice memo, or manually-pasted notes), distill it into one summary entry + a small set of atomic claim entries linked back to the summary. This is the in-conversation companion to the cron-driven Granola importer (`src/scripts/import-granola.ts`); same contract, agent-driven instead of batch.
+
+## Trigger Conditions
+
+Fire on any of:
+- Trigger phrases listed in frontmatter
+- User pastes a Granola URL, Slack canvas URL, or `.txt`/`.md` transcript path
+- User shares a meeting summary or transcript and asks anything that implies KMS persistence ("save this", "remember this meeting", "log this for the project")
+- Granola MCP returns a transcript and user wants it in KMS
+
+Do NOT fire on:
+- Casual conversation snippets (use `kms-auto-capture` at session-end)
+- Single-fact stores (use `kms-remember`)
+- Raw transcripts the user explicitly says are reference-only / not for KMS
+
+## Process
+
+### Step 1: Identify Meeting Metadata
+
+Before any storage, extract:
+- **Source**: Granola | Slack huddle | Zoom recording | Voice memo | Manual notes
+- **Source URI**: Granola meeting URL, Slack canvas URL, file path, or `null` if pasted text
+- **Date**: When the meeting happened (ISO format)
+- **Attendees**: Names from transcript (people Rich mentions or speakers)
+- **Topic**: One-line characterization ("Phoenix calibration review", "L16 gtm sync")
+- **Duration**: If available
+
+If any of these are unclear, ask the user before proceeding. A meeting entry with wrong attendees / wrong date is worse than no entry.
+
+### Step 2: Search KMS for Prior Related Meetings
+
+Run `unified_search` with the meeting topic AND attendees BEFORE storing anything:
+
+```json
+{
+  "query": "<topic> meeting <primary attendee>",
+  "filters": {
+    "userId": "richard_yaker",
+    "contentType": ["memory"]
+  },
+  "options": { "maxResults": 8, "includeRelationships": true }
+}
+```
+
+Three outcomes:
+- **No prior meetings on this topic** → store as new (steps 3-5)
+- **Recurring meeting series** → flag the prior entry IDs; new whole-meeting entry will use `action=complement&related_to=<prior_id>` if dedup gate refuses
+- **Same-meeting duplicate** (someone already ingested this transcript) → STOP. Confirm with user before re-ingesting
+
+### Step 3: Generate the Whole-Meeting Summary
+
+Write a `contentType=memory` entry: 150-300 words covering:
+1. **Purpose** — why the meeting happened
+2. **Attendees** — named explicitly
+3. **Decisions made** — explicit decisions only, not discussion
+4. **Action items** — owner + action (use Rich's name when his)
+5. **Open questions** — what was deferred / unresolved
+6. **Notable context** — anything that frames the decisions (constraints, deadlines mentioned, blockers raised)
+
+This is the "anchor" entry — the typed claims (Step 4) link back to this via `metadata.related_to`.
+
+Subject convention for whole-meeting entries: `Meetings.<YYYY-MM-DD>.<short_topic>` — e.g., `Meetings.2026-05-06.phoenix_calibration_review`.
+
+Store it:
+```json
+{
+  "content": "<150-300 word summary>",
+  "contentType": "memory",
+  "source": "<personal | technical | coaching | cross_domain>",
+  "userId": "richard_yaker",
+  "metadata": {
+    "subject": "Meetings.2026-05-06.phoenix_calibration_review",
+    "source_doc": "<Granola URL | Slack URL | file path | null>",
+    "source_type": "granola | slack | zoom | voice_memo | manual",
+    "meeting_date": "2026-05-06",
+    "attendees": ["Rich", "Jesse", "Kevin"],
+    "captured_via": "kms-meeting-synthesis"
+  },
+  "relationships": []
+}
+```
+
+**Capture the returned `id` — every claim entry will reference it.**
+
+### Step 4: Extract 2-5 Typed Atomic Claims
+
+From the transcript, pull the 2-5 most load-bearing items that are worth retrieving in isolation. Each MUST be self-contained — readable without the meeting summary or transcript.
+
+Map each to a contentType:
+| Claim type | `contentType` | When to use |
+|---|---|---|
+| Decision with reasoning | `insight` | "Decided to defer L16 launch by 2 weeks because of X" |
+| Project state / current status | `memory` | "Phoenix is blocked on canvas-bounds verification as of 2026-05-06" |
+| Concrete fact established | `fact` | "Tengo's Q3 revenue is $2.4M; runway 14 months" |
+| How-to / process change | `procedure` | "New gate-review process: PR opens issue, reviewer assigns by Friday" |
+| Behavioral pattern observed | `pattern` | "Investor calls always run 50% over scheduled time when Kevin attends" |
+
+Each claim entry:
+```json
+{
+  "content": "<self-contained atomic claim, 1-3 sentences>",
+  "contentType": "<insight | memory | fact | procedure | pattern>",
+  "source": "<inferred from topic>",
+  "userId": "richard_yaker",
+  "metadata": {
+    "subject": "<dotted-path facet — e.g., Phoenix.camera_count>",
+    "related_to": ["<whole_meeting_id from step 3>"],
+    "source_doc": "<same as whole-meeting>",
+    "meeting_date": "2026-05-06",
+    "captured_via": "kms-meeting-synthesis"
+  }
+}
+```
+
+**Every claim must have BOTH:**
+- `metadata.subject` — the specific facet this claim is about (so future supersedes work)
+- `metadata.related_to` — the whole-meeting ID (so a future agent can pull "everything from that meeting")
+
+### Step 5: Handle `dedup_required` for Each Claim
+
+If a claim trips the dedup gate, choose one:
+
+- **Same fact, refined** → `kms_update(old_id, new_content, reason)`
+  Example: "Phoenix camera count was UNKNOWN" → "Phoenix camera count is UNKNOWN pending canvas-bounds verification (clarified in 2026-05-06 review)"
+
+- **Contradicts prior fact** → `kms_supersede(old_id, new_content, reason)`
+  Example: prior entry says "Phoenix uses 6 cameras"; meeting establishes that number was wrong → supersede
+
+- **Distinct facet of same topic, follow-up to prior meeting** → `unified_store` with `action=complement&related_to=<prior_meeting_id>`
+  Example: weekly Phoenix sync — each meeting's claim about Phoenix is complementary, not duplicative
+
+- **Genuinely new despite similarity** → `unified_store` with `action=force-new&reason=<why>`
+  Use sparingly. Reason must justify why the gate was wrong.
+
+### Step 6: Report Synthesis Results
+
+```
+Synthesized "Phoenix Calibration Review (2026-05-06)" into KMS:
+
+Whole-meeting summary (id: abc-123):
+  Subject: Meetings.2026-05-06.phoenix_calibration_review
+  Attendees: Rich, Jesse, Kevin
+  Source: Granola → https://app.granola.ai/...
+
+Atomic claims:
+  1. [insight] Phoenix.calibration_status — calibration deferred 2 weeks
+     id: def-456 | related_to: [abc-123]
+  2. [fact] Phoenix.camera_count — count is UNKNOWN pending canvas-bounds
+     id: ghi-789 | related_to: [abc-123]
+     ⚠ SUPERSEDED prior entry jkl-012 ("Phoenix uses 6 cameras")
+  3. [procedure] Phoenix.review_cadence — new bi-weekly gate review process
+     id: mno-345 | related_to: [abc-123]
+
+3 claims stored | 1 supersede | 0 force-new
+```
+
+## Quality Rules
+
+- **Whole-meeting summary**: 150-300 words. Below 100 = too thin to be useful. Above 400 = it's becoming a transcript.
+- **Atomic claims**: 2-5 per meeting. Less than 2 = the meeting wasn't worth ingesting. More than 5 = you're not distilling, you're transcribing.
+- **No "see meeting notes for context" fragments**. Every claim survives without the meeting entry.
+- **No verbatim quotes** unless the quote IS the fact (e.g., "Kevin said 'we'll never ship before October' — date commitment from co-founder").
+
+## Cross-Reference
+
+- Cron-batch equivalent: `src/scripts/import-granola.ts` (PR #74) — same contract, runs nightly
+- Single-item store: `kms-remember`
+- Session-end distillation: `kms-auto-capture`
+- Recall meetings later: `kms-recall` with `metadata.related_to` filter

--- a/skills/kms-meeting-synthesis/SKILL.md
+++ b/skills/kms-meeting-synthesis/SKILL.md
@@ -55,7 +55,7 @@ Run `unified_search` with the meeting topic AND attendees BEFORE storing anythin
 {
   "query": "<topic> meeting <primary attendee>",
   "filters": {
-    "userId": "richard_yaker",
+    "userId": "<USER_ID>",
     "contentType": ["memory"]
   },
   "options": { "maxResults": 8, "includeRelationships": true }
@@ -87,13 +87,13 @@ Store it:
   "content": "<150-300 word summary>",
   "contentType": "memory",
   "source": "<personal | technical | coaching | cross_domain>",
-  "userId": "richard_yaker",
+  "userId": "<USER_ID>",
   "metadata": {
-    "subject": "Meetings.2026-05-06.phoenix_calibration_review",
+    "subject": "Meetings.<ISO date>.<short_topic>",
     "source_doc": "<Granola URL | Slack URL | file path | null>",
     "source_type": "granola | slack | zoom | voice_memo | manual",
-    "meeting_date": "2026-05-06",
-    "attendees": ["Rich", "Jesse", "Kevin"],
+    "meeting_date": "<ISO date>",
+    "attendees": ["<attendee1>", "<attendee2>"],
     "captured_via": "kms-meeting-synthesis"
   },
   "relationships": []
@@ -121,12 +121,12 @@ Each claim entry:
   "content": "<self-contained atomic claim, 1-3 sentences>",
   "contentType": "<insight | memory | fact | procedure | pattern>",
   "source": "<inferred from topic>",
-  "userId": "richard_yaker",
+  "userId": "<USER_ID>",
   "metadata": {
     "subject": "<dotted-path facet — e.g., Phoenix.camera_count>",
     "related_to": ["<whole_meeting_id from step 3>"],
     "source_doc": "<same as whole-meeting>",
-    "meeting_date": "2026-05-06",
+    "meeting_date": "<ISO date>",
     "captured_via": "kms-meeting-synthesis"
   }
 }

--- a/skills/kms-reconcile-pass/AGENTS.md
+++ b/skills/kms-reconcile-pass/AGENTS.md
@@ -1,0 +1,95 @@
+# KMS Reconcile Pass (Codex variant)
+
+Codex-flavored protocol for full-reconciliation passes over KMS topic clusters. **Never silently applies corrections.**
+
+## When this protocol applies
+
+Trigger phrases: "reconcile KMS", "clean up KMS", "audit KMS for <topic>", "weekly KMS pass", "find contradictions in KMS", "drain KMS dedup debt", "reconcile <topic>".
+
+Do NOT fire on:
+- Single-fact corrections — call `kms_supersede` directly, no skill needed
+- Pure search queries — use `kms-recall`
+- Hard cleanup of flagged entries — that's `kms_reap`, an admin tool
+
+## Defining rule
+
+Never silently apply corrections. Every supersede/update/delete needs explicit user approval before dispatch.
+
+## Process
+
+### Step 1 — Identify scope
+
+Ask user (or infer): a specific subject (`Phoenix.camera_count`), a topic cluster (`Phoenix`), a contentType+window, or N most-recently-written subjects. If unclear, present candidate clusters and let Rich pick.
+
+### Step 2 — Load the cluster
+
+```
+unified_search:
+  query: <topic keyword>
+  filters:
+    userId: richard_yaker
+    subject: <if specific subject>
+  options:
+    maxResults: 50
+    includeRelationships: true
+    includeFlagged: true
+```
+
+`includeFlagged: true` is intentional — reconciliation needs to see superseded entries to spot orphan chains.
+
+### Step 3 — Categorize each entry
+
+| Bucket | Action to propose |
+|---|---|
+| Canonical (current correct fact) | None |
+| Superseded chain (clean) | None |
+| Superseded chain (orphan) — old not flagged or `superseded_by` points to nothing | Repair: re-run `kms_supersede` or fix the flag |
+| Contradiction (two unflagged entries say opposite things on same subject) | `kms_supersede(loser_id, winner_content, reason)` — Rich picks winner |
+| Near-duplicate (same fact, slightly different phrasing) | `kms_update` on canonical + `kms_delete`/`kms_supersede` the other |
+| Stale fact (was true, no longer reflects reality) | `kms_supersede` with corrected content OR `kms_flag('RETRACTED')` if no replacement |
+| Garbage (test entry, accidental store) | `kms_delete(id, reason)` |
+
+### Step 4 — Generate proposal
+
+Structured output: numbered list of proposed actions, each with old/new content (where applicable) and a reason. DO NOT call any corrective tool yet. Audit notes for orphan chains. End with "Approve all / approve specific items / cancel?"
+
+### Step 5 — Wait for approval, then dispatch
+
+Approved actions use:
+- `kms_supersede(old_id, new_content, reason, contentType, source, metadata)` — atomic, handles backend probing per issue #62 fix
+- `kms_update(id, new_content, reason)` — appends reason to `metadata.update_history`
+- `kms_delete(id, reason)` — soft-delete, reversible 90 days
+- `kms_flag(id, 'RETRACTED' | 'UNVERIFIED', note)` — partial-wrong without replacement
+
+Or, with post-PR-#70 dispatch syntax:
+```
+unified_store:
+  content: <new>
+  action: supersede
+  old_id: <abc-123>
+  reason: <why>
+  userId: richard_yaker
+  metadata: { subject: <facet> }
+```
+
+### Step 6 — Verify and report
+
+Re-run cluster search. Report counts: supersedes applied, updates applied, deletes applied, orphan chains pending manual repair. Confirm default-search now returns corrected versions only.
+
+## Frequency
+
+Weekly or on-demand. Don't run after every session. Heuristic: >20 writes since last reconcile pass for a subject = candidate.
+
+## What this protocol does NOT do
+
+- Does NOT call `kms_reap` (separate admin operation for hard-deleting past 90-day window)
+- Does NOT auto-merge entries silently — every action needs Rich's approval
+- Does NOT run on entire KMS at once — always cluster-scoped
+- Does NOT touch `userId != richard_yaker`
+
+## Cross-reference
+
+- Single-fact correction: call `kms_supersede` directly
+- Search-only: `kms-recall`
+- Hard cleanup: `kms_reap` (admin)
+- Write-time prevention: dedup gate (automatic on `unified_store`)

--- a/skills/kms-reconcile-pass/README.md
+++ b/skills/kms-reconcile-pass/README.md
@@ -1,0 +1,70 @@
+# kms-reconcile-pass
+
+Full-reconciliation behavioral protocol — runs on demand or weekly to drain accumulated dedup debt (contradictions, near-duplicates, orphan supersede chains, stale facts) within a topic cluster. **Never silently applies corrections** — always proposes for human approval first.
+
+See [SKILL.md](./SKILL.md) for the full protocol. See [AGENTS.md](./AGENTS.md) for the Codex-flavored variant.
+
+## What it does
+
+- Triggers on "reconcile KMS", "clean up <topic>", "audit KMS for <subject>"
+- Loads a topic cluster via `unified_search` with `subject` filter and `includeFlagged: true`
+- Categorizes each entry: canonical / clean-superseded-chain / orphan-chain / contradiction / near-duplicate / stale / garbage
+- Generates a structured proposal (supersede X, update Y, delete Z) with rationale
+- Waits for explicit user approval (per-item or "approve all")
+- Dispatches via `kms_supersede` / `kms_update` / `kms_delete` / `kms_flag`
+- Verifies and reports
+
+This is the missing half of the OB1 Pattern 1 lift (full reconciliation as outer-loop skill, complementary to write-time dedup gate).
+
+## Install
+
+### Claude Code (personal)
+```bash
+mkdir -p ~/.claude/skills/kms-reconcile-pass
+cp /Users/ryaker/Dev/KMSmcp/skills/kms-reconcile-pass/SKILL.md ~/.claude/skills/kms-reconcile-pass/SKILL.md
+```
+
+### Claude Code (project)
+```bash
+ln -sf /Users/ryaker/Dev/KMSmcp/skills/kms-reconcile-pass /Users/ryaker/Dev/KMSmcp/.claude/skills/kms-reconcile-pass
+```
+
+### Cowork
+```
+/plugin marketplace add ryaker/KMSmcp
+/plugin install kms-skills@ryaker/KMSmcp
+```
+
+### claude.ai web Project
+Paste body of `SKILL.md` (post-frontmatter) into Project's Custom instructions.
+
+### iOS
+Automatic via claude.ai Project.
+
+### Codex CLI
+```bash
+cp /Users/ryaker/Dev/KMSmcp/skills/kms-reconcile-pass/AGENTS.md /path/to/project/AGENTS.md
+```
+
+## Recommended Frequency
+
+- **Weekly**: Run a reconcile pass on the top 1-3 highest-write subjects from the past week
+- **On-demand**: When you notice a topic has accumulated drift (e.g., 3+ stores about the same fact in different sessions)
+- **Never after every session** — over-fitting; the corpus needs accumulated drift before reconciliation finds signal
+
+Heuristic: `kms_get_kms_analytics` showing >20 writes since the last reconcile pass for a given subject = candidate.
+
+## Verifying Install
+
+Type: "reconcile KMS for Phoenix" — the skill should load the cluster and produce a proposal without applying anything until you approve.
+
+## Safety Notes
+
+- This skill MUST NOT silently apply corrections. If it does, the implementation is broken — file a bug.
+- Always scoped to a cluster (subject / topic / contentType), never the full KMS
+- Always `userId: richard_yaker` — does not touch other users' data
+- Does not call `kms_reap` (that's a separate admin operation)
+
+## Trigger Phrases (Reference)
+
+`reconcile KMS`, `clean up KMS`, `audit KMS for <topic>`, `weekly KMS pass`, `find contradictions in KMS`, `drain KMS dedup debt`, `reconcile <topic>`

--- a/skills/kms-reconcile-pass/SKILL.md
+++ b/skills/kms-reconcile-pass/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: kms-reconcile-pass
+description: >
+  Run a full-reconciliation pass over a topic cluster in Richard's Personal KMS —
+  identify supersede candidates, contradictions, and near-duplicates, then PROPOSE
+  corrective actions for human approval before dispatching. Triggers on "reconcile
+  KMS", "clean up KMS", "audit KMS for <topic>", "weekly KMS pass", "find
+  contradictions in KMS", "drain KMS dedup debt", "reconcile <topic>", or when
+  Rich asks to clean up an over-written subject area. NEVER silently applies
+  corrections — every supersede/update/delete needs explicit user approval first.
+  Drains the "0 corrections vs N writes" debt the dedup gate spec was written to
+  fix. Do NOT use for single-fact corrections (use kms_supersede directly). Do
+  NOT use for hard-deleting flagged entries past the reversibility window — that
+  is kms_reap, an admin tool.
+version: 1.0
+author: richard_yaker
+---
+
+# KMS Reconcile Pass — Full Reconciliation Outer Loop
+
+The dedup gate handles **incremental reconciliation** at write-time (Tier 1, ~50ms cost). This skill handles **full reconciliation** — the periodic background pass that drains accumulated dedup debt: contradictions, near-duplicates, orphan supersede chains, and stale facts. Maps directly onto Lewis Liu's agentic-KG framing and OB1 Pattern 1's full-reconciliation half.
+
+The defining rule: **never silently apply corrections**. Always propose with rationale, get user approval, then dispatch.
+
+## Trigger Conditions
+
+Fire on:
+- Trigger phrases above
+- User requests a weekly/scheduled KMS audit
+- Rich says "find contradictions in <topic>" or "clean up <subject>"
+- A prior session shipped many writes on one topic and Rich asks to review
+
+Do NOT fire on:
+- Single-fact corrections (call `kms_supersede` directly, no skill needed)
+- Search-only queries (use `kms-recall`)
+- Hard cleanup of flagged entries (use `kms_reap` — admin operation)
+
+## Process
+
+### Step 1: Identify the Reconciliation Scope
+
+Ask the user (or infer):
+- **A specific subject** — `Phoenix.camera_count`, `Tengo.business_model`, `Rich.preferences.communication_style`
+- **A topic cluster** — "Phoenix" (matches all `Phoenix.*` subjects), "L16", "MyMoneyCoach"
+- **A contentType + window** — "all `procedure` entries from the last 30 days"
+- **N most-recently-written subjects** — "top 5 high-density subjects from this month"
+
+If unclear, list the candidate clusters and ask Rich to pick:
+```
+Top candidate clusters for reconciliation:
+  1. Phoenix.* (24 entries, 0 supersedes, 3 likely contradictions)
+  2. KMSmcp.* (18 entries, 2 supersedes, 5 near-duplicates)
+  3. Rich.preferences.* (12 entries, 0 supersedes, looks healthy)
+Pick one or specify another.
+```
+
+### Step 2: Load the Cluster
+
+Run `unified_search` scoped to the cluster:
+
+```json
+{
+  "query": "<topic keyword>",
+  "filters": {
+    "userId": "richard_yaker",
+    "subject": "Phoenix.camera_count"
+  },
+  "options": {
+    "maxResults": 50,
+    "includeRelationships": true,
+    "includeFlagged": true
+  }
+}
+```
+
+`includeFlagged: true` is intentional — reconciliation needs to see superseded/retracted entries to spot orphan chains.
+
+For broader clusters, omit `subject` filter and use a topic query — but tighten with `contentType` if needed.
+
+### Step 3: Read the Cluster, Categorize Each Entry
+
+For each entry returned, place it into one of these buckets:
+
+| Bucket | Definition | Action to propose |
+|---|---|---|
+| **Canonical** | The current correct fact | None — this is the "winner" |
+| **Superseded chain (clean)** | Old entry, properly flagged with `superseded_by` | None — chain is healthy |
+| **Superseded chain (orphan)** | New entry exists but old isn't flagged, OR old has `superseded_by` pointing to nothing | Repair: re-run `kms_supersede` or fix the flag |
+| **Contradiction** | Two unflagged entries say opposite things about the same subject | Propose `kms_supersede(loser_id, winner_content, reason)` — Rich picks winner |
+| **Near-duplicate** | Two entries about the same fact, slightly different phrasing, both unflagged | Propose `kms_update` on the canonical version (merge the better wording in) and `kms_delete` or `kms_supersede` the other |
+| **Stale fact** | Was true once, no longer reflects reality | Propose `kms_supersede` with corrected content OR `kms_flag('RETRACTED')` if no replacement |
+| **Garbage** | Test entry, accidental store, broken content | Propose `kms_delete(id, reason)` |
+
+### Step 4: Generate the Reconciliation Proposal
+
+Produce a structured proposal — DO NOT call any corrective tool yet. Rich must approve first.
+
+Format:
+```
+## Reconciliation Proposal: Phoenix.camera_count
+
+Cluster size: 7 entries (5 unflagged, 2 already superseded)
+
+### Proposed actions
+
+1. SUPERSEDE
+   Old: abc-123 "Phoenix uses exactly 6 cameras" (2026-03-12)
+   New: def-456 "Phoenix camera count is UNKNOWN pending canvas-bounds verification"
+   Reason: Canvas bounds unverified per 2026-05-06 review; prior 6-camera claim used wrong zoom config (config 0 not config 2) and A-only FOV.
+
+2. UPDATE
+   Entry: ghi-789 "Phoenix camera FOV is 60deg horizontal"
+   New content: "Phoenix camera FOV is 60deg horizontal at config 2 (was wrong for config 0)"
+   Reason: Add config qualifier; fact is correct but missing context.
+
+3. DELETE
+   Entry: jkl-012 "test phoenix entry pls ignore"
+   Reason: Test artifact from 2026-02-14, no signal value.
+
+4. NO ACTION (canonical, leave as-is)
+   - mno-345 "Phoenix calibration uses 12-point checkerboard at 2m distance"
+   - pqr-678 "Phoenix project lead is Jesse as of 2026-04"
+
+### Audit notes
+- 1 orphan supersede chain detected (stu-901 has superseded_by=vwx-234, but vwx-234 doesn't exist) — flagging for manual repair
+- No contradictions detected after the proposed actions
+
+Approve all / approve specific items / cancel?
+```
+
+### Step 5: Wait for Approval — Then Dispatch
+
+Rich's options:
+- "approve all" → dispatch every action in order
+- "approve 1, 3" → dispatch only those
+- "cancel" → no action
+- Edits to specific items → revise proposal, re-show, re-confirm
+
+When dispatching, use the corrective tools:
+- `kms_supersede(old_id, new_content, reason, contentType, source, metadata)` — atomic supersede (issue #62 fix handles backend probing)
+- `kms_update(id, new_content, reason)` — in-place mutation, append reason to `metadata.update_history`
+- `kms_delete(id, reason)` — soft-delete, reversible for 90 days
+- `kms_flag(id, 'RETRACTED' | 'UNVERIFIED', note)` — partial-wrong flag, original preserved
+
+If using post-PR-#70 dispatch syntax in `unified_store`:
+```json
+{
+  "content": "<new>",
+  "action": "supersede",
+  "old_id": "abc-123",
+  "reason": "<why>",
+  "userId": "richard_yaker",
+  "metadata": { "subject": "Phoenix.camera_count" }
+}
+```
+
+### Step 6: Verify and Report
+
+After dispatching, re-run the cluster search to verify:
+
+```
+Reconciliation complete for Phoenix.camera_count:
+  ✓ 1 supersede applied (abc-123 → def-456)
+  ✓ 1 update applied (ghi-789, history bumped)
+  ✓ 1 delete applied (jkl-012)
+  ⚠ 1 orphan chain still pending manual repair (stu-901 → missing vwx-234)
+
+Cluster now: 4 active entries, 3 superseded (clean chains), 1 orphan flagged for manual review.
+
+Default-search will now return only the corrected version of camera_count.
+```
+
+## Why This Skill Exists
+
+The KMS dedup gate spec assumes per-write reconciliation is enough. It isn't. Per the OB1 study at `~/Documents/Notes/OB1-Lessons-vs-KMS-Direction.md`:
+
+> KMS encodes outer-loop policy *inside* the MCP server (dedup, supersede prompts, reaper). Both break the moment the client changes... **Incremental reconciliation** (write-time, cheap) → stays in the server. **Full reconciliation** (background brain-rewiring, expensive) → moves to user-space skills. This is what's currently missing.
+
+This skill IS the missing half. The gate prevents new debt; this skill drains old debt.
+
+## Frequency
+
+Run weekly or on-demand. Don't run after every session — that's over-fitting. The corpus needs accumulated drift before reconciliation finds signal.
+
+Heuristic: if `kms_get_kms_analytics` shows >20 writes since the last reconcile pass for a given subject, it's a candidate.
+
+## What This Skill Does NOT Do
+
+- Does NOT call `kms_reap` — that's a separate admin operation for hard-deleting entries past their 90-day soft-delete window
+- Does NOT auto-merge entries silently — every action needs Rich's approval
+- Does NOT run on the entire KMS at once — always scoped to a cluster (subject, topic, or contentType filter)
+- Does NOT touch entries outside the requested userId — always `userId: richard_yaker`
+
+## Cross-Reference
+
+- Single-fact correction: call `kms_supersede` / `kms_update` / `kms_delete` / `kms_flag` directly, no skill needed
+- Search and recall (no corrections): `kms-recall`
+- Hard cleanup of flagged entries: `kms_reap` (admin)
+- Write-time prevention: dedup gate (Tier 1, automatic on `unified_store`)

--- a/skills/kms-search-first/AGENTS.md
+++ b/skills/kms-search-first/AGENTS.md
@@ -1,0 +1,79 @@
+# KMS Search-First (Codex variant)
+
+Codex-flavored mandatory pre-generation reflex: search KMS BEFORE answering from training data when the user references prior context.
+
+## When this protocol applies
+
+Trigger phrases: "remember when", "we discussed", "I previously said", "did I store", "what did I decide about", "didn't we talk about", "I think I told you", "have I mentioned", "we worked on this before", "what's my preference for", "did I already note".
+
+Also fires when:
+- User asks a factual question about themselves, their projects, their preferences ("what's my X?", "how do I usually Y?")
+- User asks about a project/person/decision they likely have prior context on
+- You're about to generate a confident-sounding answer about Rich's preferences/projects/people from training data
+
+Do NOT fire on:
+- Pure-recall queries with no follow-up (use `kms-recall`)
+- Generic factual questions unrelated to Rich ("what's the syntax for jq?")
+- Real-time data ("what time is it?")
+
+## Process
+
+### Step 1 — Search
+
+```
+unified_search:
+  query: <topic the user referenced>
+  filters:
+    userId: richard_yaker
+    subject: <if a specific facet is implied>
+    source: <if a domain is clear>
+    minConfidence: 0.6 (optional)
+  options:
+    maxResults: 10
+    includeRelationships: true
+```
+
+### Step 2 — Surface results to the user
+
+Briefly. Don't silently absorb. Format:
+
+```
+Searched KMS for "<query>":
+  • [contentType, confidence%] subject — content preview
+  • [contentType, confidence%] subject — content preview
+
+Continuing with your question:
+```
+
+Three reasons for surfacing:
+- Transparency about what informed the answer
+- Correction opportunity if search missed or surfaced stale entries
+- Trust calibration — Rich knows it's grounded, not hallucinated
+
+### Step 3 — Proceed
+
+Search is the FIRST step, not the WHOLE step. After surfacing:
+- Question → answer using search hits as ground truth
+- Extending prior fact → `kms_update` or `kms_supersede` (NEVER additively `unified_store`)
+- Pure retrieve → done (this is `kms-recall`'s path)
+- Store new related → `unified_store` with `metadata.subject` matching prior entry's subject so they cluster
+
+### Step 4 — Handle no results
+
+If empty or low-confidence (<0.5):
+1. Say so explicitly: "I don't have anything stored about [topic] in your KMS."
+2. Offer alternatives:
+   - "Want me to search related terms? I might have something filed under [adjacent concept]."
+   - "Want me to add what we discuss to KMS?"
+3. Do NOT fall back to training data and answer as if you had context. Be honest about the gap.
+
+## Why this exists
+
+KMS adoption is bottlenecked by read failures. Every confident-from-training answer about Rich's context is a missed read AND a slow erosion of trust. Search-first cost is ~50ms; confidently-wrong cost is much higher.
+
+## What this protocol does NOT do
+
+- Does NOT replace `kms-recall` for pure-retrieval queries
+- Does NOT replace `kms-grounding` for full-context briefings
+- Does NOT call any storage tools — only `unified_search`. Storage decisions happen in the follow-on step using `kms-remember` / `kms-auto-capture` / `kms-meeting-synthesis`
+- Does NOT search for things unrelated to Rich's context

--- a/skills/kms-search-first/README.md
+++ b/skills/kms-search-first/README.md
@@ -1,0 +1,71 @@
+# kms-search-first
+
+The codification of "search before generating" as a portable behavioral skill. Triggers whenever the user references prior conversation, prior decisions, prior preferences — calls `unified_search` FIRST, surfaces results, THEN proceeds.
+
+See [SKILL.md](./SKILL.md) for the full protocol. See [AGENTS.md](./AGENTS.md) for the Codex-flavored variant.
+
+## What it does
+
+- Triggers on "remember when", "we discussed", "I previously said", "did I store", "what did I decide about", and other prior-context references
+- Calls `unified_search` BEFORE generating an answer — never after
+- Surfaces the search results to the user transparently (3-line bulleted summary)
+- Then proceeds with whatever the user actually wanted (extending / retrieving / storing related)
+- Honest about gaps: if search returns empty, says so explicitly instead of falling back to training-data generation
+
+This is intentionally minimal — most of the work is making sure search happens FIRST instead of as a fallback. Short skill, big behavioral shift.
+
+## Install
+
+### Claude Code (personal)
+```bash
+mkdir -p ~/.claude/skills/kms-search-first
+cp /Users/ryaker/Dev/KMSmcp/skills/kms-search-first/SKILL.md ~/.claude/skills/kms-search-first/SKILL.md
+```
+
+### Claude Code (project)
+```bash
+ln -sf /Users/ryaker/Dev/KMSmcp/skills/kms-search-first /Users/ryaker/Dev/KMSmcp/.claude/skills/kms-search-first
+```
+
+### Cowork
+```
+/plugin marketplace add ryaker/KMSmcp
+/plugin install kms-skills@ryaker/KMSmcp
+```
+
+### claude.ai web Project
+Paste body of `SKILL.md` (post-frontmatter) into Project's Custom instructions.
+
+### iOS
+Automatic via claude.ai Project.
+
+### Codex CLI
+```bash
+cp /Users/ryaker/Dev/KMSmcp/skills/kms-search-first/AGENTS.md /path/to/project/AGENTS.md
+```
+
+## Verifying Install
+
+Type something that references prior context, e.g.:
+> "remember when we discussed the Phoenix camera count?"
+
+The agent should:
+1. Call `unified_search` with "Phoenix camera count" + filter `userId: richard_yaker`
+2. Surface results in a bulleted list
+3. Then answer your question
+
+If it generates an answer without searching first, the skill isn't loaded.
+
+## Distinction from kms-recall
+
+| Skill | When |
+|---|---|
+| `kms-recall` | Pure retrieval query — user asks "what do I know about X" and wants a search-and-present answer, no follow-up action |
+| `kms-search-first` | User references prior context AND wants follow-up action (extend, store, use as ground truth for next answer) |
+| `kms-grounding` | User wants a synthesized briefing on a topic before working on it (more synthesis-heavy than retrieval-heavy) |
+
+Both `kms-recall` and `kms-search-first` call `unified_search`. The difference is what happens AFTER — search-first chains into the next task; recall ends after presentation.
+
+## Trigger Phrases (Reference)
+
+`remember when`, `we discussed`, `I previously said`, `did I store`, `what did I decide about`, `didn't we talk about`, `I think I told you`, `have I mentioned`, `we worked on this before`, `what's my preference for`, `did I already note`

--- a/skills/kms-search-first/SKILL.md
+++ b/skills/kms-search-first/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: kms-search-first
+description: >
+  Search Richard's Personal KMS BEFORE answering from training data or generating
+  net-new content, whenever the user references prior conversation, prior decisions,
+  prior facts, or prior preferences. Triggers on "remember when", "we discussed",
+  "I previously said", "did I store", "what did I decide about", "didn't we talk
+  about", "I think I told you", "have I mentioned", "we worked on this before",
+  "what's my preference for", "did I already note", or any reference to prior
+  context that would require KMS retrieval to answer accurately. Calls
+  unified_search FIRST, surfaces results, THEN proceeds with whatever the user
+  actually wanted (extending, retrieving, or storing). Behavioral inversion:
+  search BEFORE generation, not as a fallback. Do NOT use as a replacement for
+  kms-recall in pure-retrieval queries — kms-recall is search-and-present;
+  kms-search-first is search-then-act.
+version: 1.0
+author: richard_yaker
+---
+
+# KMS Search-First — The Mandatory Pre-Generation Reflex
+
+When the user references prior conversation, prior decisions, prior preferences, or anything that implies KMS-stored context, **call `unified_search` BEFORE generating an answer**. This is the codification of the "search first, store smart" rule from CLAUDE.md as a portable behavioral skill.
+
+The behavioral shift this enforces: **search is the FIRST action, not a fallback when training data fails.**
+
+## Trigger Conditions
+
+Fire on:
+- Trigger phrases listed in frontmatter
+- User makes ANY claim of the form "I [previously / earlier / before] [said / decided / stored / mentioned / noted] X"
+- User asks a factual question about themselves, their projects, their preferences ("what's my X?", "how do I usually Y?")
+- User asks about a project, person, or technical decision they likely have prior context on
+- You're about to generate a confident-sounding answer about Rich's preferences/projects/people from training data
+
+That last one is the critical case. If you find yourself confidently generating a Rich-specific answer without checking, that's the trigger. Stop and search.
+
+Do NOT fire on:
+- Pure-recall queries with no follow-up action ("what do I know about X?") — use `kms-recall` instead
+- Generic factual questions unrelated to Rich's personal context ("what's the syntax for jq?")
+- Real-time data ("what time is it?")
+
+## Process
+
+### Step 1: Search
+
+```json
+{
+  "query": "<the topic the user referenced>",
+  "filters": { "userId": "richard_yaker" },
+  "options": {
+    "maxResults": 10,
+    "includeRelationships": true
+  }
+}
+```
+
+Tighten with filters when you have signal:
+- Topic-specific subject: add `filters.subject: "Phoenix.camera_count"` (exact facet)
+- Domain known: add `filters.source: ["technical"]` or `["personal"]`
+- Confidence floor: `filters.minConfidence: 0.6`
+
+### Step 2: Surface Results to the User
+
+Don't silently absorb the results into the next answer. **Show what you found**, briefly:
+
+```
+Searched KMS for "Phoenix camera count":
+  • [fact, 88%] Phoenix.camera_count — UNKNOWN pending canvas-bounds verification
+    (superseded earlier 6-camera claim; reason: wrong zoom config + A-only FOV)
+  • [insight, 79%] Phoenix.calibration_status — calibration deferred 2 weeks per 2026-05-06 review
+
+Continuing with your question:
+```
+
+This serves three purposes:
+1. **Transparency** — Rich sees what context informed the next answer
+2. **Correction opportunity** — if the search missed something or surfaced a stale entry, Rich can redirect
+3. **Trust calibration** — Rich knows the answer is grounded in stored context, not hallucination
+
+### Step 3: Proceed With What Rich Actually Wanted
+
+The search is the FIRST step, not the WHOLE step. After surfacing results:
+
+- If user asked a question → answer it using the search hits as ground truth
+- If user wants to extend a prior fact → use `kms_update` or `kms_supersede` (NEVER additively `unified_store`)
+- If user wants to retrieve only → you're done; this is the `kms-recall` path
+- If user wants to store something new related to the prior context → `unified_store` with `metadata.subject` matching the prior entry's subject so they're queryable as a cluster
+
+### Step 4: Handle "No Results"
+
+If search returns empty or low-confidence (<0.5) hits:
+1. Say so explicitly: "I don't have anything stored about [topic] in your KMS."
+2. Offer alternatives:
+   - "Want me to search for related terms? I might have something filed under [adjacent concept]."
+   - "Want me to add what we discuss now to KMS as a new entry?"
+3. Do NOT silently fall back to training data and answer as if you had context. Be honest about the gap.
+
+## Why This Skill Exists
+
+KMS adoption is bottlenecked by **read failures**, not write failures. The corpus has 200+ entries; most never get retrieved because the agent doesn't think to search. Every confident-from-training answer about Rich's preferences/projects is a missed read — and a slow erosion of trust in the KMS as a source.
+
+This skill makes search-first into muscle memory. The cost of an unnecessary search is ~50ms; the cost of a confidently-wrong answer that contradicts stored context is much higher.
+
+## What This Skill Does NOT Do
+
+- Does NOT replace `kms-recall` for pure-retrieval queries — that skill is search-and-present, this one is search-then-act
+- Does NOT replace `kms-grounding` for full-context briefings — that skill synthesizes; this one is a reflex
+- Does NOT call any storage tools — only `unified_search`. Storage decisions happen in the follow-on step using the skill that fits (`kms-remember`, `kms-auto-capture`, `kms-meeting-synthesis`)
+- Does NOT search for things unrelated to Rich's context — generic web-knowledge questions don't trigger this
+
+## Cross-Reference
+
+- Pure search-and-present: `kms-recall`
+- Full briefing on a topic: `kms-grounding`
+- Single-item store after search: `kms-remember`
+- Session-end batched store: `kms-auto-capture`
+- Correct a prior wrong fact found in search: `kms_supersede` (direct tool call, not a skill)

--- a/skills/kms-trust-boundaries/AGENTS.md
+++ b/skills/kms-trust-boundaries/AGENTS.md
@@ -1,0 +1,81 @@
+# KMS Trust Boundaries (Codex variant)
+
+Codex-flavored corpus trust enforcement for L16/Lumen/libcp work. Codifies KMS memory `54f04f28-259e-4c8c-9f6e-64cefc8fff52`.
+
+## When this protocol applies
+
+Fires on:
+- ANY file operation (Read, Grep, ingest, cite, summarize) where path matches `Light_*`
+- ANY claim about Lumen, libcp, L16, or related reverse-engineering topics where source provenance matters
+- User asks "is this verified" / "can I trust this source" / "is this canonical"
+- About to call `unified_store` with content from an UNTRUSTED path
+- About to cite a fact in an answer where source is UNTRUSTED
+
+Does NOT fire on:
+- Generic file ops on unrelated directories
+- Citation of L16 facts where source is the TRUSTED `L16_Lumen_ReverseEngineering` repo
+- Quoting Rich-authored notes in `~/Documents/Notes/` (case-by-case, neither blanket-trusted nor blanket-untrusted)
+
+## Trust matrix
+
+| Path | Trust | Meaning |
+|---|---|---|
+| `/Users/ryaker/Dev/L16_Lumen_ReverseEngineering/` | TRUSTED | Codex-curated canonical source. Cite freely. Ingest into KMS as `fact`/`procedure`. |
+| `~/Documents/Light_Work/` (and `Light_*` siblings) | UNTRUSTED | Working drafts, AI output, scratch notes, unverified external content. Do NOT cite as fact. Do NOT ingest into KMS without explicit user override. |
+
+Path-name pattern matters: `Light_Work` and `L16_Lumen_ReverseEngineering` look similar, opposite trust. A future `Light_Lumen_v2/` would be UNTRUSTED until Rich explicitly promotes it.
+
+## Behavioral rules
+
+### Rule 1: reading allowed; citing constrained
+
+You MAY read UNTRUSTED files — they often contain context Rich wants you to consider. Citing them as fact is what's constrained.
+
+When citing UNTRUSTED content:
+- Prefix `[unverified]` in the answer
+- Name source path explicitly
+- If TRUSTED counterpart exists in `L16_Lumen_ReverseEngineering`, prefer it
+- If conflict between UNTRUSTED claim and TRUSTED L16 repo, surface BOTH and recommend the L16 version
+
+### Rule 2: no UNTRUSTED → KMS without explicit override
+
+Before `unified_store` from a `Light_*` path:
+1. STOP. Tell Rich: "This content is from an UNTRUSTED path (`<path>`). Ingesting into KMS would promote it to fact-status."
+2. Ask: "Do you want me to (a) ingest with `metadata.trust=unverified`, (b) verify against L16 repo first, or (c) skip the ingest?"
+3. Wait for explicit approval. Default to (c) skip.
+
+If approved:
+- Always include `metadata.trust: "unverified"` and `metadata.source_path: "<full path>"`
+- Always include `metadata.subject` for future supersede-ability
+- Strongly consider `contentType: pattern` or flag `'UNVERIFIED'` instead of `fact`/`insight`
+
+### Rule 3: prefer TRUSTED source for any Lumen/libcp/L16 claim
+
+When generating answers involving Lumen, libcp, or L16:
+1. Check `L16_Lumen_ReverseEngineering` first
+2. If user-cited material conflicts with L16 repo, surface conflict — don't silently pick
+3. KMS entries with `metadata.subject = L16.*` older than 30 days should be checked against the L16 repo (repo is moving canonical, KMS entries are point-in-time captures)
+
+### Rule 4: verify-before-trust extends to path heuristics
+
+Same path-name pattern, opposite trust levels. When in doubt about a new directory's trust level, ASK before treating it as canonical.
+
+## Operational checklist
+
+Before any write that could touch the L16/Lumen knowledge boundary:
+
+- [ ] Source path identified
+- [ ] Trust level determined (TRUSTED / UNTRUSTED / project-specific)
+- [ ] If UNTRUSTED: did Rich explicitly approve KMS ingest?
+- [ ] If citing: is `[unverified]` prefix present for UNTRUSTED sources?
+- [ ] If conflict with L16 repo: surfaced explicitly to Rich?
+- [ ] Subject facet set for future supersede-ability?
+
+## Cross-reference
+
+- Canonical write-up: KMS memory `54f04f28-259e-4c8c-9f6e-64cefc8fff52`
+- L16 repo: `/Users/ryaker/Dev/L16_Lumen_ReverseEngineering/`
+- Untrusted scratch: `~/Documents/Light_Work/` and `Light_*` siblings
+- Always check KMS first: `kms-search-first`
+- Meeting transcripts of L16 review meetings are TRUSTED, ingest with `subject: L16.*`: `kms-meeting-synthesis`
+- When wrong fact leaked through: `kms_supersede` with reason citing this skill's Rule 2 violation

--- a/skills/kms-trust-boundaries/README.md
+++ b/skills/kms-trust-boundaries/README.md
@@ -1,0 +1,71 @@
+# kms-trust-boundaries
+
+Enforces corpus trust boundaries when reading, citing, or ingesting any document for Lumen / libcp / L16 reverse-engineering work. Codifies KMS memory `54f04f28-259e-4c8c-9f6e-64cefc8fff52` as a portable behavioral skill.
+
+See [SKILL.md](./SKILL.md) for the full protocol. See [AGENTS.md](./AGENTS.md) for the Codex-flavored variant.
+
+## What it does
+
+- Recognizes path-name trust levels:
+  - `~/Dev/L16_Lumen_ReverseEngineering/` → **TRUSTED** (canonical L16 source)
+  - `~/Documents/Light_Work/` (and `Light_*` siblings) → **UNTRUSTED** (drafts, AI output, scratch)
+- Allows reading UNTRUSTED files but constrains citation: prefix `[unverified]` and name source path
+- Refuses to ingest UNTRUSTED content into KMS without explicit user override
+- Surfaces conflicts when UNTRUSTED claims contradict the L16 canonical repo
+- Verify-before-trust extends to path-name heuristics (similar names ≠ similar trust)
+
+## Install
+
+### Claude Code (personal)
+```bash
+mkdir -p ~/.claude/skills/kms-trust-boundaries
+cp /Users/ryaker/Dev/KMSmcp/skills/kms-trust-boundaries/SKILL.md ~/.claude/skills/kms-trust-boundaries/SKILL.md
+```
+
+### Claude Code (project)
+```bash
+ln -sf /Users/ryaker/Dev/KMSmcp/skills/kms-trust-boundaries /Users/ryaker/Dev/KMSmcp/.claude/skills/kms-trust-boundaries
+```
+
+### Cowork
+```
+/plugin marketplace add ryaker/KMSmcp
+/plugin install kms-skills@ryaker/KMSmcp
+```
+
+### claude.ai web Project
+Paste body of `SKILL.md` (post-frontmatter) into Project's Custom instructions.
+
+### iOS
+Automatic via claude.ai Project.
+
+### Codex CLI
+```bash
+cp /Users/ryaker/Dev/KMSmcp/skills/kms-trust-boundaries/AGENTS.md /path/to/project/AGENTS.md
+```
+
+## Verifying Install
+
+Ask the agent to "ingest the contents of `~/Documents/Light_Work/<some-file>.md` into KMS." The skill should:
+1. Detect the path is UNTRUSTED
+2. STOP and tell you it would promote the content to fact-status
+3. Ask if you want to (a) ingest with `metadata.trust=unverified`, (b) verify against L16 repo first, or (c) skip
+4. Default to (c) skip if no answer
+
+If the agent silently ingests, the skill isn't loaded.
+
+## Why This Exists
+
+In prior sessions, AI-generated speculation in `Light_Work/` got cited as fact and ingested into KMS, where it then leaked into every future session's context injection. Once a wrong "Phoenix uses 6 cameras" entry is in the corpus, every search that touches Phoenix surfaces it. This skill prevents the input-side of that failure mode.
+
+The complementary write-time enforcement is the dedup gate (refuses near-duplicates). The complementary correction tool is `kms_supersede` (cleans up wrong facts that already leaked). This skill is the prevention layer.
+
+## Trigger Phrases (Reference)
+
+`is this verified`, `can I trust this source`, `is this canonical`, `should I cite this`, `ingest this into KMS` (when source is `Light_*`), and any operation against paths matching the trust matrix.
+
+## Cross-Reference
+
+- Canonical write-up: KMS memory `54f04f28-259e-4c8c-9f6e-64cefc8fff52`
+- L16 repo: `/Users/ryaker/Dev/L16_Lumen_ReverseEngineering/`
+- Untrusted scratch space: `~/Documents/Light_Work/` (and `Light_*` siblings)

--- a/skills/kms-trust-boundaries/SKILL.md
+++ b/skills/kms-trust-boundaries/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: kms-trust-boundaries
+description: >
+  Enforce corpus trust boundaries when reading, citing, or ingesting any document
+  for Richard's projects — especially Lumen / libcp / L16 reverse-engineering work.
+  Triggers when working with files under ~/Documents/Light_Work/ (UNTRUSTED),
+  ~/Dev/L16_Lumen_ReverseEngineering/ (TRUSTED), or any L16/Lumen/libcp claim.
+  Also triggers on "is this verified", "can I trust this source", "is this
+  canonical", "should I cite this", "ingest this into KMS" when the source is
+  Light_*, or any operation that risks promoting untrusted material into KMS as
+  fact. Refuses to cite from UNTRUSTED paths without "[unverified]" prefix and
+  refuses to ingest into KMS without explicit user override. Codifies the rule
+  stored in KMS memory 54f04f28-259e-4c8c-9f6e-64cefc8fff52. Do NOT use as a
+  generic file-trust skill — this is L16/Lumen-corpus-specific and applies
+  Rich's verify-before-trust standard for that domain.
+version: 1.0
+author: richard_yaker
+---
+
+# KMS Trust Boundaries — Corpus Trust Enforcement
+
+Some directories on Rich's machine contain canonical, verified material. Others contain working drafts, experiments, AI-generated speculation, or untrusted external dumps. Treating them interchangeably has caused incorrect facts to leak into KMS in the past. This skill encodes the boundary.
+
+The canonical write-up of this rule is stored in KMS as memory `54f04f28-259e-4c8c-9f6e-64cefc8fff52`. This skill is the agent-facing enforcement protocol.
+
+## Trust Levels
+
+| Path | Trust | Meaning |
+|---|---|---|
+| `/Users/ryaker/Dev/L16_Lumen_ReverseEngineering/` | **TRUSTED** | Codex-curated canonical L16/Lumen/libcp source. Cite freely. Ingest into KMS as `fact` / `procedure`. |
+| `~/Documents/Light_Work/` (and `Light_*` siblings) | **UNTRUSTED** | Working drafts, AI-generated material, scratch notes, unverified external content. Do NOT cite as fact. Do NOT ingest into KMS without explicit user override. |
+| Other Rich-authored notes in `~/Documents/Notes/`, code in `~/Dev/<other-projects>/` | Project-specific | Use project's own conventions; this skill does not override |
+
+The path-name pattern matters: `Light_*` directories have **opposite** trust levels from each other and from `L16_Lumen_ReverseEngineering`. A file at `~/Documents/Light_Work/phoenix-config.md` and one at `~/Dev/L16_Lumen_ReverseEngineering/phoenix-config.md` may say opposite things — the L16 path wins.
+
+## Trigger Conditions
+
+Fire on:
+- ANY file operation (Read, Grep, ingest, cite, summarize) where the path matches `Light_*`
+- ANY claim about Lumen, libcp, L16, or related reverse-engineering topics where source provenance matters
+- User asks "is this verified" / "can I trust this source" / "is this canonical"
+- About to call `unified_store` with content sourced from an UNTRUSTED path
+- About to cite a fact in an answer where the source is UNTRUSTED
+
+Do NOT fire on:
+- Generic file operations on unrelated directories
+- Citation of L16 facts where the source is the TRUSTED `L16_Lumen_ReverseEngineering` repo
+- Quoting Rich-authored notes in `~/Documents/Notes/` (those are Rich's working space — neither blanket-trusted nor blanket-untrusted, treated case-by-case)
+
+## Behavioral Rules
+
+### Rule 1: Reading Is Allowed; Citing Is Constrained
+
+You MAY read files under UNTRUSTED paths (`Light_*`) — they often contain context Rich wants you to consider. What's constrained is **citing them as fact**.
+
+When you cite content from an UNTRUSTED path:
+- Prefix with `[unverified]` in the answer
+- Name the source path explicitly so Rich can verify
+- If a TRUSTED counterpart exists in `L16_Lumen_ReverseEngineering`, prefer it
+
+Example:
+```
+Per ~/Documents/Light_Work/phoenix-camera-spec.md [unverified]: Phoenix uses 6 cameras.
+
+⚠ This contradicts the canonical entry in
+  ~/Dev/L16_Lumen_ReverseEngineering/cameras/phoenix.md, which says camera count
+  is configuration-dependent (config 0 = 4 cameras, config 2 = 6 cameras).
+
+Recommend deferring to the L16 repo unless you have new info.
+```
+
+### Rule 2: Do NOT Ingest UNTRUSTED Content Into KMS Without Explicit Override
+
+Before calling `unified_store` with content from a `Light_*` path:
+1. STOP. Tell Rich: "This content is from an UNTRUSTED path (`<path>`). Ingesting into KMS would promote it to fact-status."
+2. Ask: "Do you want me to (a) ingest with `metadata.trust=unverified`, (b) verify against L16 repo first, or (c) skip the ingest?"
+3. Wait for explicit approval.
+
+Default to (c) skip. The cost of a wrong fact in KMS leaking into every future session via context injection is high; the cost of skipping a draft is zero.
+
+If approval is given:
+- Always include `metadata.trust: "unverified"` and `metadata.source_path: "<full path>"`
+- Always include `metadata.subject` so future supersede calls can fix it cleanly
+- Strongly consider `contentType: pattern` or a flag like `'UNVERIFIED'` instead of `fact`/`insight`
+
+### Rule 3: For ANY Lumen/libcp/L16 Claim — Prefer the TRUSTED Source
+
+When generating an answer that involves Lumen, libcp, or L16:
+1. Check if `L16_Lumen_ReverseEngineering` has the relevant info first
+2. If user-cited material conflicts with L16 repo, surface the conflict — don't silently pick one
+3. KMS entries with `metadata.subject = L16.*` should be checked against the L16 repo if the entry is older than 30 days; the repo is the moving canonical, KMS entries are point-in-time captures
+
+### Rule 4: Verify-Before-Trust Extends to Path-Name Heuristics
+
+Same path-name pattern, opposite trust levels:
+- `Light_Work` ≠ `L16_Lumen_ReverseEngineering` despite the visual similarity
+- A future directory named `Light_Lumen_v2/` would be UNTRUSTED until Rich explicitly promotes it
+
+When in doubt about a new directory's trust level, ASK before treating it as canonical.
+
+## Operational Checklist (Fast Reference)
+
+Before any write that could touch the L16/Lumen knowledge boundary:
+
+```
+[ ] Source path identified
+[ ] Trust level determined (TRUSTED / UNTRUSTED / project-specific)
+[ ] If UNTRUSTED: did Rich explicitly approve KMS ingest?
+[ ] If citing: is "[unverified]" prefix present for UNTRUSTED sources?
+[ ] If conflict with L16 repo: surfaced explicitly to Rich?
+[ ] Subject facet set for future supersede-ability?
+```
+
+## Cross-Reference
+
+- Canonical write-up of this rule: KMS memory `54f04f28-259e-4c8c-9f6e-64cefc8fff52`
+- Related: `kms-search-first` (always check KMS before generating Lumen claims)
+- Related: `kms-meeting-synthesis` (transcripts of L16 review meetings ARE trusted, ingest with subject `L16.*`)
+- Corrective when wrong fact leaked through: `kms_supersede` with reason citing this skill's Rule 2 violation


### PR DESCRIPTION
## Summary

Adds a **Skills Layer** to KMSmcp — five portable behavioral protocols that lift the KMS curation policy out of CLAUDE.md (Claude Code-only, Mac mini-only) and into client-portable SKILL.md files that work across **Claude Code, Cowork (Claude Desktop), claude.ai web, iOS, and Codex CLI**.

Implements the **OB1 Pattern 1 outer-loop model** from the design study at \`~/Documents/Notes/OB1-Lessons-vs-KMS-Direction.md\`: KMSmcp stays the dumb storage primitive; behavioral patterns move into skills that fire in any client where Rich talks to Claude.

**No code changes to KMSmcp's TS source** — pure markdown + YAML.

## The Five Skills

| Skill | Behavior |
|---|---|
| \`kms-auto-capture\` | Session-end distillation into atomic claims. Search-first; \`metadata.subject\` REQUIRED; routes contradictions through \`kms_supersede\` instead of additive store |
| \`kms-meeting-synthesis\` | Granola/Slack/call transcript → 1 whole-meeting summary + 2-5 typed atomic claims linked via \`metadata.related_to\`. In-conversation companion to the cron-driven importer (PR #74) |
| \`kms-reconcile-pass\` | Full-reconciliation outer loop. **PROPOSES** corrective actions, never silently applies. OB1 Pattern 1's currently-missing half (incremental reconciliation lives in the gate; full reconciliation lives here) |
| \`kms-search-first\` | Mandatory pre-generation reflex — \`unified_search\` BEFORE answering when user references prior context. Codifies the "search first, store smart" rule from CLAUDE.md as a portable skill |
| \`kms-trust-boundaries\` | Enforces L16/Lumen corpus trust boundaries. UNTRUSTED \`Light_*\` paths require \`[unverified]\` citation and explicit override before KMS ingest (codifies KMS memory \`54f04f28-259e-4c8c-9f6e-64cefc8fff52\`) |

## Files

```
skills/
├── README.md                            # top-level index + unified install matrix
├── .claude-plugin/plugin.json           # Cowork plugin manifest (kms-skills@1.0.0)
├── kms-auto-capture/{SKILL,README,AGENTS}.md
├── kms-meeting-synthesis/{SKILL,README,AGENTS}.md
├── kms-reconcile-pass/{SKILL,README,AGENTS}.md
├── kms-search-first/{SKILL,README,AGENTS}.md
└── kms-trust-boundaries/{SKILL,README,AGENTS}.md
```

Each skill ships **3 files**:
- \`SKILL.md\` — Anthropic skills frontmatter + behavioral body (Claude Code, Cowork, claude.ai)
- \`README.md\` — install instructions for all 5 clients
- \`AGENTS.md\` — Codex-flavored variant (pure markdown, no YAML frontmatter, per agents.md spec)

Plus \`.gitignore\` was tweaked to allowlist \`skills/**/*.json\` (the existing \`*.json\` blanket-ignore would have hidden the plugin manifest).

## Cross-Client Install (Highlights)

**Claude Code (personal, all projects):**
\`\`\`bash
SKILLS_SRC=/Users/ryaker/Dev/KMSmcp/skills
for s in kms-auto-capture kms-meeting-synthesis kms-reconcile-pass kms-search-first kms-trust-boundaries; do
  mkdir -p ~/.claude/skills/\$s && cp \$SKILLS_SRC/\$s/SKILL.md ~/.claude/skills/\$s/SKILL.md
done
\`\`\`

**Cowork (Claude Desktop):**
\`\`\`
/plugin marketplace add ryaker/KMSmcp
/plugin install kms-skills@ryaker/KMSmcp
\`\`\`
(Marketplace publishing deferred — see "Out of scope" below. Manual copy works today.)

**claude.ai web Project:** paste \`SKILL.md\` body (post-frontmatter) into Project's Custom instructions. iOS inherits.

**Codex CLI:** \`cp skills/<name>/AGENTS.md /path/to/project/AGENTS.md\` (or to \`~/AGENTS.md\` for global).

Full matrix in \`skills/README.md\`.

## Design Choices Resolved

- **Frontmatter**: matches Anthropic's published spec (\`name\`, \`description\`, plus \`version\` and \`author\` as informational fields). Verified all descriptions land well under the 1,536-char cap (max 918 chars).
- **AGENTS.md format**: pure markdown, no YAML — per the agents.md spec (Codex parses any heading structure).
- **Plugin manifest location**: \`skills/.claude-plugin/plugin.json\` per the Anthropic plugin spec (\`.claude-plugin/\` at plugin root, NOT a top-level \`skills/plugin.json\`).
- **\`metadata.subject\` is REQUIRED** in every skill's store call (when the fact is one Rich expects to update/supersede). Aligns with the DG-FACET-A guidance in CLAUDE.md.
- **\`dedup_required\` handling** is explicit in every skill — never blind retry. Skills route to \`supersede\` / \`update\` / \`complement\` / \`force-new\` based on the contradiction type.
- **CLAUDE.md untouched** — separately tracked, referenced only.

## Out of Scope

- **Marketplace publishing** to the official Anthropic marketplace (\`claude.ai/settings/plugins/submit\`) — separate authorization gate Rich hasn't approved. Plugin manifest is in place; manual copy / symlink / paste works for all clients today.
- **MCP connector setup** for Cowork / claude.ai — these are configured separately at \`https://kms.yaker.org/mcp\`. Skills assume the MCP is already connected.
- **Auto-install hooks** — these are skills, not hooks. Hook-bound auto-storage in Claude Code (\`kms-periodic-checkpoint.sh\`) is left in place; \`kms-auto-capture\` coexists rather than replaces (per Open Question 4 in OB1 design study).

## References

- OB1 design study: \`~/Documents/Notes/OB1-Lessons-vs-KMS-Direction.md\`
- Anthropic skills spec: https://code.claude.com/docs/en/skills
- Plugin spec: https://code.claude.com/docs/en/plugins
- AGENTS.md spec: https://agents.md
- Trust-boundaries canonical: KMS memory \`54f04f28-259e-4c8c-9f6e-64cefc8fff52\`

## Test Plan

- [ ] In Claude Code: install one skill personally, type a trigger phrase, verify it fires
- [ ] In claude.ai web: create a Project, paste the body of \`kms-search-first/SKILL.md\` into Custom instructions, verify the search-first reflex behavior
- [ ] In Codex CLI: \`cp skills/kms-auto-capture/AGENTS.md ~/AGENTS.md\`, start a Codex session, type "wrap up", verify the protocol fires
- [ ] Validate frontmatter parses cleanly (already done locally — all 5 skills validated)
- [ ] Validate \`plugin.json\` is well-formed JSON (already done locally)
- [ ] Verify \`skills/.claude-plugin/plugin.json\` committed and not gitignored (verified: \`.gitignore\` updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)