### PR TITLE
feat(dedup-gate): Tier 0 fingerprint dedup (prepend)

### DIFF
--- a/dist/dedup/Fingerprint.js
+++ b/dist/dedup/Fingerprint.js
@@ -31,15 +31,34 @@
  * subsequent Tier 0 lookups can match against it directly.
  */
 import crypto from 'crypto';
+// Horizontal whitespace character class — used by normalize() to identify
+// non-newline whitespace. Enumerates space, tab, form-feed, vertical-tab,
+// and U+00A0 non-breaking space. NBSP is included because it commonly
+// appears in copy-pasted content from rich-text sources (Word, Google
+// Docs) and would otherwise fork the fingerprint vs the plain-space
+// version of the same content. Newlines are deliberately excluded so
+// paragraph structure is preserved at the higher level.
+const HWS_CHAR = /[ \t\f\v ]/;
+const HWS_RUN_GLOBAL = /[ \t\f\v ]+/g;
+const HWS_TRAILING = /[ \t\f\v ]+$/;
 /**
  * Normalize content for fingerprinting. Two strings that differ only in
- * whitespace produce the same fingerprint.
+ * trailing whitespace, internal whitespace runs, or line-ending style
+ * produce the same fingerprint.
  *
  * Rules:
- *   - Strip trailing whitespace from each line
- *   - Collapse runs of horizontal whitespace WITHIN a line to a single space
  *   - Normalize line endings (CRLF / CR → LF)
+ *   - Strip TRAILING horizontal whitespace from each line
+ *   - Collapse runs of horizontal whitespace WITHIN a line to a single space
+ *     (but preserve a single leading-indent block intact)
  *   - Strip leading/trailing blank lines from the whole content
+ *
+ * Why leading indentation is preserved: indentation is semantically
+ * meaningful in code blocks, nested lists, and structured prose. Collapsing
+ * `"    code()"` and `"code()"` to the same fingerprint would let Tier 0
+ * declare two non-equivalent entries identical. We collapse internal runs
+ * (so `"foo    bar"` and `"foo bar"` match) but keep the first leading-
+ * whitespace block of each line verbatim.
  *
  * We deliberately preserve internal blank lines (between paragraphs) so
  * structurally distinct content stays distinct after normalization.
@@ -50,20 +69,23 @@ export function normalize(content) {
     // Normalize line endings first so per-line operations work uniformly.
     const unifiedNewlines = content.replace(/\r\n?/g, '\n');
     const lines = unifiedNewlines.split('\n').map(line => {
-        // Collapse runs of horizontal whitespace within the line to a single
-        // space. We explicitly enumerate horizontal whitespace (space, tab,
-        // form-feed, vertical-tab, U+00A0 non-breaking space) instead of \s
-        // so paragraph structure (newlines) is preserved. NBSP is included
-        // because it commonly appears in copy-pasted content from rich-text
-        // sources and would otherwise fork the fingerprint vs the plain-space
-        // version of the same content.
-        const collapsed = line.replace(/[ \t\f\v ]+/g, ' ');
-        // Strip leading + trailing whitespace per-line (line-internal already
-        // collapsed; this drops the leading/trailing single-space residue).
-        return collapsed.trim();
+        // 1) Capture leading indentation (the contiguous block of horizontal
+        //    whitespace at the start of the line). Preserved verbatim —
+        //    collapsing it would erase code/list semantics.
+        let leadingEnd = 0;
+        while (leadingEnd < line.length && HWS_CHAR.test(line.charAt(leadingEnd))) {
+            leadingEnd++;
+        }
+        const leading = line.slice(0, leadingEnd);
+        const rest = line.slice(leadingEnd);
+        // 2) Collapse internal whitespace runs in the rest of the line.
+        const collapsedRest = rest.replace(HWS_RUN_GLOBAL, ' ');
+        // 3) Strip trailing horizontal whitespace only — leading indent kept.
+        return (leading + collapsedRest).replace(HWS_TRAILING, '');
     });
-    // Drop leading + trailing blank lines so wrapping noise doesn't fork the
-    // fingerprint. Internal blank lines preserved (paragraph structure).
+    // Drop leading + trailing fully-blank lines so wrapping noise doesn't
+    // fork the fingerprint. (After the per-line trailing strip, lines that
+    // were pure-whitespace have become empty strings and qualify as blank.)
     let start = 0;
     let end = lines.length;
     while (start < end && lines[start] === '')

--- a/dist/dedup/Fingerprint.js
+++ b/dist/dedup/Fingerprint.js
@@ -1,0 +1,94 @@
+/**
+ * Tier 0 fingerprint dedup (issue: DG-T0).
+ *
+ * Computes a deterministic SHA-256 fingerprint over the tuple
+ *   (normalized_content, userId, contentType, subject ?? '')
+ *
+ * Used by the dedup gate as a CHEAP prepend layer that runs BEFORE the
+ * Tier 1 vector similarity check in `unified_store`. Two writes that produce
+ * the same fingerprint are guaranteed-identical at the content/scope level
+ * (modulo benign whitespace differences) — no embedder, no cosine math,
+ * no LLM judge needed.
+ *
+ * Why Tier 0 helps even with HNSW populated:
+ *   1. **Whitespace-equivalent inputs.** Two writes that differ only in
+ *      trailing spaces or line-ending style hash to different bytes BUT
+ *      are equivalent content. The embedder will score them very high
+ *      (often >0.99) but not always above the 0.88 refuse threshold —
+ *      especially for very short content where each token weighs heavily.
+ *      Tier 0's normalize() collapses these to the same fingerprint.
+ *   2. **Latency short-circuit.** A fingerprint check is an O(n) scan of
+ *      the in-memory sidecar (~1200 entries → ~0.1 ms). The Tier 1 path
+ *      is HNSW search (1-3 ms) + JS post-filter + (sometimes) Anthropic
+ *      Haiku 4.5 round-trip (5 s timeout). Tier 0 catches the easy cases
+ *      for free.
+ *   3. **Exact-match certainty.** When the LLM judge or the embedder is
+ *      down (Ollama unreachable, ANTHROPIC_API_KEY unset), Tier 0 still
+ *      catches identical re-stores. Useful for batch importers and the
+ *      "user accidentally hit submit twice" case.
+ *
+ * The fingerprint is stored in `metadata.fingerprint` on the new entry so
+ * subsequent Tier 0 lookups can match against it directly.
+ */
+import crypto from 'crypto';
+/**
+ * Normalize content for fingerprinting. Two strings that differ only in
+ * whitespace produce the same fingerprint.
+ *
+ * Rules:
+ *   - Strip trailing whitespace from each line
+ *   - Collapse runs of horizontal whitespace WITHIN a line to a single space
+ *   - Normalize line endings (CRLF / CR → LF)
+ *   - Strip leading/trailing blank lines from the whole content
+ *
+ * We deliberately preserve internal blank lines (between paragraphs) so
+ * structurally distinct content stays distinct after normalization.
+ */
+export function normalize(content) {
+    if (typeof content !== 'string')
+        return '';
+    // Normalize line endings first so per-line operations work uniformly.
+    const unifiedNewlines = content.replace(/\r\n?/g, '\n');
+    const lines = unifiedNewlines.split('\n').map(line => {
+        // Collapse runs of horizontal whitespace within the line to a single
+        // space. We explicitly enumerate horizontal whitespace (space, tab,
+        // form-feed, vertical-tab, U+00A0 non-breaking space) instead of \s
+        // so paragraph structure (newlines) is preserved. NBSP is included
+        // because it commonly appears in copy-pasted content from rich-text
+        // sources and would otherwise fork the fingerprint vs the plain-space
+        // version of the same content.
+        const collapsed = line.replace(/[ \t\f\v ]+/g, ' ');
+        // Strip leading + trailing whitespace per-line (line-internal already
+        // collapsed; this drops the leading/trailing single-space residue).
+        return collapsed.trim();
+    });
+    // Drop leading + trailing blank lines so wrapping noise doesn't fork the
+    // fingerprint. Internal blank lines preserved (paragraph structure).
+    let start = 0;
+    let end = lines.length;
+    while (start < end && lines[start] === '')
+        start++;
+    while (end > start && lines[end - 1] === '')
+        end--;
+    return lines.slice(start, end).join('\n');
+}
+/**
+ * Compute the Tier 0 fingerprint over a write's identifying tuple.
+ *
+ * Subject defaults to empty string when absent — Tier 0 deliberately treats
+ * "no subject" as a distinct scope from "subject=X". This matches Tier 1's
+ * subject scoping behavior (see UnifiedStoreTool's `findSimilar` call: when
+ * no subject is provided, the gate falls back to userId + contentType only).
+ */
+export function computeFingerprint(args) {
+    const tuple = [
+        normalize(args.content),
+        args.userId,
+        args.contentType,
+        args.subject ?? ''
+    ];
+    // JSON.stringify gives us a canonical, unambiguous separator-free encoding.
+    // Two arrays with the same elements always produce the same JSON.
+    const payload = JSON.stringify(tuple);
+    return crypto.createHash('sha256').update(payload, 'utf8').digest('hex');
+}

--- a/dist/embedding/EmbeddingService.js
+++ b/dist/embedding/EmbeddingService.js
@@ -13,6 +13,24 @@
  *     just without an embedding. A backfill job can re-embed later.
  */
 import { logger } from '../logger.js';
+/**
+ * Transient metadata keys for the embedding-handoff pattern (PR #69).
+ *
+ * UnifiedStoreTool clones the knowledge object before the graph fan-out and
+ * splices the freshly-computed vector + embedderId into metadata under these
+ * keys. SparrowDBStorage.store() plucks them off and feeds them into a single
+ * MERGE-with-all-props-inline executeWithParams call — the only Cypher
+ * pattern SparrowDB 0.1.22 honours for HNSW population (see channel msg #202
+ * for the SET-silent-failure repro).
+ *
+ * Both the producer (UnifiedStoreTool) and consumer (SparrowDBStorage) MUST
+ * import these — duplicating the literal strings would silently break the
+ * handoff if one side renamed and the other didn't. The double-underscore
+ * prefix marks them internal/transient; SparrowDBStorage strips them before
+ * the sidecar JSON write so they never persist.
+ */
+export const PENDING_EMBEDDING_KEY = '__pending_embedding';
+export const PENDING_EMBEDDER_ID_KEY = '__pending_embedder_id';
 // ---------------------------------------------------------------------------
 const DEFAULT_BASE_URL = 'http://localhost:11434';
 const DEFAULT_MODEL = 'nomic-embed-text';

--- a/dist/index.js
+++ b/dist/index.js
@@ -356,6 +356,11 @@ export class UnifiedKMSServer {
                 result = this.truncateSearchResult(await this.tools.documentStore.search(args));
                 break;
             case 'kms_update':
+                // Inject auth-context userId so Mem0 propagation can scope its
+                // metadata.kms_id lookup to the right user (Mem0 is per-user).
+                if (authContext.user?.id && !args.userId) {
+                    args.userId = authContext.user.id;
+                }
                 result = await this.tools.store.update(args);
                 break;
             case 'kms_delete':
@@ -723,7 +728,7 @@ export class UnifiedKMSServer {
             },
             {
                 name: 'kms_update',
-                description: 'Update an existing KMS entry by ID — mutate content, metadata, or confidence in place. Use for genuine edits (typo fix, metadata correction, confidence adjustment). NOT for retraction — use kms_supersede when correcting a wrong fact with a new one. Bumps the timestamp and appends the reason to metadata.update_history for audit.',
+                description: 'Update an existing KMS entry by ID — mutate content, metadata, or confidence in place across SparrowDB, MongoDB, and Mem0 (best-effort). Use for genuine edits (typo fix, metadata correction, confidence adjustment). NOT for retraction — use kms_supersede when correcting a wrong fact with a new one. Bumps the timestamp and appends the reason to metadata.update_history for audit. Mem0 propagation looks the entry up by metadata.kms_id and skips silently if the entry was never routed to Mem0.',
                 inputSchema: {
                     type: 'object',
                     properties: {
@@ -731,7 +736,8 @@ export class UnifiedKMSServer {
                         content: { type: 'string', description: 'OPTIONAL — new content' },
                         metadata: { type: 'object', description: 'OPTIONAL — fields to merge into existing metadata' },
                         confidence: { type: 'number', minimum: 0, maximum: 1, description: 'OPTIONAL — new confidence score' },
-                        reason: { type: 'string', description: 'Why this update is being made (recorded in audit history)' }
+                        reason: { type: 'string', description: 'Why this update is being made (recorded in audit history)' },
+                        userId: { type: 'string', description: 'OPTIONAL — defaults to current user context. Used to scope the Mem0 lookup.' }
                     },
                     required: ['id', 'reason']
                 }

--- a/dist/storage/Mem0Storage.js
+++ b/dist/storage/Mem0Storage.js
@@ -21,6 +21,7 @@
  *  - `mem0` CLI (npm i -g @mem0/cli) — translates --user-id to filters.user_id
  *  - Live `kms_ping` previously threw on getStats top-level user_id (caught + fixed 2026-05-07)
  */
+import { logger } from '../logger.js';
 export class Mem0Storage {
     config;
     name = 'mem0';
@@ -221,6 +222,132 @@ export class Mem0Storage {
         }
         catch (error) {
             console.error('❌ Mem0 delete error:', error);
+            return false;
+        }
+    }
+    /**
+     * Update an existing Mem0 entry by KMS id (kms_update propagation).
+     *
+     * Why this exists: kms_update mutates content + metadata in Mongo and
+     * SparrowDB, but historically skipped Mem0 — the rationale was "Mem0
+     * memories are LLM-managed and re-extracted on next store". In practice
+     * this caused Mem0's corpus to drift from corrected truth: a fact
+     * superseded or rewritten in Mongo would still surface its outdated form
+     * via Mem0 search (and via the kms-context-fetch hook). By calling Mem0's
+     * own update endpoint with the new text, we let Mem0's LLM re-extract a
+     * coherent memory from the corrected content rather than continuing to
+     * surface the stale extraction.
+     *
+     * Mem0 indexes by its own internal id, NOT the KMS id. The mapping is
+     * one-way: at store() time we set `metadata.kms_id = knowledge.id` on the
+     * Mem0 record but we never persisted Mem0's returned id back into our
+     * canonical record. So here we look the Mem0 id up via search-and-filter:
+     *
+     *   1. Search Mem0 with the kms id as the query, scoped to user_id.
+     *      Mem0 stores metadata as searchable text, so the kms id usually
+     *      surfaces the right entry near the top.
+     *   2. Filter results client-side for `metadata.kms_id === kmsId` (exact
+     *      match — a substring hit on a different entry's metadata is a false
+     *      positive we must not act on).
+     *   3. If exactly one match, call client.update(mem0Id, content).
+     *   4. If zero matches → probe-and-skip: log debug, return false. This
+     *      mirrors the kms_supersede pattern (PR #65 / issue #62): an entry
+     *      may not have been routed to Mem0 (routing is content-type
+     *      dependent), and the corrective op should succeed silently rather
+     *      than fail the whole update.
+     *   5. If multiple matches → log warning, update the first (most-relevant
+     *      per Mem0's ranking). Multi-match shouldn't happen in practice
+     *      (kms_id is set once per store) but defensive logging surfaces
+     *      anomalies.
+     *
+     * Mem0 v3 SDK update signature is `update(memoryId, message)` — text
+     * only, no metadata. Mem0's LLM re-extracts metadata from the new text
+     * itself; we cannot directly set kms_id / subject / etc. on update. The
+     * kms_id we wrote at store() time persists.
+     *
+     * Return value mirrors the boolean shape of MongoStorage.update /
+     * SparrowDBStorage.update: true on successful propagation, false on any
+     * skip / soft-fail / unexpected error. We never throw — Mem0 propagation
+     * is best-effort by design (a Mem0 outage must not tear down a kms_update
+     * that already mutated Mongo + SparrowDB).
+     */
+    async update(id, content, _metadata, userId) {
+        // No content → no-op. Mem0's update endpoint requires `text`. A
+        // metadata-only or confidence-only kms_update has no Mem0 equivalent
+        // (Mem0 re-extracts metadata from content; there's no direct setter).
+        if (content === undefined || content === null || content === '') {
+            logger.debug(`[Mem0Storage.update] No content provided for ${id} — skipping Mem0 propagation (Mem0 update requires text)`);
+            return false;
+        }
+        try {
+            const resolvedUserId = userId || this.config.defaultUserId || 'personal';
+            // Step 1: locate the Mem0 internal id via search.
+            // Use the kms_id as the query string. Mem0 stores metadata fields as
+            // part of the indexed payload, so the id usually surfaces in the top
+            // few hits. Cap at 50 to bound the client-side filter cost.
+            let mem0Id = null;
+            try {
+                // Mirrors Mem0Storage.search() above: declare the options as a free
+                // object literal (not typed against SearchOptions) so the SDK's
+                // camelCase `topK` — which it converts to snake_case at the wire —
+                // is accepted. The SDK's published .d.ts only lists `top_k`; the
+                // runtime accepts both.
+                const searchOptions = {
+                    topK: 50,
+                    filters: { user_id: resolvedUserId }
+                };
+                const response = await this.client.search(id, searchOptions);
+                const results = Array.isArray(response) ? response : (response?.results ?? []);
+                // Step 2: exact-match filter on metadata.kms_id. Substring hits on
+                // adjacent entries' metadata would be false positives.
+                const matches = results.filter((r) => r?.metadata?.kms_id === id);
+                if (matches.length === 0) {
+                    // Probe-and-skip — entry may never have been routed to Mem0
+                    // (routing is content-type dependent). Same pattern as PR #65.
+                    logger.debug(`[Mem0Storage.update] kms_id=${id} not found in Mem0 for user=${resolvedUserId} — skipping (probe-and-skip)`);
+                    return false;
+                }
+                if (matches.length > 1) {
+                    logger.warn(`[Mem0Storage.update] kms_id=${id} returned ${matches.length} Mem0 matches — using first. This usually means a duplicate kms_id was written to Mem0; investigate.`);
+                }
+                mem0Id = matches[0].id;
+                if (!mem0Id) {
+                    logger.warn(`[Mem0Storage.update] Mem0 search match for kms_id=${id} has no id field — skipping`);
+                    return false;
+                }
+            }
+            catch (searchError) {
+                // Search failure is non-fatal — log and skip. We don't want a
+                // transient Mem0 search error to fail the whole kms_update.
+                logger.warn(`[Mem0Storage.update] Mem0 search failed while looking up kms_id=${id}:`, searchError);
+                return false;
+            }
+            // Step 3: call Mem0 update with the resolved internal id.
+            try {
+                logger.debug(`[Mem0Storage.update] Updating Mem0 entry mem0Id=${mem0Id} for kms_id=${id}`);
+                await this.client.update(mem0Id, content);
+                logger.debug(`[Mem0Storage.update] Successfully propagated kms_update to Mem0 (kms_id=${id}, mem0Id=${mem0Id})`);
+                return true;
+            }
+            catch (updateError) {
+                // 404 = entry was deleted between our search and update (rare
+                // race). Treat as probe-and-skip — there's nothing to update,
+                // and we don't want to fail the kms_update for a vanished entry.
+                const errMsg = updateError instanceof Error ? updateError.message : String(updateError);
+                if (/\b404\b|not found|does not exist/i.test(errMsg)) {
+                    logger.debug(`[Mem0Storage.update] Mem0 entry mem0Id=${mem0Id} returned 404 on update — skipping (probe-and-skip)`);
+                    return false;
+                }
+                // Other unexpected errors are swallowed by the outer catch below —
+                // re-throw here so the outer handler can log them and return false.
+                throw updateError;
+            }
+        }
+        catch (error) {
+            // Outer catch for anything that escaped — keep the same defensive
+            // shape as the rest of this class so a Mem0 hiccup never tears down
+            // a kms_update call.
+            logger.warn(`[Mem0Storage.update] Failed to propagate kms_update to Mem0 for kms_id=${id}:`, error);
             return false;
         }
     }

--- a/dist/storage/SparrowDBStorage.js
+++ b/dist/storage/SparrowDBStorage.js
@@ -46,6 +46,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { homedir } from 'os';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { PENDING_EMBEDDING_KEY, PENDING_EMBEDDER_ID_KEY } from '../embedding/EmbeddingService.js';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // ---------------------------------------------------------------------------
 // Load the native .node module
@@ -193,13 +194,11 @@ export class SparrowDBStorage {
         // attached one. This is the inline-MERGE path for HNSW population — see
         // storeEmbedding() for the architectural rationale (SparrowDB 0.1.22's
         // MATCH+SET silently no-ops for vector params; only MERGE/CREATE pattern's
-        // literal property dict triggers idx.insert). The payload uses a
-        // double-underscored key to mark it transient — we strip it before the
-        // sidecar write so it never persists.
-        const META_EMB_KEY = '__pending_embedding';
-        const META_EMB_ID_KEY = '__pending_embedder_id';
-        const inlineEmb = knowledge.metadata?.[META_EMB_KEY];
-        const inlineEmbId = knowledge.metadata?.[META_EMB_ID_KEY];
+        // literal property dict triggers idx.insert). Keys are exported from
+        // ../embedding/EmbeddingService.ts so the producer (UnifiedStoreTool) and
+        // consumer (here) share a single source of truth — see PR #69 review.
+        const inlineEmb = knowledge.metadata?.[PENDING_EMBEDDING_KEY];
+        const inlineEmbId = knowledge.metadata?.[PENDING_EMBEDDER_ID_KEY];
         const hasInlineEmb = inlineEmb !== undefined &&
             inlineEmbId !== undefined &&
             this.vectorIndexAvailable &&
@@ -261,8 +260,8 @@ export class SparrowDBStorage {
         // Strip the transient embedding payload before persisting so it never
         // serializes into the JSON sidecar (would balloon the file by ~6KB/entry).
         const cleanMetadata = { ...(knowledge.metadata ?? {}) };
-        delete cleanMetadata[META_EMB_KEY];
-        delete cleanMetadata[META_EMB_ID_KEY];
+        delete cleanMetadata[PENDING_EMBEDDING_KEY];
+        delete cleanMetadata[PENDING_EMBEDDER_ID_KEY];
         const entry = {
             id: knowledge.id,
             content: knowledge.content,
@@ -663,6 +662,42 @@ export class SparrowDBStorage {
                 out.push(e);
         }
         return out;
+    }
+    /**
+     * Tier 0 fingerprint dedup lookup (DG-T0).
+     *
+     * Returns the first entry whose `metadata.fingerprint === fingerprint` AND
+     * `userId === userId`. Scans the in-memory contentIndex (~1200 entries on
+     * the production corpus → ~0.1 ms typical). Skips flagged entries by
+     * default — the gate should not refuse a write because of a previously
+     * deleted/superseded/retracted match. Pass `includeFlagged: true` for
+     * audit / reaper paths.
+     *
+     * Returns `null` when no match is found (no entry has the fingerprint, or
+     * the only matches are flagged when `includeFlagged` is false).
+     *
+     * Why a linear scan rather than a fingerprint→id index: the contentIndex
+     * is an in-memory Map already holding every entry; scanning is bounded
+     * and the cost is well below the Tier 1 latency floor. A separate index
+     * would be a maintenance burden (load/save sidecar, dedup eviction on
+     * delete/update, etc.) for negligible gain at current corpus size. If
+     * the corpus grows past ~10k entries we can revisit.
+     */
+    findByFingerprint(fingerprint, userId, options) {
+        const includeFlagged = options?.includeFlagged === true;
+        if (!fingerprint || !userId)
+            return null;
+        for (const entry of this.contentIndex.values()) {
+            if (entry.userId !== userId)
+                continue;
+            if (!includeFlagged && entry.flag)
+                continue;
+            const fp = entry.metadata?.fingerprint;
+            if (typeof fp === 'string' && fp === fingerprint) {
+                return entry;
+            }
+        }
+        return null;
     }
     // -------------------------------------------------------------------------
     // StorageSystem.search

--- a/dist/storage/SparrowDBStorage.js
+++ b/dist/storage/SparrowDBStorage.js
@@ -47,6 +47,7 @@ import { homedir } from 'os';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { PENDING_EMBEDDING_KEY, PENDING_EMBEDDER_ID_KEY } from '../embedding/EmbeddingService.js';
+import { computeFingerprint } from '../dedup/Fingerprint.js';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // ---------------------------------------------------------------------------
 // Load the native .node module
@@ -676,6 +677,17 @@ export class SparrowDBStorage {
      * Returns `null` when no match is found (no entry has the fingerprint, or
      * the only matches are flagged when `includeFlagged` is false).
      *
+     * Backfill of pre-rollout entries: entries written before DG-T0 was wired
+     * have no `metadata.fingerprint`. On the first lookup we lazily compute
+     * + stamp fingerprints for those entries (one-shot opportunistic backfill,
+     * gated by `_fingerprintBackfillDone`) so Tier 0 starts catching them
+     * without requiring a separate migration script. The backfill scans the
+     * full corpus once (~1200 entries; a few ms); subsequent calls are pure
+     * O(n) lookups. The stamps are written to the in-memory contentIndex
+     * only — flushed on the next organic _saveSidecar() call (delete /
+     * update / flag / store) so we don't pay a sidecar I/O cost on every
+     * Tier 0 lookup.
+     *
      * Why a linear scan rather than a fingerprint→id index: the contentIndex
      * is an in-memory Map already holding every entry; scanning is bounded
      * and the cost is well below the Tier 1 latency floor. A separate index
@@ -687,6 +699,9 @@ export class SparrowDBStorage {
         const includeFlagged = options?.includeFlagged === true;
         if (!fingerprint || !userId)
             return null;
+        // One-shot backfill of pre-rollout entries that have no
+        // metadata.fingerprint. Idempotent: subsequent calls are a no-op.
+        this._backfillFingerprintsOnce();
         for (const entry of this.contentIndex.values()) {
             if (entry.userId !== userId)
                 continue;
@@ -698,6 +713,54 @@ export class SparrowDBStorage {
             }
         }
         return null;
+    }
+    /**
+     * Tracks whether the lazy fingerprint backfill has run for this process.
+     * Set true after the first findByFingerprint call to avoid re-scanning on
+     * every subsequent lookup. Reset only on a fresh process start (no
+     * persistence — the stamped fingerprints flush to the sidecar through
+     * organic save calls, so they survive restarts naturally).
+     */
+    _fingerprintBackfillDone = false;
+    /**
+     * Compute + stamp `metadata.fingerprint` on every contentIndex entry that
+     * doesn't have one. Runs once per process. The fingerprint is computed
+     * over (content, userId, contentType, metadata.subject ?? '') to match
+     * the contract in src/dedup/Fingerprint.ts — UnifiedStoreTool.store()
+     * uses the same tuple for new writes.
+     *
+     * Errors during compute are non-fatal — a single bad entry won't crash
+     * the backfill. The corresponding entry just stays without a fingerprint
+     * and will retry on the next process restart.
+     */
+    _backfillFingerprintsOnce() {
+        if (this._fingerprintBackfillDone)
+            return;
+        this._fingerprintBackfillDone = true;
+        let stamped = 0;
+        for (const entry of this.contentIndex.values()) {
+            const meta = entry.metadata ?? {};
+            if (typeof meta.fingerprint === 'string' && meta.fingerprint.length > 0)
+                continue;
+            try {
+                const subject = typeof meta.subject === 'string' ? meta.subject : undefined;
+                const fp = computeFingerprint({
+                    content: entry.content,
+                    userId: entry.userId,
+                    contentType: entry.contentType,
+                    subject
+                });
+                entry.metadata = { ...meta, fingerprint: fp };
+                stamped++;
+            }
+            catch (e) {
+                logger.debug(`findByFingerprint backfill: skipped ${entry.id} ` +
+                    `(${e instanceof Error ? e.message : String(e)})`);
+            }
+        }
+        if (stamped > 0) {
+            logger.debug(`✅ Tier 0 fingerprint backfill: stamped ${stamped} pre-rollout entries`);
+        }
     }
     // -------------------------------------------------------------------------
     // StorageSystem.search

--- a/dist/tools/UnifiedStoreTool.js
+++ b/dist/tools/UnifiedStoreTool.js
@@ -4,6 +4,8 @@
 import crypto from 'crypto';
 import { FACTCache } from '../cache/FACTCache.js';
 import { ContentInference } from '../inference/ContentInference.js';
+import { PENDING_EMBEDDING_KEY, PENDING_EMBEDDER_ID_KEY } from '../embedding/EmbeddingService.js';
+import { computeFingerprint } from '../dedup/Fingerprint.js';
 import { logger } from '../logger.js';
 const debug = (...args) => { if (process.env.KMS_DEBUG)
     console.error(...args); };
@@ -148,6 +150,95 @@ export class UnifiedStoreTool {
             confidence: enrichedArgs.confidence || 0.8,
             relationships: enrichedArgs.relationships || []
         };
+        // ---------------------------------------------------------------------
+        // Dedup gate — Tier 0 (DG-T0) fingerprint check (PREPENDS Tier 1)
+        //
+        // Cheap O(n) scan of the in-memory sidecar against a SHA-256 fingerprint
+        // of (normalized_content, userId, contentType, subject ?? ''). Catches:
+        //   - Whitespace-only differences that the embedder may not score above
+        //     the cosine refuse threshold.
+        //   - Repeated submits / batch importer re-runs.
+        //   - Anything identical when the embedder or LLM judge is down.
+        //
+        // Skipped when:
+        //   - options.skip_dedup === true (admin escape hatch; same path the
+        //     DG-T1-C dispatcher uses for action=complement / action=force-new).
+        //   - The graph backend doesn't expose findByFingerprint (older builds).
+        //
+        // The fingerprint is also stamped into knowledge.metadata so subsequent
+        // Tier 0 lookups match against it directly.
+        // ---------------------------------------------------------------------
+        const tier0SubjectFacet = typeof knowledge.metadata?.subject === 'string'
+            ? knowledge.metadata.subject
+            : undefined;
+        const fingerprint = computeFingerprint({
+            content: knowledge.content,
+            userId: knowledge.userId,
+            contentType: knowledge.contentType,
+            subject: tier0SubjectFacet
+        });
+        // Stamp fingerprint into metadata for future Tier 0 hits. We do this
+        // unconditionally (regardless of whether Tier 0 finds a match this call)
+        // so the next write of identical content lands a fingerprint match. Set
+        // BEFORE the Tier 0 check so the in-memory metadata clone propagates
+        // through embedding, routing, and storage fan-out.
+        knowledge.metadata = {
+            ...knowledge.metadata,
+            fingerprint
+        };
+        if (args.options?.skip_dedup !== true &&
+            typeof this.storage.graph.findByFingerprint === 'function') {
+            try {
+                const existing = this.storage.graph.findByFingerprint(fingerprint, knowledge.userId);
+                if (existing && !existing.flag) {
+                    const subject = typeof existing.metadata?.subject === 'string'
+                        ? existing.metadata.subject
+                        : undefined;
+                    const preview = (existing.content ?? '').slice(0, 200);
+                    // Reuse the resolved Tier 1 thresholds for the response echo so the
+                    // caller sees the *same* threshold context across tiers (Tier 0 is
+                    // additive, not a replacement). The thresholds aren't actually used
+                    // to make the Tier 0 decision — fingerprint identity is binary.
+                    const { refuse: refuseThreshold, confirm: confirmThreshold } = resolveDedupThresholds(knowledge.contentType, args.options?.dedup_threshold_override);
+                    const response = {
+                        status: 'dedup_required',
+                        candidates: [{
+                                id: existing.id,
+                                similarity: 1.0,
+                                content_preview: preview,
+                                contentType: existing.contentType ?? knowledge.contentType,
+                                source: existing.source ?? knowledge.source,
+                                subject,
+                                created: existing.timestamp ?? '',
+                                flag: existing.flag ?? null,
+                                // Fingerprint match is a stronger signal than any embedder
+                                // similarity, so we tag 'duplicate' inline without invoking
+                                // the Tier 2 LLM judge.
+                                llm_relation: 'duplicate'
+                            }],
+                        message: `Exact-match duplicate found via Tier 0 fingerprint (sha256). ` +
+                            `Identical normalized content for the same userId+contentType+subject scope. ` +
+                            `Retry with action.`,
+                        retry_with: [
+                            `action=supersede&old_id=${existing.id}&reason=<...>`,
+                            `action=update&old_id=${existing.id}&reason=<...>`,
+                            `action=complement&related_to=${existing.id}`,
+                            `action=force-new&reason=<justification>`
+                        ],
+                        band: 'exact',
+                        thresholds: { refuse: refuseThreshold, confirm: confirmThreshold }
+                    };
+                    debug(`🛑 DEDUP GATE refused write (exact/Tier 0): fingerprint match against id=${existing.id}`);
+                    return response;
+                }
+            }
+            catch (e) {
+                // Non-fatal: degrade to "no Tier 0 check" rather than blocking the write.
+                // Tier 1 still runs.
+                console.warn(`⚠️ unified_store: findByFingerprint failed (continuing to Tier 1): ` +
+                    `${e instanceof Error ? e.message : String(e)}`);
+            }
+        }
         // ---------------------------------------------------------------------
         // Pre-store: generate embedding (DG-T1-A)
         //
@@ -412,8 +503,9 @@ export class UnifiedStoreTool {
         // a noisy metadata field. Restored after fan-out so non-graph backends
         // see clean metadata.
         // -----------------------------------------------------------------
-        const META_EMB_KEY = '__pending_embedding';
-        const META_EMB_ID_KEY = '__pending_embedder_id';
+        // Transient handoff keys live in ../embedding/EmbeddingService.ts so the
+        // producer (here) and consumer (SparrowDBStorage.store) share one source
+        // of truth — see PR #69 review feedback.
         // Helper: clone knowledge with the embedding payload spliced into metadata.
         // We use a clone (not in-place mutation) so non-graph backends see clean
         // metadata without needing finally-block scrubbing — and so any later
@@ -423,8 +515,8 @@ export class UnifiedStoreTool {
             ...k,
             metadata: {
                 ...k.metadata,
-                [META_EMB_KEY]: pendingEmbedding,
-                [META_EMB_ID_KEY]: pendingEmbedderId
+                [PENDING_EMBEDDING_KEY]: pendingEmbedding,
+                [PENDING_EMBEDDER_ID_KEY]: pendingEmbedderId
             }
         });
         try {

--- a/dist/tools/UnifiedStoreTool.js
+++ b/dist/tools/UnifiedStoreTool.js
@@ -883,17 +883,54 @@ export class UnifiedStoreTool {
             updates.content = args.content;
         if (args.confidence !== undefined)
             updates.confidence = args.confidence;
-        // Fetch existing record so we can merge metadata instead of overwriting it.
-        // This prevents $set from dropping existing metadata keys and prior
-        // update_history entries that the caller did not include in args.metadata.
+        // Fetch existing record so we can:
+        //   1. Merge metadata instead of overwriting it (preserves existing keys
+        //      + prior update_history that the caller didn't include in args).
+        //   2. Recompute the Tier 0 fingerprint (DG-T0) when content or
+        //      metadata.subject changes — userId + contentType come from the
+        //      existing entry (caller can't change them via update()). Without
+        //      this, an updated entry would keep its OLD fingerprint and Tier 0
+        //      would mis-match the next write of the OLD content.
+        //
+        // Prefer the graph's findById since the sidecar holds full content + the
+        // current fingerprint authoritative metadata; fall back to MongoDB for
+        // procedure-routed entries that don't live in the graph.
         let existingMetadata = {};
+        let existingContent;
+        let existingContentType;
+        let existingUserId;
         try {
-            const existing = await this.storage.mongodb.findById(args.id);
-            if (existing?.metadata)
-                existingMetadata = existing.metadata;
+            const graphAny = this.storage.graph;
+            if (typeof graphAny.findById === 'function') {
+                const e = await graphAny.findById(args.id);
+                if (e) {
+                    if (e.metadata)
+                        existingMetadata = e.metadata;
+                    if (typeof e.content === 'string')
+                        existingContent = e.content;
+                    if (typeof e.contentType === 'string')
+                        existingContentType = e.contentType;
+                    if (typeof e.userId === 'string')
+                        existingUserId = e.userId;
+                }
+            }
+            if (existingContent === undefined || existingContentType === undefined || existingUserId === undefined) {
+                const e = await this.storage.mongodb.findById(args.id);
+                if (e) {
+                    if (e.metadata && Object.keys(existingMetadata).length === 0) {
+                        existingMetadata = e.metadata;
+                    }
+                    if (existingContent === undefined && typeof e.content === 'string')
+                        existingContent = e.content;
+                    if (existingContentType === undefined && typeof e.contentType === 'string')
+                        existingContentType = e.contentType;
+                    if (existingUserId === undefined && typeof e.userId === 'string')
+                        existingUserId = e.userId;
+                }
+            }
         }
         catch (e) {
-            console.warn('⚠️  unified_update: could not fetch existing metadata for merge (non-fatal):', e);
+            console.warn('⚠️  unified_update: could not fetch existing entry for merge (non-fatal):', e);
         }
         // Merge: existing metadata base, then caller-supplied overrides, then
         // append the new audit entry to update_history (preserving prior entries).
@@ -904,6 +941,27 @@ export class UnifiedStoreTool {
         if (args.reason) {
             const prior = Array.isArray(mergedMetadata.update_history) ? mergedMetadata.update_history : [];
             mergedMetadata.update_history = [...prior, { at: new Date().toISOString(), reason: args.reason }];
+        }
+        // Recompute Tier 0 fingerprint (DG-T0) when we have enough context to do
+        // it correctly. The fingerprint covers (content, userId, contentType,
+        // subject) — any of those changing means the cached fingerprint is stale
+        // and Tier 0 would mis-route subsequent writes against this entry.
+        //
+        // We unconditionally recompute when we know userId + contentType (cheap;
+        // bytes-of-content + sha256 over a few hundred chars). The new content
+        // is args.content if provided, else the existing content. Same for
+        // metadata.subject (caller override > existing).
+        if (existingUserId !== undefined && existingContentType !== undefined) {
+            const newContent = args.content !== undefined ? args.content : (existingContent ?? '');
+            const newSubject = typeof mergedMetadata.subject === 'string'
+                ? mergedMetadata.subject
+                : undefined;
+            mergedMetadata.fingerprint = computeFingerprint({
+                content: newContent,
+                userId: existingUserId,
+                contentType: existingContentType,
+                subject: newSubject
+            });
         }
         updates.metadata = mergedMetadata;
         const backends = [];

--- a/dist/tools/UnifiedStoreTool.js
+++ b/dist/tools/UnifiedStoreTool.js
@@ -684,7 +684,8 @@ export class UnifiedStoreTool {
                     content: args.content,
                     metadata: args.metadata,
                     confidence: args.confidence,
-                    reason: args.reason
+                    reason: args.reason,
+                    userId: args.userId
                 });
                 return {
                     status: 'updated',
@@ -876,8 +877,12 @@ export class UnifiedStoreTool {
      * Use update for genuine edits (typo fix, metadata correction, confidence
      * adjustment).
      *
-     * Calls SparrowDB and MongoDB. Mem0 is skipped — its memories are LLM-managed
-     * and re-extracted on next store, so direct edits don't make sense.
+     * Calls SparrowDB, MongoDB, and Mem0 (best-effort). Mem0 propagation looks
+     * the entry up by kms_id metadata and rewrites its text via Mem0's update
+     * endpoint; if the entry was never routed to Mem0 it's a no-op (probe-and-
+     * skip, same pattern as kms_supersede in PR #65). Without Mem0 propagation,
+     * Mem0's LLM-extracted memories drift from corrected truth and leak stale
+     * content into search + the kms-context-fetch hook.
      */
     async update(args) {
         const updates = {};
@@ -893,6 +898,8 @@ export class UnifiedStoreTool {
         //      existing entry (caller can't change them via update()). Without
         //      this, an updated entry would keep its OLD fingerprint and Tier 0
         //      would mis-match the next write of the OLD content.
+        //   3. Surface existingUserId so Mem0 propagation (PR #79) can scope its
+        //      search to the right user when the caller didn't supply args.userId.
         //
         // Prefer the graph's findById since the sidecar holds full content + the
         // current fingerprint authoritative metadata; fall back to MongoDB for
@@ -984,6 +991,16 @@ export class UnifiedStoreTool {
         }
         catch (e) {
             console.warn('⚠️  unified_update MongoDB error:', e);
+        }
+        // Mem0 propagation (best-effort). Mem0 indexes by its own internal id,
+        // not the KMS id; Mem0Storage.update looks the mem0_id up via search
+        // filtered by metadata.kms_id and skips silently if the entry was never
+        // routed to Mem0 (probe-and-skip). Without this, Mem0's corpus drifts
+        // from corrected truth and stale content leaks into context injection.
+        if (typeof this.storage.mem0.update === 'function') {
+            const ok = await this.storage.mem0.update(args.id, args.content, args.metadata, args.userId ?? existingUserId);
+            if (ok)
+                backends.push('mem0');
         }
         // Invalidate cache after any successful backend update so stale search
         // results and knowledge cache entries don't serve pre-update content.

--- a/dist/tools/UnifiedStoreTool.js
+++ b/dist/tools/UnifiedStoreTool.js
@@ -234,8 +234,10 @@ export class UnifiedStoreTool {
             }
             catch (e) {
                 // Non-fatal: degrade to "no Tier 0 check" rather than blocking the write.
-                // Tier 1 still runs.
-                console.warn(`⚠️ unified_store: findByFingerprint failed (continuing to Tier 1): ` +
+                // Tier 1 still runs. Use the project logger for consistency with the
+                // rest of the dedup-gate code path (Tier 1 / Tier 2 also log via
+                // logger.warn — see the findSimilar guard below).
+                logger.warn(`⚠️ unified_store: findByFingerprint failed (continuing to Tier 1): ` +
                     `${e instanceof Error ? e.message : String(e)}`);
             }
         }

--- a/src/__tests__/dedup_tier0.test.ts
+++ b/src/__tests__/dedup_tier0.test.ts
@@ -1,0 +1,709 @@
+/**
+ * DG-T0 — Tier 0 fingerprint dedup (prepend) integration tests.
+ *
+ * Verifies the UnifiedStoreTool.store() Tier 0 fingerprint check that
+ * runs BEFORE the Tier 1 vector similarity check:
+ *   1. Identical content → exact-band refuse (Tier 0 hit)
+ *   2. Whitespace-only differences → still hit (normalize() works)
+ *   3. Different userId → no Tier 0 hit; falls through to Tier 1
+ *   4. Different contentType → no Tier 0 hit
+ *   5. Same content + same subject → Tier 0 hit
+ *   6. Same content + different subject → no Tier 0 hit
+ *   7. New writes get a fingerprint stamped into metadata
+ *   8. Tier 0 short-circuits BEFORE the embedder is called
+ *   9. Flagged matches don't trigger Tier 0 (deleted/superseded entries)
+ *  10. options.skip_dedup bypasses Tier 0
+ *  11. action field bypasses Tier 0 (DG-T1-C dispatch)
+ *  12. Older backends without findByFingerprint → Tier 0 inert
+ *  13. computeFingerprint determinism + tuple separation properties
+ *  14. normalize() drops trailing whitespace per line and collapses runs
+ */
+
+import { UnifiedStoreTool, type UnifiedStoreResult, type DedupRequiredResponse } from '../tools/UnifiedStoreTool.js'
+import { IntelligentStorageRouter } from '../routing/IntelligentStorageRouter.js'
+import type { GraphStorage } from '../types/index.js'
+import type { EmbeddingService } from '../embedding/EmbeddingService.js'
+import { computeFingerprint, normalize } from '../dedup/Fingerprint.js'
+
+function isDedupRequired(r: UnifiedStoreResult): r is DedupRequiredResponse {
+  return (r as any).status === 'dedup_required'
+}
+
+describe('DG-T0 — Fingerprint module (computeFingerprint / normalize)', () => {
+  describe('normalize()', () => {
+    it('strips trailing whitespace per line', () => {
+      expect(normalize('hello   \nworld   ')).toBe('hello\nworld')
+    })
+
+    it('collapses runs of horizontal whitespace within a line', () => {
+      expect(normalize('foo    bar\t\tbaz')).toBe('foo bar baz')
+    })
+
+    it('preserves internal blank lines (paragraph structure)', () => {
+      expect(normalize('para 1\n\npara 2')).toBe('para 1\n\npara 2')
+    })
+
+    it('drops leading and trailing blank lines from the whole content', () => {
+      expect(normalize('\n\nhello\n\n')).toBe('hello')
+    })
+
+    it('normalizes CRLF / CR line endings to LF', () => {
+      expect(normalize('a\r\nb\rc')).toBe('a\nb\nc')
+    })
+
+    it('returns empty string for empty / non-string input', () => {
+      expect(normalize('')).toBe('')
+      expect(normalize(undefined as any)).toBe('')
+      expect(normalize(null as any)).toBe('')
+    })
+  })
+
+  describe('computeFingerprint()', () => {
+    it('produces a deterministic 64-char hex SHA-256', () => {
+      const fp = computeFingerprint({
+        content: 'hello world',
+        userId: 'u',
+        contentType: 'fact'
+      })
+      expect(fp).toMatch(/^[0-9a-f]{64}$/)
+    })
+
+    it('returns the same fingerprint for identical inputs', () => {
+      const a = computeFingerprint({ content: 'x', userId: 'u', contentType: 'fact' })
+      const b = computeFingerprint({ content: 'x', userId: 'u', contentType: 'fact' })
+      expect(a).toBe(b)
+    })
+
+    it('returns the same fingerprint for whitespace-equivalent inputs', () => {
+      const a = computeFingerprint({ content: 'foo bar', userId: 'u', contentType: 'fact' })
+      const b = computeFingerprint({ content: '  foo    bar  \t', userId: 'u', contentType: 'fact' })
+      expect(a).toBe(b)
+    })
+
+    it('changes when userId differs', () => {
+      const a = computeFingerprint({ content: 'x', userId: 'u1', contentType: 'fact' })
+      const b = computeFingerprint({ content: 'x', userId: 'u2', contentType: 'fact' })
+      expect(a).not.toBe(b)
+    })
+
+    it('changes when contentType differs', () => {
+      const a = computeFingerprint({ content: 'x', userId: 'u', contentType: 'fact' })
+      const b = computeFingerprint({ content: 'x', userId: 'u', contentType: 'insight' })
+      expect(a).not.toBe(b)
+    })
+
+    it('changes when subject differs', () => {
+      const a = computeFingerprint({ content: 'x', userId: 'u', contentType: 'fact', subject: 'A' })
+      const b = computeFingerprint({ content: 'x', userId: 'u', contentType: 'fact', subject: 'B' })
+      expect(a).not.toBe(b)
+    })
+
+    it('treats omitted subject as empty string (deterministic absence)', () => {
+      const omitted = computeFingerprint({ content: 'x', userId: 'u', contentType: 'fact' })
+      const explicitEmpty = computeFingerprint({ content: 'x', userId: 'u', contentType: 'fact', subject: '' })
+      expect(omitted).toBe(explicitEmpty)
+    })
+
+    it('treats "no subject" as a distinct scope from a real subject', () => {
+      const noSubject = computeFingerprint({ content: 'x', userId: 'u', contentType: 'fact' })
+      const withSubject = computeFingerprint({ content: 'x', userId: 'u', contentType: 'fact', subject: 'A' })
+      expect(noSubject).not.toBe(withSubject)
+    })
+
+    it('cannot be confused by tuple-element separator collisions', () => {
+      // If we had used a string separator like ":" naive concatenation could
+      // collide. JSON.stringify on an array gives canonical separation.
+      const a = computeFingerprint({ content: 'foo', userId: 'bar:baz', contentType: 'fact' })
+      const b = computeFingerprint({ content: 'foo:bar', userId: 'baz', contentType: 'fact' })
+      expect(a).not.toBe(b)
+    })
+  })
+})
+
+describe('DG-T0 — UnifiedStoreTool Tier 0 dedup gate', () => {
+  let mongo: any
+  let graph: any
+  let mem0: any
+  let cache: any
+  let router: IntelligentStorageRouter
+  let embedder: jest.Mocked<EmbeddingService>
+
+  function axisVec(axis: number): Float32Array {
+    const v = new Float32Array(768)
+    v[axis] = 1
+    return v
+  }
+
+  beforeEach(() => {
+    mongo = {
+      store: jest.fn().mockResolvedValue(undefined),
+      update: jest.fn().mockResolvedValue(true),
+      delete: jest.fn().mockResolvedValue(true),
+      flag: jest.fn().mockResolvedValue(true),
+      listFlagged: jest.fn().mockResolvedValue([])
+    }
+
+    // Default graph mock: no Tier 0 match, no Tier 1 candidates.
+    graph = {
+      name: 'sparrowdb',
+      store: jest.fn().mockResolvedValue(undefined),
+      storeEmbedding: jest.fn().mockResolvedValue(true),
+      findSimilar: jest.fn().mockResolvedValue([]),
+      findByFingerprint: jest.fn().mockReturnValue(null),
+      update: jest.fn().mockResolvedValue(true),
+      delete: jest.fn().mockResolvedValue(true),
+      flag: jest.fn().mockResolvedValue(true),
+      findById: jest.fn().mockReturnValue(null),
+      listFlagged: jest.fn().mockReturnValue([])
+    } as unknown as GraphStorage
+
+    mem0 = {
+      store: jest.fn().mockResolvedValue(undefined),
+      deleteMemory: jest.fn().mockResolvedValue(true)
+    }
+
+    cache = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValue(undefined),
+      invalidate: jest.fn().mockResolvedValue(undefined)
+    }
+
+    router = {
+      determineStorage: jest.fn().mockReturnValue({
+        primary: 'graph',
+        secondary: ['mongodb', 'mem0'],
+        cacheStrategy: 'L3',
+        reasoning: 'test'
+      }),
+      getRoutingStats: jest.fn().mockReturnValue({})
+    } as unknown as IntelligentStorageRouter
+
+    embedder = {
+      embedderId: 'nomic-embed-text:v1',
+      dimensions: 768,
+      embed: jest.fn().mockResolvedValue(axisVec(0)),
+      isAvailable: jest.fn().mockResolvedValue(true)
+    } as unknown as jest.Mocked<EmbeddingService>
+  })
+
+  function makeTool(): UnifiedStoreTool {
+    return new UnifiedStoreTool(
+      router,
+      { mongodb: mongo, graph, mem0 },
+      cache,
+      null, null,
+      embedder
+    )
+  }
+
+  // -------------------------------------------------------------------------
+  // 1. Identical content → exact-band refuse
+  // -------------------------------------------------------------------------
+
+  it('refuses identical content with band="exact" (Tier 0 hit)', async () => {
+    const matchingEntry = {
+      id: 'existing-fp-id',
+      content: 'Phoenix camera count is 6',
+      contentType: 'fact',
+      source: 'technical',
+      userId: 'u',
+      timestamp: '2026-04-01T00:00:00Z',
+      flag: null,
+      metadata: { fingerprint: 'whatever' }
+    }
+    ;(graph as any).findByFingerprint = jest.fn().mockReturnValue(matchingEntry)
+
+    const tool = makeTool()
+    const result = await tool.store({
+      content: 'Phoenix camera count is 6',
+      contentType: 'fact',
+      userId: 'u'
+    })
+
+    expect(isDedupRequired(result)).toBe(true)
+    if (!isDedupRequired(result)) return
+
+    expect(result.band).toBe('exact')
+    expect(result.candidates).toHaveLength(1)
+    expect(result.candidates[0].id).toBe('existing-fp-id')
+    expect(result.candidates[0].similarity).toBe(1.0)
+    expect(result.candidates[0].llm_relation).toBe('duplicate')
+    expect(result.message).toMatch(/Tier 0|fingerprint/i)
+    expect(result.retry_with).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('action=supersede'),
+        expect.stringContaining('action=update'),
+        expect.stringContaining('action=complement'),
+        expect.stringContaining('action=force-new')
+      ])
+    )
+
+    // Critical: storage fan-out NEVER called when gate refuses
+    expect(graph.store).not.toHaveBeenCalled()
+    expect(mongo.store).not.toHaveBeenCalled()
+    expect(mem0.store).not.toHaveBeenCalled()
+  })
+
+  // -------------------------------------------------------------------------
+  // 2. Whitespace-only differences still trigger Tier 0
+  // -------------------------------------------------------------------------
+
+  it('catches whitespace-only differences (normalize() collapses them)', async () => {
+    // The fingerprint for the original write
+    const fpOriginal = computeFingerprint({
+      content: 'foo bar baz',
+      userId: 'u',
+      contentType: 'fact'
+    })
+    const fpWhitespaceVariant = computeFingerprint({
+      content: '  foo    bar\t\tbaz  ',
+      userId: 'u',
+      contentType: 'fact'
+    })
+    expect(fpOriginal).toBe(fpWhitespaceVariant)  // sanity: normalize equates them
+
+    // Mock: when the gate looks up the whitespace-variant fingerprint, it
+    // finds the original entry (because they share a fingerprint).
+    ;(graph as any).findByFingerprint = jest.fn().mockImplementation(
+      (fp: string, _userId: string) => {
+        if (fp === fpOriginal) {
+          return {
+            id: 'original-id',
+            content: 'foo bar baz',
+            contentType: 'fact',
+            source: 'technical',
+            userId: 'u',
+            timestamp: '2026-04-01T00:00:00Z',
+            flag: null,
+            metadata: { fingerprint: fpOriginal }
+          }
+        }
+        return null
+      }
+    )
+
+    const tool = makeTool()
+    // Now write with extra whitespace. Should hit Tier 0.
+    const result = await tool.store({
+      content: '  foo    bar\t\tbaz  ',
+      contentType: 'fact',
+      userId: 'u'
+    })
+
+    expect(isDedupRequired(result)).toBe(true)
+    if (!isDedupRequired(result)) return
+    expect(result.band).toBe('exact')
+    expect(result.candidates[0].id).toBe('original-id')
+  })
+
+  // -------------------------------------------------------------------------
+  // 3. Different userId → no Tier 0 hit; falls through to Tier 1
+  // -------------------------------------------------------------------------
+
+  it('does not hit Tier 0 across different userIds (falls through)', async () => {
+    // Mock findByFingerprint to scope by userId (this is what real impl does).
+    ;(graph as any).findByFingerprint = jest.fn().mockReturnValue(null)
+    // Tier 1 returns nothing either, so the write should succeed.
+    ;(graph as any).findSimilar = jest.fn().mockResolvedValue([])
+
+    const tool = makeTool()
+    const result = await tool.store({
+      content: 'shared content',
+      contentType: 'fact',
+      userId: 'user_b'  // different from any pre-existing
+    })
+
+    expect(isDedupRequired(result)).toBe(false)
+    if (isDedupRequired(result)) return
+    expect(result.success).toBe(true)
+    // Tier 1 ran (because Tier 0 didn't refuse)
+    expect((graph as any).findSimilar).toHaveBeenCalledTimes(1)
+  })
+
+  // -------------------------------------------------------------------------
+  // 4. Different contentType → no Tier 0 hit (different fingerprint)
+  // -------------------------------------------------------------------------
+
+  it('produces different fingerprints for different contentTypes', async () => {
+    let observedFingerprint: string | null = null
+    ;(graph as any).findByFingerprint = jest.fn().mockImplementation((fp: string) => {
+      observedFingerprint = fp
+      return null  // no Tier 0 match
+    })
+
+    const tool = makeTool()
+    await tool.store({
+      content: 'x',
+      contentType: 'insight',
+      userId: 'u'
+    })
+
+    const fpFact = computeFingerprint({ content: 'x', userId: 'u', contentType: 'fact' })
+    const fpInsight = computeFingerprint({ content: 'x', userId: 'u', contentType: 'insight' })
+    expect(observedFingerprint).toBe(fpInsight)
+    expect(observedFingerprint).not.toBe(fpFact)
+  })
+
+  // -------------------------------------------------------------------------
+  // 5. Same content + same subject → Tier 0 hit
+  // -------------------------------------------------------------------------
+
+  it('hits Tier 0 when content + subject match', async () => {
+    const fp = computeFingerprint({
+      content: 'X',
+      userId: 'u',
+      contentType: 'fact',
+      subject: 'Phoenix.cam'
+    })
+    ;(graph as any).findByFingerprint = jest.fn().mockImplementation((reqFp: string, uid: string) => {
+      if (reqFp === fp && uid === 'u') {
+        return {
+          id: 'subject-tier0-match',
+          content: 'X',
+          contentType: 'fact',
+          source: 'technical',
+          userId: 'u',
+          timestamp: '2026-04-01T00:00:00Z',
+          flag: null,
+          metadata: { fingerprint: fp, subject: 'Phoenix.cam' }
+        }
+      }
+      return null
+    })
+
+    const tool = makeTool()
+    const result = await tool.store({
+      content: 'X',
+      contentType: 'fact',
+      userId: 'u',
+      metadata: { subject: 'Phoenix.cam' }
+    })
+
+    expect(isDedupRequired(result)).toBe(true)
+    if (!isDedupRequired(result)) return
+    expect(result.band).toBe('exact')
+    expect(result.candidates[0].id).toBe('subject-tier0-match')
+    expect(result.candidates[0].subject).toBe('Phoenix.cam')
+  })
+
+  // -------------------------------------------------------------------------
+  // 6. Same content + different subject → no Tier 0 hit
+  // -------------------------------------------------------------------------
+
+  it('does not hit Tier 0 when subject differs (different fingerprint scope)', async () => {
+    let observedFingerprint: string | null = null
+    ;(graph as any).findByFingerprint = jest.fn().mockImplementation((fp: string) => {
+      observedFingerprint = fp
+      return null
+    })
+
+    const tool = makeTool()
+    await tool.store({
+      content: 'X',
+      contentType: 'fact',
+      userId: 'u',
+      metadata: { subject: 'Phoenix.cam' }
+    })
+
+    const fpA = computeFingerprint({
+      content: 'X', userId: 'u', contentType: 'fact', subject: 'Phoenix.cam'
+    })
+    const fpB = computeFingerprint({
+      content: 'X', userId: 'u', contentType: 'fact', subject: 'Phoenix.zoom'
+    })
+    expect(observedFingerprint).toBe(fpA)
+    expect(observedFingerprint).not.toBe(fpB)
+  })
+
+  // -------------------------------------------------------------------------
+  // 7. New writes get a fingerprint stamped into metadata
+  // -------------------------------------------------------------------------
+
+  it('stamps metadata.fingerprint on the stored entry', async () => {
+    ;(graph as any).findByFingerprint = jest.fn().mockReturnValue(null)
+    ;(graph as any).findSimilar = jest.fn().mockResolvedValue([])
+
+    const tool = makeTool()
+    const result = await tool.store({
+      content: 'genuinely new content',
+      contentType: 'fact',
+      userId: 'u'
+    })
+
+    expect(isDedupRequired(result)).toBe(false)
+    if (isDedupRequired(result)) return
+    expect(result.success).toBe(true)
+
+    // graph.store was called with the knowledge object — inspect its metadata.
+    expect(graph.store).toHaveBeenCalledTimes(1)
+    const stored = (graph.store as jest.Mock).mock.calls[0][0]
+    expect(stored.metadata).toBeDefined()
+    expect(typeof stored.metadata.fingerprint).toBe('string')
+    expect(stored.metadata.fingerprint).toMatch(/^[0-9a-f]{64}$/)
+
+    // Sanity: it matches what computeFingerprint would produce.
+    const expected = computeFingerprint({
+      content: 'genuinely new content',
+      userId: 'u',
+      contentType: 'fact'
+    })
+    expect(stored.metadata.fingerprint).toBe(expected)
+  })
+
+  it('preserves the subject facet in the stamped fingerprint', async () => {
+    ;(graph as any).findByFingerprint = jest.fn().mockReturnValue(null)
+
+    const tool = makeTool()
+    await tool.store({
+      content: 'subject-tagged',
+      contentType: 'fact',
+      userId: 'u',
+      metadata: { subject: 'Phoenix.cam' }
+    })
+
+    const stored = (graph.store as jest.Mock).mock.calls[0][0]
+    const expected = computeFingerprint({
+      content: 'subject-tagged',
+      userId: 'u',
+      contentType: 'fact',
+      subject: 'Phoenix.cam'
+    })
+    expect(stored.metadata.fingerprint).toBe(expected)
+    expect(stored.metadata.subject).toBe('Phoenix.cam')  // facet preserved
+  })
+
+  // -------------------------------------------------------------------------
+  // 8. Tier 0 short-circuits BEFORE the embedder is called
+  // -------------------------------------------------------------------------
+
+  it('Tier 0 hit short-circuits before the embedder is called', async () => {
+    ;(graph as any).findByFingerprint = jest.fn().mockReturnValue({
+      id: 'tier0-hit',
+      content: 'C',
+      contentType: 'fact',
+      source: 'technical',
+      userId: 'u',
+      timestamp: '2026-04-01T00:00:00Z',
+      flag: null,
+      metadata: {}
+    })
+
+    const tool = makeTool()
+    const result = await tool.store({
+      content: 'C',
+      contentType: 'fact',
+      userId: 'u'
+    })
+
+    expect(isDedupRequired(result)).toBe(true)
+    // Embedder never invoked — Tier 0 short-circuited.
+    expect(embedder.embed).not.toHaveBeenCalled()
+    // findSimilar (Tier 1) also never invoked.
+    expect((graph as any).findSimilar).not.toHaveBeenCalled()
+  })
+
+  // -------------------------------------------------------------------------
+  // 9. Flagged matches don't trigger Tier 0
+  // -------------------------------------------------------------------------
+
+  it('skips flagged Tier 0 matches (deleted/superseded entries do not block)', async () => {
+    // Real impl filters out flagged entries internally. Here we simulate a
+    // backend that returned the flagged entry (defensive: the gate itself
+    // also checks `existing.flag` before refusing).
+    ;(graph as any).findByFingerprint = jest.fn().mockReturnValue({
+      id: 'flagged-old-entry',
+      content: 'old content',
+      contentType: 'fact',
+      source: 'technical',
+      userId: 'u',
+      timestamp: '2026-04-01T00:00:00Z',
+      flag: 'SUPERSEDED',  // gate must NOT refuse based on this
+      metadata: {}
+    })
+    ;(graph as any).findSimilar = jest.fn().mockResolvedValue([])
+
+    const tool = makeTool()
+    const result = await tool.store({
+      content: 'corrective rewrite',
+      contentType: 'fact',
+      userId: 'u'
+    })
+
+    // Tier 0 must NOT refuse — proceeds to Tier 1, which is also empty,
+    // so the write succeeds.
+    expect(isDedupRequired(result)).toBe(false)
+    if (isDedupRequired(result)) return
+    expect(result.success).toBe(true)
+  })
+
+  // -------------------------------------------------------------------------
+  // 10. options.skip_dedup bypasses Tier 0
+  // -------------------------------------------------------------------------
+
+  it('options.skip_dedup=true bypasses Tier 0 entirely', async () => {
+    const findByFingerprint = jest.fn().mockReturnValue({
+      id: 'would-have-blocked',
+      content: 'X',
+      contentType: 'fact',
+      source: 'technical',
+      userId: 'u',
+      timestamp: '2026-04-01T00:00:00Z',
+      flag: null,
+      metadata: {}
+    })
+    ;(graph as any).findByFingerprint = findByFingerprint
+
+    const tool = makeTool()
+    const result = await tool.store({
+      content: 'X',
+      contentType: 'fact',
+      userId: 'u',
+      options: { skip_dedup: true }
+    } as any)
+
+    expect(isDedupRequired(result)).toBe(false)
+    if (isDedupRequired(result)) return
+    expect(result.success).toBe(true)
+    expect(findByFingerprint).not.toHaveBeenCalled()
+  })
+
+  // -------------------------------------------------------------------------
+  // 11. action field bypasses Tier 0 (DG-T1-C dispatch)
+  // -------------------------------------------------------------------------
+
+  it('action=force-new bypasses Tier 0', async () => {
+    const findByFingerprint = jest.fn().mockReturnValue({
+      id: 'would-have-blocked',
+      content: 'X',
+      contentType: 'fact',
+      source: 'technical',
+      userId: 'u',
+      timestamp: '2026-04-01T00:00:00Z',
+      flag: null,
+      metadata: {}
+    })
+    ;(graph as any).findByFingerprint = findByFingerprint
+
+    const tool = makeTool()
+    const result = await tool.store({
+      content: 'X',
+      contentType: 'fact',
+      userId: 'u',
+      action: 'force-new',
+      reason: 'caller has explicit reason'
+    } as any)
+
+    expect(isDedupRequired(result)).toBe(false)
+    if (isDedupRequired(result)) return
+    expect(result.success).toBe(true)
+    expect(findByFingerprint).not.toHaveBeenCalled()
+  })
+
+  // -------------------------------------------------------------------------
+  // 12. Older backend without findByFingerprint → Tier 0 inert
+  // -------------------------------------------------------------------------
+
+  it('graph backend with no findByFingerprint method → Tier 0 inert (back-compat)', async () => {
+    delete (graph as any).findByFingerprint
+
+    const tool = makeTool()
+    const result = await tool.store({
+      content: 'older binding test',
+      contentType: 'fact',
+      userId: 'u'
+    })
+
+    expect(isDedupRequired(result)).toBe(false)
+    if (isDedupRequired(result)) return
+    expect(result.success).toBe(true)
+    // Tier 1 still runs.
+    expect((graph as any).findSimilar).toHaveBeenCalledTimes(1)
+  })
+
+  // -------------------------------------------------------------------------
+  // 13. findByFingerprint throw degrades to Tier 1 (non-fatal)
+  // -------------------------------------------------------------------------
+
+  it('findByFingerprint throw degrades to Tier 1 (non-fatal)', async () => {
+    ;(graph as any).findByFingerprint = jest.fn().mockImplementation(() => {
+      throw new Error('sidecar load failed')
+    })
+    ;(graph as any).findSimilar = jest.fn().mockResolvedValue([])
+
+    const tool = makeTool()
+    const result = await tool.store({
+      content: 'tier 0 errored',
+      contentType: 'fact',
+      userId: 'u'
+    })
+
+    expect(isDedupRequired(result)).toBe(false)
+    if (isDedupRequired(result)) return
+    expect(result.success).toBe(true)
+    // Tier 1 ran after Tier 0 failed.
+    expect((graph as any).findSimilar).toHaveBeenCalledTimes(1)
+  })
+
+  // -------------------------------------------------------------------------
+  // 14. Tier 0 threads correct args to findByFingerprint
+  // -------------------------------------------------------------------------
+
+  it('threads (fingerprint, userId) into findByFingerprint', async () => {
+    const findByFingerprint = jest.fn().mockReturnValue(null)
+    ;(graph as any).findByFingerprint = findByFingerprint
+
+    const tool = makeTool()
+    await tool.store({
+      content: 'precise inputs',
+      contentType: 'insight',
+      userId: 'richard_yaker',
+      metadata: { subject: 'Phoenix.camera_count' }
+    })
+
+    expect(findByFingerprint).toHaveBeenCalledTimes(1)
+    const [fp, uid] = findByFingerprint.mock.calls[0]
+    expect(typeof fp).toBe('string')
+    expect(fp).toMatch(/^[0-9a-f]{64}$/)
+    expect(uid).toBe('richard_yaker')
+    // Sanity: matches what computeFingerprint produces for the same inputs.
+    const expected = computeFingerprint({
+      content: 'precise inputs',
+      userId: 'richard_yaker',
+      contentType: 'insight',
+      subject: 'Phoenix.camera_count'
+    })
+    expect(fp).toBe(expected)
+  })
+
+  // -------------------------------------------------------------------------
+  // 15. Tier 0 falls through to Tier 1 when no fingerprint match
+  // -------------------------------------------------------------------------
+
+  it('Tier 0 miss falls through to Tier 1 (existing dedup gate intact)', async () => {
+    ;(graph as any).findByFingerprint = jest.fn().mockReturnValue(null)
+    ;(graph as any).findSimilar = jest.fn().mockResolvedValue([
+      {
+        id: 'tier1-near-dup',
+        similarity: 0.92,
+        contentType: 'fact',
+        source: 'technical',
+        created: '2026-04-01T00:00:00Z',
+        flag: null,
+        content_preview: 'similar but not byte-identical'
+      }
+    ])
+
+    const tool = makeTool()
+    const result = await tool.store({
+      content: 'this content is similar but whitespace differs from existing',
+      contentType: 'fact',
+      userId: 'u'
+    })
+
+    // Tier 1 refuse-band kicks in.
+    expect(isDedupRequired(result)).toBe(true)
+    if (!isDedupRequired(result)) return
+    expect(result.band).toBe('refuse')
+    expect(result.candidates[0].id).toBe('tier1-near-dup')
+  })
+})

--- a/src/__tests__/dedup_tier0.test.ts
+++ b/src/__tests__/dedup_tier0.test.ts
@@ -39,12 +39,33 @@ describe('DG-T0 — Fingerprint module (computeFingerprint / normalize)', () => 
       expect(normalize('foo    bar\t\tbaz')).toBe('foo bar baz')
     })
 
+    it('preserves leading indentation (code blocks / nested lists)', () => {
+      // Leading indent kept verbatim — collapsing it would erase code/list
+      // semantics. Internal runs still collapse; trailing still stripped.
+      expect(normalize('    code()   ')).toBe('    code()')
+      expect(normalize('  - item one\n  - item two   ')).toBe('  - item one\n  - item two')
+    })
+
+    it('does not collapse leading-indent into adjacent internal whitespace', () => {
+      // The leading indent block ends at the first non-HWS character. The
+      // collapse pass operates only on the rest of the line.
+      expect(normalize('    foo    bar')).toBe('    foo bar')
+    })
+
     it('preserves internal blank lines (paragraph structure)', () => {
       expect(normalize('para 1\n\npara 2')).toBe('para 1\n\npara 2')
     })
 
     it('drops leading and trailing blank lines from the whole content', () => {
       expect(normalize('\n\nhello\n\n')).toBe('hello')
+    })
+
+    it('treats lines with only whitespace as blank for leading/trailing trimming', () => {
+      // Pure-whitespace lines collapse to empty after trailing strip, then
+      // qualify for the leading/trailing blank-line removal. The middle
+      // line preserves its leading indent (a single tab) — that's
+      // semantic content, not wrapping noise.
+      expect(normalize('   \n\thello   \n   ')).toBe('\thello')
     })
 
     it('normalizes CRLF / CR line endings to LF', () => {
@@ -74,10 +95,19 @@ describe('DG-T0 — Fingerprint module (computeFingerprint / normalize)', () => 
       expect(a).toBe(b)
     })
 
-    it('returns the same fingerprint for whitespace-equivalent inputs', () => {
+    it('returns the same fingerprint for trailing-whitespace + internal-run differences', () => {
+      // Same leading indent (none); only trailing + internal-run differ.
       const a = computeFingerprint({ content: 'foo bar', userId: 'u', contentType: 'fact' })
-      const b = computeFingerprint({ content: '  foo    bar  \t', userId: 'u', contentType: 'fact' })
+      const b = computeFingerprint({ content: 'foo    bar  \t', userId: 'u', contentType: 'fact' })
       expect(a).toBe(b)
+    })
+
+    it('produces DIFFERENT fingerprints when leading indentation differs', () => {
+      // Leading indent is semantic (code / nested lists). Two writes that
+      // differ ONLY in their leading indent are NOT equivalent.
+      const a = computeFingerprint({ content: 'foo bar', userId: 'u', contentType: 'fact' })
+      const b = computeFingerprint({ content: '    foo bar', userId: 'u', contentType: 'fact' })
+      expect(a).not.toBe(b)
     })
 
     it('changes when userId differs', () => {
@@ -248,15 +278,18 @@ describe('DG-T0 — UnifiedStoreTool Tier 0 dedup gate', () => {
   // 2. Whitespace-only differences still trigger Tier 0
   // -------------------------------------------------------------------------
 
-  it('catches whitespace-only differences (normalize() collapses them)', async () => {
-    // The fingerprint for the original write
+  it('catches trailing-whitespace + internal-run-only differences (Tier 0 hit)', async () => {
+    // Both inputs share the same leading indent (none); only trailing
+    // whitespace and internal-run length differ. Leading indent is
+    // semantic and preserved by normalize() — see Fingerprint module
+    // contract — so we don't vary it across these two writes.
     const fpOriginal = computeFingerprint({
       content: 'foo bar baz',
       userId: 'u',
       contentType: 'fact'
     })
     const fpWhitespaceVariant = computeFingerprint({
-      content: '  foo    bar\t\tbaz  ',
+      content: 'foo    bar\t\tbaz  ',
       userId: 'u',
       contentType: 'fact'
     })
@@ -283,9 +316,9 @@ describe('DG-T0 — UnifiedStoreTool Tier 0 dedup gate', () => {
     )
 
     const tool = makeTool()
-    // Now write with extra whitespace. Should hit Tier 0.
+    // Now write with extra trailing/internal whitespace. Should hit Tier 0.
     const result = await tool.store({
-      content: '  foo    bar\t\tbaz  ',
+      content: 'foo    bar\t\tbaz  ',
       contentType: 'fact',
       userId: 'u'
     })
@@ -705,5 +738,159 @@ describe('DG-T0 — UnifiedStoreTool Tier 0 dedup gate', () => {
     if (!isDedupRequired(result)) return
     expect(result.band).toBe('refuse')
     expect(result.candidates[0].id).toBe('tier1-near-dup')
+  })
+
+  // -------------------------------------------------------------------------
+  // Update path: fingerprint recomputation
+  //
+  // When UnifiedStoreTool.update() mutates content / metadata / subject, the
+  // stored entry's metadata.fingerprint must be recomputed — otherwise the
+  // entry keeps a stale fingerprint that would mis-route the next Tier 0
+  // lookup of either the old or new content.
+  // -------------------------------------------------------------------------
+
+  it('update() recomputes metadata.fingerprint when content changes', async () => {
+    // Pre-existing entry the update path will fetch.
+    const oldContent = 'phoenix camera count is 6'
+    const newContent = 'phoenix camera count is UNKNOWN'
+    const oldFp = computeFingerprint({
+      content: oldContent,
+      userId: 'u',
+      contentType: 'fact'
+    })
+    ;(graph as any).findById = jest.fn().mockReturnValue({
+      id: 'entry-1',
+      content: oldContent,
+      contentType: 'fact',
+      source: 'technical',
+      userId: 'u',
+      metadata: { fingerprint: oldFp, subject: 'Phoenix.cam' }
+    })
+    mongo.findById = jest.fn().mockResolvedValue(null)
+    ;(graph as any).update = jest.fn().mockResolvedValue(true)
+    mongo.update = jest.fn().mockResolvedValue(true)
+
+    const tool = makeTool()
+    const result = await tool.update({
+      id: 'entry-1',
+      content: newContent,
+      reason: 'discovered the prior count was wrong'
+    })
+
+    expect(result.success).toBe(true)
+    // Inspect the metadata that was passed to the backend update.
+    const sentToGraph = ((graph as any).update as jest.Mock).mock.calls[0][1]
+    const newFp = computeFingerprint({
+      content: newContent,
+      userId: 'u',
+      contentType: 'fact',
+      subject: 'Phoenix.cam'
+    })
+    expect(sentToGraph.metadata.fingerprint).toBe(newFp)
+    expect(sentToGraph.metadata.fingerprint).not.toBe(oldFp)
+  })
+
+  it('update() recomputes fingerprint when metadata.subject changes', async () => {
+    const content = 'shared content'
+    const oldFp = computeFingerprint({
+      content,
+      userId: 'u',
+      contentType: 'fact',
+      subject: 'A'
+    })
+    ;(graph as any).findById = jest.fn().mockReturnValue({
+      id: 'entry-2',
+      content,
+      contentType: 'fact',
+      source: 'technical',
+      userId: 'u',
+      metadata: { fingerprint: oldFp, subject: 'A' }
+    })
+    mongo.findById = jest.fn().mockResolvedValue(null)
+    ;(graph as any).update = jest.fn().mockResolvedValue(true)
+    mongo.update = jest.fn().mockResolvedValue(true)
+
+    const tool = makeTool()
+    await tool.update({
+      id: 'entry-2',
+      metadata: { subject: 'B' },
+      reason: 'fact moved to a new subject facet'
+    })
+
+    const sentToGraph = ((graph as any).update as jest.Mock).mock.calls[0][1]
+    const newFp = computeFingerprint({
+      content,
+      userId: 'u',
+      contentType: 'fact',
+      subject: 'B'
+    })
+    expect(sentToGraph.metadata.fingerprint).toBe(newFp)
+    expect(sentToGraph.metadata.fingerprint).not.toBe(oldFp)
+  })
+
+  it('update() preserves existing fingerprint when content + scope unchanged', async () => {
+    // Pure metadata-edit (e.g. confidence bump) should still recompute the
+    // fingerprint, but the result equals the existing one because the
+    // tuple inputs haven't changed.
+    const content = 'stable content'
+    const fp = computeFingerprint({
+      content,
+      userId: 'u',
+      contentType: 'fact'
+    })
+    ;(graph as any).findById = jest.fn().mockReturnValue({
+      id: 'entry-3',
+      content,
+      contentType: 'fact',
+      source: 'technical',
+      userId: 'u',
+      metadata: { fingerprint: fp }
+    })
+    mongo.findById = jest.fn().mockResolvedValue(null)
+    ;(graph as any).update = jest.fn().mockResolvedValue(true)
+    mongo.update = jest.fn().mockResolvedValue(true)
+
+    const tool = makeTool()
+    await tool.update({
+      id: 'entry-3',
+      confidence: 0.95,
+      reason: 'higher confidence after follow-up'
+    })
+
+    const sentToGraph = ((graph as any).update as jest.Mock).mock.calls[0][1]
+    expect(sentToGraph.metadata.fingerprint).toBe(fp)
+  })
+
+  it('update() falls back to MongoDB findById when graph entry not found', async () => {
+    // Procedure-routed entries live in MongoDB only. Update must still be
+    // able to recompute the fingerprint from the MongoDB-side metadata.
+    const content = 'procedure content'
+    ;(graph as any).findById = jest.fn().mockReturnValue(null)
+    mongo.findById = jest.fn().mockResolvedValue({
+      id: 'proc-1',
+      content,
+      contentType: 'procedure',
+      source: 'technical',
+      userId: 'u',
+      metadata: { fingerprint: 'old-stale-fp' }
+    })
+    ;(graph as any).update = jest.fn().mockResolvedValue(false)
+    mongo.update = jest.fn().mockResolvedValue(true)
+
+    const tool = makeTool()
+    const result = await tool.update({
+      id: 'proc-1',
+      content: 'updated procedure body',
+      reason: 'cleaned up step ordering'
+    })
+
+    expect(result.success).toBe(true)
+    const sentToMongo = (mongo.update as jest.Mock).mock.calls[0][1]
+    const expectedFp = computeFingerprint({
+      content: 'updated procedure body',
+      userId: 'u',
+      contentType: 'procedure'
+    })
+    expect(sentToMongo.metadata.fingerprint).toBe(expectedFp)
   })
 })

--- a/src/dedup/Fingerprint.ts
+++ b/src/dedup/Fingerprint.ts
@@ -33,15 +33,35 @@
 
 import crypto from 'crypto'
 
+// Horizontal whitespace character class — used by normalize() to identify
+// non-newline whitespace. Enumerates space, tab, form-feed, vertical-tab,
+// and U+00A0 non-breaking space. NBSP is included because it commonly
+// appears in copy-pasted content from rich-text sources (Word, Google
+// Docs) and would otherwise fork the fingerprint vs the plain-space
+// version of the same content. Newlines are deliberately excluded so
+// paragraph structure is preserved at the higher level.
+const HWS_CHAR = /[ \t\f\v ]/
+const HWS_RUN_GLOBAL = /[ \t\f\v ]+/g
+const HWS_TRAILING = /[ \t\f\v ]+$/
+
 /**
  * Normalize content for fingerprinting. Two strings that differ only in
- * whitespace produce the same fingerprint.
+ * trailing whitespace, internal whitespace runs, or line-ending style
+ * produce the same fingerprint.
  *
  * Rules:
- *   - Strip trailing whitespace from each line
- *   - Collapse runs of horizontal whitespace WITHIN a line to a single space
  *   - Normalize line endings (CRLF / CR → LF)
+ *   - Strip TRAILING horizontal whitespace from each line
+ *   - Collapse runs of horizontal whitespace WITHIN a line to a single space
+ *     (but preserve a single leading-indent block intact)
  *   - Strip leading/trailing blank lines from the whole content
+ *
+ * Why leading indentation is preserved: indentation is semantically
+ * meaningful in code blocks, nested lists, and structured prose. Collapsing
+ * `"    code()"` and `"code()"` to the same fingerprint would let Tier 0
+ * declare two non-equivalent entries identical. We collapse internal runs
+ * (so `"foo    bar"` and `"foo bar"` match) but keep the first leading-
+ * whitespace block of each line verbatim.
  *
  * We deliberately preserve internal blank lines (between paragraphs) so
  * structurally distinct content stays distinct after normalization.
@@ -50,21 +70,28 @@ export function normalize(content: string): string {
   if (typeof content !== 'string') return ''
   // Normalize line endings first so per-line operations work uniformly.
   const unifiedNewlines = content.replace(/\r\n?/g, '\n')
+
   const lines = unifiedNewlines.split('\n').map(line => {
-    // Collapse runs of horizontal whitespace within the line to a single
-    // space. We explicitly enumerate horizontal whitespace (space, tab,
-    // form-feed, vertical-tab, U+00A0 non-breaking space) instead of \s
-    // so paragraph structure (newlines) is preserved. NBSP is included
-    // because it commonly appears in copy-pasted content from rich-text
-    // sources and would otherwise fork the fingerprint vs the plain-space
-    // version of the same content.
-    const collapsed = line.replace(/[ \t\f\v ]+/g, ' ')
-    // Strip leading + trailing whitespace per-line (line-internal already
-    // collapsed; this drops the leading/trailing single-space residue).
-    return collapsed.trim()
+    // 1) Capture leading indentation (the contiguous block of horizontal
+    //    whitespace at the start of the line). Preserved verbatim —
+    //    collapsing it would erase code/list semantics.
+    let leadingEnd = 0
+    while (leadingEnd < line.length && HWS_CHAR.test(line.charAt(leadingEnd))) {
+      leadingEnd++
+    }
+    const leading = line.slice(0, leadingEnd)
+    const rest = line.slice(leadingEnd)
+
+    // 2) Collapse internal whitespace runs in the rest of the line.
+    const collapsedRest = rest.replace(HWS_RUN_GLOBAL, ' ')
+
+    // 3) Strip trailing horizontal whitespace only — leading indent kept.
+    return (leading + collapsedRest).replace(HWS_TRAILING, '')
   })
-  // Drop leading + trailing blank lines so wrapping noise doesn't fork the
-  // fingerprint. Internal blank lines preserved (paragraph structure).
+
+  // Drop leading + trailing fully-blank lines so wrapping noise doesn't
+  // fork the fingerprint. (After the per-line trailing strip, lines that
+  // were pure-whitespace have become empty strings and qualify as blank.)
   let start = 0
   let end = lines.length
   while (start < end && lines[start] === '') start++

--- a/src/dedup/Fingerprint.ts
+++ b/src/dedup/Fingerprint.ts
@@ -1,0 +1,95 @@
+/**
+ * Tier 0 fingerprint dedup (issue: DG-T0).
+ *
+ * Computes a deterministic SHA-256 fingerprint over the tuple
+ *   (normalized_content, userId, contentType, subject ?? '')
+ *
+ * Used by the dedup gate as a CHEAP prepend layer that runs BEFORE the
+ * Tier 1 vector similarity check in `unified_store`. Two writes that produce
+ * the same fingerprint are guaranteed-identical at the content/scope level
+ * (modulo benign whitespace differences) — no embedder, no cosine math,
+ * no LLM judge needed.
+ *
+ * Why Tier 0 helps even with HNSW populated:
+ *   1. **Whitespace-equivalent inputs.** Two writes that differ only in
+ *      trailing spaces or line-ending style hash to different bytes BUT
+ *      are equivalent content. The embedder will score them very high
+ *      (often >0.99) but not always above the 0.88 refuse threshold —
+ *      especially for very short content where each token weighs heavily.
+ *      Tier 0's normalize() collapses these to the same fingerprint.
+ *   2. **Latency short-circuit.** A fingerprint check is an O(n) scan of
+ *      the in-memory sidecar (~1200 entries → ~0.1 ms). The Tier 1 path
+ *      is HNSW search (1-3 ms) + JS post-filter + (sometimes) Anthropic
+ *      Haiku 4.5 round-trip (5 s timeout). Tier 0 catches the easy cases
+ *      for free.
+ *   3. **Exact-match certainty.** When the LLM judge or the embedder is
+ *      down (Ollama unreachable, ANTHROPIC_API_KEY unset), Tier 0 still
+ *      catches identical re-stores. Useful for batch importers and the
+ *      "user accidentally hit submit twice" case.
+ *
+ * The fingerprint is stored in `metadata.fingerprint` on the new entry so
+ * subsequent Tier 0 lookups can match against it directly.
+ */
+
+import crypto from 'crypto'
+
+/**
+ * Normalize content for fingerprinting. Two strings that differ only in
+ * whitespace produce the same fingerprint.
+ *
+ * Rules:
+ *   - Strip trailing whitespace from each line
+ *   - Collapse runs of horizontal whitespace WITHIN a line to a single space
+ *   - Normalize line endings (CRLF / CR → LF)
+ *   - Strip leading/trailing blank lines from the whole content
+ *
+ * We deliberately preserve internal blank lines (between paragraphs) so
+ * structurally distinct content stays distinct after normalization.
+ */
+export function normalize(content: string): string {
+  if (typeof content !== 'string') return ''
+  // Normalize line endings first so per-line operations work uniformly.
+  const unifiedNewlines = content.replace(/\r\n?/g, '\n')
+  const lines = unifiedNewlines.split('\n').map(line => {
+    // Collapse runs of horizontal whitespace (spaces, tabs) within the line
+    // to a single space. \s would also match newlines — we explicitly use
+    // [ \t\f\v ] so paragraph structure (newlines) is preserved.
+    const collapsed = line.replace(/[ \t\f\v ]+/g, ' ')
+    // Strip leading + trailing whitespace per-line (line-internal already
+    // collapsed; this drops the leading/trailing single-space residue).
+    return collapsed.trim()
+  })
+  // Drop leading + trailing blank lines so wrapping noise doesn't fork the
+  // fingerprint. Internal blank lines preserved (paragraph structure).
+  let start = 0
+  let end = lines.length
+  while (start < end && lines[start] === '') start++
+  while (end > start && lines[end - 1] === '') end--
+  return lines.slice(start, end).join('\n')
+}
+
+/**
+ * Compute the Tier 0 fingerprint over a write's identifying tuple.
+ *
+ * Subject defaults to empty string when absent — Tier 0 deliberately treats
+ * "no subject" as a distinct scope from "subject=X". This matches Tier 1's
+ * subject scoping behavior (see UnifiedStoreTool's `findSimilar` call: when
+ * no subject is provided, the gate falls back to userId + contentType only).
+ */
+export function computeFingerprint(args: {
+  content: string
+  userId: string
+  contentType: string
+  subject?: string
+}): string {
+  const tuple = [
+    normalize(args.content),
+    args.userId,
+    args.contentType,
+    args.subject ?? ''
+  ]
+  // JSON.stringify gives us a canonical, unambiguous separator-free encoding.
+  // Two arrays with the same elements always produce the same JSON.
+  const payload = JSON.stringify(tuple)
+  return crypto.createHash('sha256').update(payload, 'utf8').digest('hex')
+}

--- a/src/dedup/Fingerprint.ts
+++ b/src/dedup/Fingerprint.ts
@@ -51,9 +51,13 @@ export function normalize(content: string): string {
   // Normalize line endings first so per-line operations work uniformly.
   const unifiedNewlines = content.replace(/\r\n?/g, '\n')
   const lines = unifiedNewlines.split('\n').map(line => {
-    // Collapse runs of horizontal whitespace (spaces, tabs) within the line
-    // to a single space. \s would also match newlines — we explicitly use
-    // [ \t\f\v ] so paragraph structure (newlines) is preserved.
+    // Collapse runs of horizontal whitespace within the line to a single
+    // space. We explicitly enumerate horizontal whitespace (space, tab,
+    // form-feed, vertical-tab, U+00A0 non-breaking space) instead of \s
+    // so paragraph structure (newlines) is preserved. NBSP is included
+    // because it commonly appears in copy-pasted content from rich-text
+    // sources and would otherwise fork the fingerprint vs the plain-space
+    // version of the same content.
     const collapsed = line.replace(/[ \t\f\v ]+/g, ' ')
     // Strip leading + trailing whitespace per-line (line-internal already
     // collapsed; this drops the leading/trailing single-space residue).

--- a/src/storage/SparrowDBStorage.ts
+++ b/src/storage/SparrowDBStorage.ts
@@ -48,6 +48,7 @@ import { homedir } from 'os'
 import { join, dirname } from 'path'
 import { fileURLToPath } from 'url'
 import { PENDING_EMBEDDING_KEY, PENDING_EMBEDDER_ID_KEY } from '../embedding/EmbeddingService.js'
+import { computeFingerprint } from '../dedup/Fingerprint.js'
 import { StorageSystem, UnifiedKnowledge, KnowledgeQuery, KnownPersonEntry, KnownPeopleConfig, KnowledgeFlag } from '../types/index.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -893,6 +894,17 @@ export class SparrowDBStorage implements StorageSystem {
    * Returns `null` when no match is found (no entry has the fingerprint, or
    * the only matches are flagged when `includeFlagged` is false).
    *
+   * Backfill of pre-rollout entries: entries written before DG-T0 was wired
+   * have no `metadata.fingerprint`. On the first lookup we lazily compute
+   * + stamp fingerprints for those entries (one-shot opportunistic backfill,
+   * gated by `_fingerprintBackfillDone`) so Tier 0 starts catching them
+   * without requiring a separate migration script. The backfill scans the
+   * full corpus once (~1200 entries; a few ms); subsequent calls are pure
+   * O(n) lookups. The stamps are written to the in-memory contentIndex
+   * only — flushed on the next organic _saveSidecar() call (delete /
+   * update / flag / store) so we don't pay a sidecar I/O cost on every
+   * Tier 0 lookup.
+   *
    * Why a linear scan rather than a fingerprint→id index: the contentIndex
    * is an in-memory Map already holding every entry; scanning is bounded
    * and the cost is well below the Tier 1 latency floor. A separate index
@@ -907,6 +919,11 @@ export class SparrowDBStorage implements StorageSystem {
   ): ContentEntry | null {
     const includeFlagged = options?.includeFlagged === true
     if (!fingerprint || !userId) return null
+
+    // One-shot backfill of pre-rollout entries that have no
+    // metadata.fingerprint. Idempotent: subsequent calls are a no-op.
+    this._backfillFingerprintsOnce()
+
     for (const entry of this.contentIndex.values()) {
       if (entry.userId !== userId) continue
       if (!includeFlagged && entry.flag) continue
@@ -916,6 +933,56 @@ export class SparrowDBStorage implements StorageSystem {
       }
     }
     return null
+  }
+
+  /**
+   * Tracks whether the lazy fingerprint backfill has run for this process.
+   * Set true after the first findByFingerprint call to avoid re-scanning on
+   * every subsequent lookup. Reset only on a fresh process start (no
+   * persistence — the stamped fingerprints flush to the sidecar through
+   * organic save calls, so they survive restarts naturally).
+   */
+  private _fingerprintBackfillDone = false
+
+  /**
+   * Compute + stamp `metadata.fingerprint` on every contentIndex entry that
+   * doesn't have one. Runs once per process. The fingerprint is computed
+   * over (content, userId, contentType, metadata.subject ?? '') to match
+   * the contract in src/dedup/Fingerprint.ts — UnifiedStoreTool.store()
+   * uses the same tuple for new writes.
+   *
+   * Errors during compute are non-fatal — a single bad entry won't crash
+   * the backfill. The corresponding entry just stays without a fingerprint
+   * and will retry on the next process restart.
+   */
+  private _backfillFingerprintsOnce(): void {
+    if (this._fingerprintBackfillDone) return
+    this._fingerprintBackfillDone = true
+
+    let stamped = 0
+    for (const entry of this.contentIndex.values()) {
+      const meta = entry.metadata ?? {}
+      if (typeof meta.fingerprint === 'string' && meta.fingerprint.length > 0) continue
+      try {
+        const subject = typeof meta.subject === 'string' ? (meta.subject as string) : undefined
+        const fp = computeFingerprint({
+          content: entry.content,
+          userId: entry.userId,
+          contentType: entry.contentType,
+          subject
+        })
+        entry.metadata = { ...meta, fingerprint: fp }
+        stamped++
+      } catch (e) {
+        logger.debug(
+          `findByFingerprint backfill: skipped ${entry.id} ` +
+          `(${e instanceof Error ? e.message : String(e)})`
+        )
+      }
+    }
+    if (stamped > 0) {
+      logger.debug(`✅ Tier 0 fingerprint backfill: stamped ${stamped} pre-rollout entries`)
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/src/storage/SparrowDBStorage.ts
+++ b/src/storage/SparrowDBStorage.ts
@@ -880,6 +880,44 @@ export class SparrowDBStorage implements StorageSystem {
     return out
   }
 
+  /**
+   * Tier 0 fingerprint dedup lookup (DG-T0).
+   *
+   * Returns the first entry whose `metadata.fingerprint === fingerprint` AND
+   * `userId === userId`. Scans the in-memory contentIndex (~1200 entries on
+   * the production corpus → ~0.1 ms typical). Skips flagged entries by
+   * default — the gate should not refuse a write because of a previously
+   * deleted/superseded/retracted match. Pass `includeFlagged: true` for
+   * audit / reaper paths.
+   *
+   * Returns `null` when no match is found (no entry has the fingerprint, or
+   * the only matches are flagged when `includeFlagged` is false).
+   *
+   * Why a linear scan rather than a fingerprint→id index: the contentIndex
+   * is an in-memory Map already holding every entry; scanning is bounded
+   * and the cost is well below the Tier 1 latency floor. A separate index
+   * would be a maintenance burden (load/save sidecar, dedup eviction on
+   * delete/update, etc.) for negligible gain at current corpus size. If
+   * the corpus grows past ~10k entries we can revisit.
+   */
+  findByFingerprint(
+    fingerprint: string,
+    userId: string,
+    options?: { includeFlagged?: boolean }
+  ): ContentEntry | null {
+    const includeFlagged = options?.includeFlagged === true
+    if (!fingerprint || !userId) return null
+    for (const entry of this.contentIndex.values()) {
+      if (entry.userId !== userId) continue
+      if (!includeFlagged && entry.flag) continue
+      const fp = entry.metadata?.fingerprint
+      if (typeof fp === 'string' && fp === fingerprint) {
+        return entry
+      }
+    }
+    return null
+  }
+
   // -------------------------------------------------------------------------
   // StorageSystem.search
   // -------------------------------------------------------------------------

--- a/src/tools/UnifiedStoreTool.ts
+++ b/src/tools/UnifiedStoreTool.ts
@@ -17,7 +17,8 @@ import {
   PENDING_EMBEDDER_ID_KEY
 } from '../embedding/EmbeddingService.js'
 import type { LLMJudgeService, LLMRelation } from '../embedding/LLMJudgeService.js'
-import { logger } from '../logger.js' 
+import { computeFingerprint } from '../dedup/Fingerprint.js'
+import { logger } from '../logger.js'
 
 const debug = (...args: unknown[]) => { if (process.env.KMS_DEBUG) console.error(...args) }
 
@@ -97,8 +98,17 @@ export interface DedupRequiredResponse {
   candidates: DedupCandidate[]
   message: string
   retry_with: string[]
-  /** Threshold band for the highest-similarity candidate ('refuse' | 'confirm'). */
-  band: 'refuse' | 'confirm'
+  /**
+   * Threshold band for the highest-similarity candidate.
+   *  - 'exact'   — Tier 0 fingerprint match (DG-T0). Identical normalized
+   *    content for the same userId / contentType / subject scope. similarity
+   *    is reported as 1.0 and llm_relation is 'duplicate' inline (no LLM
+   *    call — the fingerprint is a stronger signal than any embedder).
+   *  - 'refuse'  — Tier 1 cosine similarity ≥ refuseThreshold (default 0.88,
+   *    or per-contentType override).
+   *  - 'confirm' — Tier 1 cosine similarity ∈ [confirmThreshold, refuseThreshold).
+   */
+  band: 'exact' | 'refuse' | 'confirm'
   /** Echo of the thresholds applied to this call (for caller diagnostics). */
   thresholds: { refuse: number; confirm: number }
 }
@@ -335,6 +345,114 @@ export class UnifiedStoreTool {
       timestamp: new Date(),
       confidence: enrichedArgs.confidence || 0.8,
       relationships: enrichedArgs.relationships || []
+    }
+
+    // ---------------------------------------------------------------------
+    // Dedup gate — Tier 0 (DG-T0) fingerprint check (PREPENDS Tier 1)
+    //
+    // Cheap O(n) scan of the in-memory sidecar against a SHA-256 fingerprint
+    // of (normalized_content, userId, contentType, subject ?? ''). Catches:
+    //   - Whitespace-only differences that the embedder may not score above
+    //     the cosine refuse threshold.
+    //   - Repeated submits / batch importer re-runs.
+    //   - Anything identical when the embedder or LLM judge is down.
+    //
+    // Skipped when:
+    //   - options.skip_dedup === true (admin escape hatch; same path the
+    //     DG-T1-C dispatcher uses for action=complement / action=force-new).
+    //   - The graph backend doesn't expose findByFingerprint (older builds).
+    //
+    // The fingerprint is also stamped into knowledge.metadata so subsequent
+    // Tier 0 lookups match against it directly.
+    // ---------------------------------------------------------------------
+    const tier0SubjectFacet = typeof knowledge.metadata?.subject === 'string'
+      ? (knowledge.metadata.subject as string)
+      : undefined
+
+    const fingerprint = computeFingerprint({
+      content: knowledge.content,
+      userId: knowledge.userId,
+      contentType: knowledge.contentType,
+      subject: tier0SubjectFacet
+    })
+
+    // Stamp fingerprint into metadata for future Tier 0 hits. We do this
+    // unconditionally (regardless of whether Tier 0 finds a match this call)
+    // so the next write of identical content lands a fingerprint match. Set
+    // BEFORE the Tier 0 check so the in-memory metadata clone propagates
+    // through embedding, routing, and storage fan-out.
+    knowledge.metadata = {
+      ...knowledge.metadata,
+      fingerprint
+    }
+
+    if (
+      args.options?.skip_dedup !== true &&
+      typeof (this.storage.graph as any).findByFingerprint === 'function'
+    ) {
+      try {
+        const existing = (this.storage.graph as any).findByFingerprint(
+          fingerprint,
+          knowledge.userId
+        ) as { id: string; content?: string; contentType?: string; source?: string; metadata?: Record<string, any>; timestamp?: string; flag?: KnowledgeFlag | null } | null
+
+        if (existing && !existing.flag) {
+          const subject = typeof existing.metadata?.subject === 'string'
+            ? (existing.metadata.subject as string)
+            : undefined
+          const preview = (existing.content ?? '').slice(0, 200)
+
+          // Reuse the resolved Tier 1 thresholds for the response echo so the
+          // caller sees the *same* threshold context across tiers (Tier 0 is
+          // additive, not a replacement). The thresholds aren't actually used
+          // to make the Tier 0 decision — fingerprint identity is binary.
+          const { refuse: refuseThreshold, confirm: confirmThreshold } = resolveDedupThresholds(
+            knowledge.contentType,
+            args.options?.dedup_threshold_override
+          )
+
+          const response: DedupRequiredResponse = {
+            status: 'dedup_required',
+            candidates: [{
+              id: existing.id,
+              similarity: 1.0,
+              content_preview: preview,
+              contentType: existing.contentType ?? knowledge.contentType,
+              source: existing.source ?? knowledge.source,
+              subject,
+              created: existing.timestamp ?? '',
+              flag: existing.flag ?? null,
+              // Fingerprint match is a stronger signal than any embedder
+              // similarity, so we tag 'duplicate' inline without invoking
+              // the Tier 2 LLM judge.
+              llm_relation: 'duplicate'
+            }],
+            message:
+              `Exact-match duplicate found via Tier 0 fingerprint (sha256). ` +
+              `Identical normalized content for the same userId+contentType+subject scope. ` +
+              `Retry with action.`,
+            retry_with: [
+              `action=supersede&old_id=${existing.id}&reason=<...>`,
+              `action=update&old_id=${existing.id}&reason=<...>`,
+              `action=complement&related_to=${existing.id}`,
+              `action=force-new&reason=<justification>`
+            ],
+            band: 'exact',
+            thresholds: { refuse: refuseThreshold, confirm: confirmThreshold }
+          }
+          debug(
+            `🛑 DEDUP GATE refused write (exact/Tier 0): fingerprint match against id=${existing.id}`
+          )
+          return response
+        }
+      } catch (e) {
+        // Non-fatal: degrade to "no Tier 0 check" rather than blocking the write.
+        // Tier 1 still runs.
+        console.warn(
+          `⚠️ unified_store: findByFingerprint failed (continuing to Tier 1): ` +
+          `${e instanceof Error ? e.message : String(e)}`
+        )
+      }
     }
 
     // ---------------------------------------------------------------------

--- a/src/tools/UnifiedStoreTool.ts
+++ b/src/tools/UnifiedStoreTool.ts
@@ -388,13 +388,13 @@ export class UnifiedStoreTool {
 
     if (
       args.options?.skip_dedup !== true &&
-      typeof (this.storage.graph as any).findByFingerprint === 'function'
+      typeof this.storage.graph.findByFingerprint === 'function'
     ) {
       try {
-        const existing = (this.storage.graph as any).findByFingerprint(
+        const existing = this.storage.graph.findByFingerprint(
           fingerprint,
           knowledge.userId
-        ) as { id: string; content?: string; contentType?: string; source?: string; metadata?: Record<string, any>; timestamp?: string; flag?: KnowledgeFlag | null } | null
+        )
 
         if (existing && !existing.flag) {
           const subject = typeof existing.metadata?.subject === 'string'
@@ -447,8 +447,10 @@ export class UnifiedStoreTool {
         }
       } catch (e) {
         // Non-fatal: degrade to "no Tier 0 check" rather than blocking the write.
-        // Tier 1 still runs.
-        console.warn(
+        // Tier 1 still runs. Use the project logger for consistency with the
+        // rest of the dedup-gate code path (Tier 1 / Tier 2 also log via
+        // logger.warn — see the findSimilar guard below).
+        logger.warn(
           `⚠️ unified_store: findByFingerprint failed (continuing to Tier 1): ` +
           `${e instanceof Error ? e.message : String(e)}`
         )

--- a/src/tools/UnifiedStoreTool.ts
+++ b/src/tools/UnifiedStoreTool.ts
@@ -1223,19 +1223,48 @@ export class UnifiedStoreTool {
     if (args.content !== undefined) updates.content = args.content
     if (args.confidence !== undefined) updates.confidence = args.confidence
 
-    // Fetch existing record so we can merge metadata instead of overwriting it.
-    // This prevents $set from dropping existing metadata keys and prior
-    // update_history entries that the caller did not include in args.metadata.
-    // Also surfaces the existing userId so Mem0 propagation can scope its
-    // search to the right user when the caller didn't supply args.userId.
+    // Fetch existing record so we can:
+    //   1. Merge metadata instead of overwriting it (preserves existing keys
+    //      + prior update_history that the caller didn't include in args).
+    //   2. Recompute the Tier 0 fingerprint (DG-T0) when content or
+    //      metadata.subject changes — userId + contentType come from the
+    //      existing entry (caller can't change them via update()). Without
+    //      this, an updated entry would keep its OLD fingerprint and Tier 0
+    //      would mis-match the next write of the OLD content.
+    //   3. Surface existingUserId so Mem0 propagation (PR #79) can scope its
+    //      search to the right user when the caller didn't supply args.userId.
+    //
+    // Prefer the graph's findById since the sidecar holds full content + the
+    // current fingerprint authoritative metadata; fall back to MongoDB for
+    // procedure-routed entries that don't live in the graph.
     let existingMetadata: Record<string, any> = {}
+    let existingContent: string | undefined
+    let existingContentType: string | undefined
     let existingUserId: string | undefined
     try {
-      const existing = await this.storage.mongodb.findById(args.id)
-      if (existing?.metadata) existingMetadata = existing.metadata as Record<string, any>
-      if (existing?.userId) existingUserId = existing.userId
+      const graphAny = this.storage.graph as any
+      if (typeof graphAny.findById === 'function') {
+        const e = await graphAny.findById(args.id)
+        if (e) {
+          if (e.metadata) existingMetadata = e.metadata as Record<string, any>
+          if (typeof e.content === 'string') existingContent = e.content
+          if (typeof e.contentType === 'string') existingContentType = e.contentType
+          if (typeof e.userId === 'string') existingUserId = e.userId
+        }
+      }
+      if (existingContent === undefined || existingContentType === undefined || existingUserId === undefined) {
+        const e = await this.storage.mongodb.findById(args.id)
+        if (e) {
+          if (e.metadata && Object.keys(existingMetadata).length === 0) {
+            existingMetadata = e.metadata as Record<string, any>
+          }
+          if (existingContent === undefined && typeof e.content === 'string') existingContent = e.content
+          if (existingContentType === undefined && typeof e.contentType === 'string') existingContentType = e.contentType
+          if (existingUserId === undefined && typeof e.userId === 'string') existingUserId = e.userId
+        }
+      }
     } catch (e) {
-      console.warn('⚠️  unified_update: could not fetch existing metadata for merge (non-fatal):', e)
+      console.warn('⚠️  unified_update: could not fetch existing entry for merge (non-fatal):', e)
     }
 
     // Merge: existing metadata base, then caller-supplied overrides, then
@@ -1248,6 +1277,29 @@ export class UnifiedStoreTool {
       const prior = Array.isArray(mergedMetadata.update_history) ? mergedMetadata.update_history : []
       mergedMetadata.update_history = [...prior, { at: new Date().toISOString(), reason: args.reason }]
     }
+
+    // Recompute Tier 0 fingerprint (DG-T0) when we have enough context to do
+    // it correctly. The fingerprint covers (content, userId, contentType,
+    // subject) — any of those changing means the cached fingerprint is stale
+    // and Tier 0 would mis-route subsequent writes against this entry.
+    //
+    // We unconditionally recompute when we know userId + contentType (cheap;
+    // bytes-of-content + sha256 over a few hundred chars). The new content
+    // is args.content if provided, else the existing content. Same for
+    // metadata.subject (caller override > existing).
+    if (existingUserId !== undefined && existingContentType !== undefined) {
+      const newContent = args.content !== undefined ? args.content : (existingContent ?? '')
+      const newSubject = typeof mergedMetadata.subject === 'string'
+        ? (mergedMetadata.subject as string)
+        : undefined
+      mergedMetadata.fingerprint = computeFingerprint({
+        content: newContent,
+        userId: existingUserId,
+        contentType: existingContentType,
+        subject: newSubject
+      })
+    }
+
     updates.metadata = mergedMetadata
 
     const backends: string[] = []

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -178,6 +178,15 @@ export interface GraphStorage extends StorageSystem {
   ): Promise<boolean>
   findById?(id: string): { id: string; flag?: KnowledgeFlag | null; flag_date?: string; [k: string]: any } | null
   listFlagged?(): Array<{ id: string; flag?: KnowledgeFlag | null; flag_date?: string; [k: string]: any }>
+  // Tier 0 fingerprint dedup (DG-T0) — returns the first entry whose
+  // metadata.fingerprint matches AND userId matches. Skips flagged entries
+  // by default. Returns null when no match. Optional so backends without an
+  // in-memory index can degrade to "no Tier 0 check".
+  findByFingerprint?(
+    fingerprint: string,
+    userId: string,
+    options?: { includeFlagged?: boolean }
+  ): { id: string; flag?: KnowledgeFlag | null; metadata?: Record<string, any>; [k: string]: any } | null
   // Embedding write (DG-T1-A) — persists a 768-dim vector into the HNSW index
   // for the (Knowledge, embedding) tuple. Optional so older bindings degrade.
   storeEmbedding?(id: string, embedding: Float32Array, embedderId: string): Promise<boolean>


### PR DESCRIPTION
## Summary

Adds **Tier 0 — exact-match fingerprint dedup** as a prepend layer that runs BEFORE the existing Tier 1 vector check in `unified_store`. Catches identical content the embedder might score below the 0.88 cosine refuse threshold (whitespace differences, edge cases) AND short-circuits the expensive vector + LLM path on guaranteed exact matches.

## Why Tier 0 helps even with HNSW populated

1. **Whitespace-equivalent inputs.** Two writes that differ only in *trailing whitespace*, *internal whitespace runs*, or *line-ending style* (CRLF vs LF) hash to different bytes BUT are equivalent content. The embedder will score them very high (often >0.99) but not always above the 0.88 refuse threshold — especially for short content where each token weighs heavily. Tier 0's `normalize()` collapses these to the same fingerprint. *Leading indentation is preserved* — code blocks, nested lists, and structured prose stay distinct in the fingerprint.
2. **Latency short-circuit.** Tier 0 is an O(n) scan of the in-memory sidecar (~1200 entries → ~0.1 ms). Tier 1 is HNSW search (1-3 ms) + JS post-filter + sometimes a 5 s Anthropic Haiku 4.5 round-trip for confirm-band candidates. Tier 0 catches the easy cases for free.
3. **Exact-match certainty.** When Ollama is unreachable or `ANTHROPIC_API_KEY` is unset, Tier 0 still catches identical re-stores. Useful for batch importers and the "user accidentally hit submit twice" case.

## Implementation

- **`src/dedup/Fingerprint.ts`** — pure-function module:
  - `normalize(content)`:
    - Normalizes line endings (CRLF/CR → LF).
    - For each line: captures leading horizontal-whitespace block verbatim, then collapses internal whitespace runs in the rest, then strips trailing horizontal whitespace.
    - Strips leading/trailing blank lines from the whole content (paragraph structure preserved internally).
    - The horizontal-whitespace class includes space, tab, form-feed, vertical-tab, and U+00A0 NBSP (covers rich-text paste).
  - `computeFingerprint({content, userId, contentType, subject?})` returns SHA-256 hex over `JSON.stringify([normalize(content), userId, contentType, subject ?? ''])`. Subject defaults to empty string when absent (omitted subject and `subject=""` produce the same fingerprint, but both differ from any non-empty subject value).

- **`SparrowDBStorage.findByFingerprint(fingerprint, userId, options?)`** — scans the in-memory `contentIndex` Map. Filters by `userId` (always required); skips flagged entries (DELETED/SUPERSEDED/RETRACTED) by default. Returns `null` when no match.
  - **Lazy backfill**: on first call per process, walks the contentIndex and stamps `metadata.fingerprint` on every entry that doesn't have one — handles pre-rollout entries without requiring a separate migration. Stamps live in memory and flush on the next organic sidecar save.

- **`UnifiedStoreTool.store()`** — Tier 0 check inserted between the `knowledge` object creation and the embedding step:
  - Computes fingerprint from `(content, userId, contentType, metadata.subject)`.
  - Stamps `metadata.fingerprint` on the new entry unconditionally so future Tier 0 lookups hit.
  - Calls `findByFingerprint`. If a non-flagged entry matches, returns `dedup_required` with `band: "exact"`, `similarity: 1.0`, `llm_relation: "duplicate"` (no LLM call — fingerprint is a stronger signal than any embedder).
  - If no match: falls through to the existing Tier 1 vector path.
  - Skipped entirely when `options.skip_dedup === true` or `args.action` is set.

- **`UnifiedStoreTool.update()`** — recomputes `metadata.fingerprint` whenever the existing entry can be located (graph first, MongoDB fallback). Without this, an updated entry would keep its OLD fingerprint and Tier 0 would mis-match the next write of the OLD content. Falls back gracefully if the entry can't be fetched.

- **Response shape**: reuses the existing `DedupRequiredResponse`. The `band` union widens from `'refuse' | 'confirm'` to `'exact' | 'refuse' | 'confirm'`. Same `retry_with` options as Tier 1.

- **`GraphStorage` interface**: `findByFingerprint?` added as optional so older backends degrade to "no Tier 0 check".

## Constraints honored

- Tier 1 thresholds and behavior **unchanged** (purely additive).
- Existing `dedup_required` response shape reused (only `band` literal union widened).
- Subject defaults to empty string when absent.
- `@anthropic-ai/sdk` version untouched.

## Review iterations

- Round 1 (CodeRabbit): leading indent was being stripped by `trim()`, breaking code-block / nested-list semantics → switched to leading-indent-preserving normalize. Pre-rollout backfill + `update()` recompute path added.
- Round 2 (gemini-code-assist): dropped `as any` casts on `findByFingerprint` (interface declares the optional method); switched the Tier 0 fallback path from `console.warn` to `logger.warn` for consistency with the rest of the dedup-gate code.

## Test plan

- [x] **39 new tests** in `src/__tests__/dedup_tier0.test.ts` covering:
  - `normalize()` rules (whitespace collapse, leading-indent preservation, line endings, blank-line trim)
  - `computeFingerprint()` determinism + tuple separation properties
  - Identical content → exact-band refuse
  - Trailing-whitespace + internal-run-only differences → still hit
  - **Different leading indent → DIFFERENT fingerprint** (semantic preservation)
  - Same content, different userId → no Tier 0 hit (proceeds to Tier 1)
  - Same content, different contentType → no Tier 0 hit
  - Same content + same subject → refuse; same content + different subject → no hit
  - `metadata.fingerprint` stamped on new writes
  - Tier 0 short-circuits BEFORE the embedder is called
  - Flagged matches don't block (deleted/superseded entries OK)
  - `skip_dedup` and `action` field bypass Tier 0
  - Older backends without `findByFingerprint` → Tier 0 inert
  - `findByFingerprint` throw degrades to Tier 1 (non-fatal)
  - Tier 0 miss falls through to existing Tier 1 gate
  - `update()` recomputes fingerprint on content change
  - `update()` recomputes fingerprint on metadata.subject change
  - `update()` preserves fingerprint on confidence-only edits
  - `update()` falls back to MongoDB.findById for procedure-routed entries
- [x] All 338 existing tests pass (no regressions in Tier 1 / Tier 1c / Tier 2 dedup tests).
- [x] `npx tsc --noEmit` clean.
- [x] `npm run build` clean.
- [x] CodeRabbit review: SUCCESS.
- [ ] Manual smoke test against live SparrowDB once merged (current SparrowDB binding limitation around vector inserts means Tier 1 is inert in practice — Tier 0 should now be the active dedup layer for that corpus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)