### PR TITLE
feat(granola): cache-v6.json autonomous source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ dist/
 !tsconfig.json
 !tsconfig.test.json
 !test-fixtures/*.json
+!src/__tests__/fixtures/*.json
 !skills/**/*.json
 *.sh
 !examples/**/*.sh

--- a/scripts/import-granola.ts
+++ b/scripts/import-granola.ts
@@ -110,12 +110,17 @@ import {
   mapClaimTypeToContentType,
   parseDistilledResponse
 } from '../src/scripts/granola-distill-prompt.js'
+import {
+  GranolaCacheV6Source,
+  DEFAULT_CACHE_V6_PATH,
+  DEFAULT_WATERMARK_PATH
+} from '../src/scripts/granola-cache-v6-source.js'
 
 // ─────────────────────────────────────────────────────────────────────────
 // Types
 // ─────────────────────────────────────────────────────────────────────────
 
-interface RawMeeting {
+export interface RawMeeting {
   id: string
   title: string
   date?: string
@@ -138,6 +143,14 @@ interface ImportReport {
 
 interface CliOptions {
   input?: string
+  /** Source selector: 'file' (default, --input dump) or 'cache-v6' (read Granola cache directly). */
+  source: 'file' | 'cache-v6'
+  /** When source=cache-v6: path to Granola's cache-v6.json (default: DEFAULT_CACHE_V6_PATH). */
+  cachePath?: string
+  /** When source=cache-v6: watermark file path (default: DEFAULT_WATERMARK_PATH). */
+  watermarkPath?: string
+  /** When source=cache-v6: only emit meetings with end-ts >= this date (ISO). */
+  since?: string
   timeRange: string
   customStart?: string
   customEnd?: string
@@ -156,6 +169,7 @@ interface CliOptions {
 
 export function parseArgs(argv: string[]): CliOptions {
   const opts: CliOptions = {
+    source: 'file',
     timeRange: 'last_30_days',
     kmsUrl: process.env.KMS_URL || 'http://localhost:8180/mcp',
     syncLogPath: process.env.KMS_GRANOLA_SYNC_LOG || join(homedir(), '.kms-granola-sync.json'),
@@ -177,6 +191,20 @@ export function parseArgs(argv: string[]): CliOptions {
     }
     switch (arg) {
       case '--input':              opts.input = next('--input'); break
+      case '--source': {
+        const v = next('--source')
+        if (v !== 'file' && v !== 'cache-v6') {
+          console.error(`❌ Invalid --source: ${v} (expected 'file' or 'cache-v6')`)
+          process.exit(2)
+        }
+        opts.source = v
+        break
+      }
+      // --cache-v6 is sugar for --source cache-v6
+      case '--cache-v6':           opts.source = 'cache-v6'; break
+      case '--cache-path':         opts.cachePath = next('--cache-path'); break
+      case '--watermark-path':     opts.watermarkPath = next('--watermark-path'); break
+      case '--since':              opts.since = next('--since'); break
       case '--time-range':         opts.timeRange = next('--time-range'); break
       case '--custom-start':       opts.customStart = next('--custom-start'); break
       case '--custom-end':         opts.customEnd = next('--custom-end'); break
@@ -215,10 +243,23 @@ function printHelp(): void {
 Granola → KMS importer
 
 Usage:
+  # Source A — pre-dumped JSON file (claude.ai-driven workflow):
   tsx scripts/import-granola.ts --input <meetings.json> [options]
 
-Required:
-  --input <file>            Path to a JSON array of meetings.
+  # Source B — read Granola desktop app's cache directly (autonomous / cron):
+  tsx scripts/import-granola.ts --source cache-v6 [options]
+  # (or use the shorthand: --cache-v6)
+
+Source selection:
+  --source <kind>           'file' (default; --input required) or 'cache-v6'
+  --cache-v6                Shorthand for --source cache-v6.
+  --input <file>            Required when --source file: JSON array of meetings.
+  --cache-path <path>       --source cache-v6 only. Path to cache-v6.json
+                            (default: ~/Library/Application Support/Granola/cache-v6.json).
+  --watermark-path <path>   --source cache-v6 only. Resumability state file
+                            (default: ~/.kms-granola-state.json).
+  --since <ISO>             --source cache-v6 only. Skip meetings ending before this.
+                            (Watermark wins if it's later.)
 
 Options:
   --time-range <r>          last_30_days (default) | this_week | last_week | custom | all_time (advisory)
@@ -480,6 +521,12 @@ function parseSseToJson(sse: string): any {
 
 export interface GranolaSource {
   list(): Promise<RawMeeting[]>
+  /**
+   * Optional hook: tell the source that meeting <id> was successfully imported.
+   * Sources that maintain a watermark (e.g. GranolaCacheV6Source) advance it
+   * here. No-op for stateless sources (FileGranolaSource).
+   */
+  markImported?(meetingId: string): void
 }
 
 export class FileGranolaSource implements GranolaSource {
@@ -772,7 +819,20 @@ export async function runImport(deps: ImporterDeps): Promise<ImportReport> {
         deps.log.completed.push(meeting.id)
         // Save sync log immediately after each success — partial progress is
         // valuable, especially for long Haiku-bound runs.
-        if (!deps.opts.dryRun) saveSyncLog(deps.opts.syncLogPath, deps.log)
+        if (!deps.opts.dryRun) {
+          saveSyncLog(deps.opts.syncLogPath, deps.log)
+          // Advance the source's watermark (if any) so cron-mode skips on next run.
+          // Skipped under dry-run — nothing was actually written, so we shouldn't
+          // poison the watermark for the real run.
+          try {
+            deps.source.markImported?.(meeting.id)
+          } catch (e) {
+            console.warn(
+              `⚠️  source.markImported failed for ${meeting.id}: ` +
+              `${e instanceof Error ? e.message : e}`
+            )
+          }
+        }
         break
       case 'skipped':
         report.skipped.push({ id: meeting.id, title: meeting.title })
@@ -815,10 +875,21 @@ export async function runImport(deps: ImporterDeps): Promise<ImportReport> {
 async function main(): Promise<void> {
   const opts = parseArgs(process.argv.slice(2))
 
-  if (!opts.input) {
-    console.error('❌ --input <file> is required (path to a JSON array of meetings).')
-    console.error('   See --help for the expected file shape.')
+  if (opts.source === 'file' && !opts.input) {
+    console.error(`❌ --input <file> is required when --source=file (the default).`)
+    console.error(`   Use --source cache-v6 (or --cache-v6) for autonomous reads.`)
+    console.error(`   See --help for the expected file shape.`)
     process.exit(2)
+  }
+
+  let sinceDate: Date | undefined
+  if (opts.since) {
+    const d = new Date(opts.since)
+    if (isNaN(d.getTime())) {
+      console.error(`❌ --since must be a valid ISO date, got: ${opts.since}`)
+      process.exit(2)
+    }
+    sinceDate = d
   }
 
   const apiKey = process.env.ANTHROPIC_API_KEY
@@ -829,7 +900,14 @@ async function main(): Promise<void> {
   }
 
   console.log(`🚀 Granola → KMS importer starting`)
-  console.log(`   Input:        ${opts.input}`)
+  console.log(`   Source:       ${opts.source}`)
+  if (opts.source === 'file') {
+    console.log(`   Input:        ${opts.input}`)
+  } else {
+    console.log(`   Cache path:   ${opts.cachePath ?? DEFAULT_CACHE_V6_PATH}`)
+    console.log(`   Watermark:    ${opts.watermarkPath ?? DEFAULT_WATERMARK_PATH}`)
+    if (sinceDate) console.log(`   Since:        ${sinceDate.toISOString()}`)
+  }
   console.log(`   KMS URL:      ${opts.kmsUrl}`)
   console.log(`   Sync log:     ${opts.syncLogPath}`)
   console.log(`   User ID:      ${opts.userId}`)
@@ -837,7 +915,13 @@ async function main(): Promise<void> {
   console.log(`   Dry run:      ${opts.dryRun}`)
   if (opts.maxMeetings) console.log(`   Cap:          ${opts.maxMeetings} meetings`)
 
-  const source = new FileGranolaSource(opts.input)
+  const source: GranolaSource = opts.source === 'cache-v6'
+    ? new GranolaCacheV6Source({
+        cachePath: opts.cachePath,
+        watermarkPath: opts.watermarkPath,
+        since: sinceDate
+      })
+    : new FileGranolaSource(opts.input!)
   const distiller = opts.dryRun
     ? new NoopDistiller()
     : new HaikuDistiller(apiKey!, opts.anthropicModel)

--- a/src/__tests__/GranolaCacheV6Source.test.ts
+++ b/src/__tests__/GranolaCacheV6Source.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Tests for GranolaCacheV6Source — the autonomous source that reads
+ * transcripts directly from the Granola desktop app's on-disk cache.
+ *
+ * Coverage:
+ *   - Lists meetings from a fixture cache
+ *   - Filters by `since` (and merges with watermark)
+ *   - Watermark persists and skips on next run
+ *   - Skips deleted / non-meeting / malformed documents gracefully (no throw)
+ *   - Handles missing keys / missing file / unreadable JSON without crashing
+ *   - assembleTranscript groups same-source segments and skips non-final/empty
+ */
+
+import {
+  GranolaCacheV6Source,
+  loadWatermark,
+  saveWatermark,
+  assembleTranscript,
+  CacheV6Watermark
+} from '../scripts/granola-cache-v6-source.js'
+
+import { mkdtempSync, writeFileSync, rmSync, readFileSync, existsSync, copyFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join, resolve } from 'path'
+
+const FIXTURE_PATH = resolve(__dirname, 'fixtures', 'granola-cache-v6.fixture.json')
+
+describe('GranolaCacheV6Source — fixture cache', () => {
+  let tmpDir: string
+  let cachePath: string
+  let wmPath: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'granola-cache-v6-'))
+    cachePath = join(tmpDir, 'cache-v6.json')
+    wmPath = join(tmpDir, 'state.json')
+    copyFileSync(FIXTURE_PATH, cachePath)
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('lists every importable meeting from the fixture (3 of 7 documents)', async () => {
+    const src = new GranolaCacheV6Source({
+      cachePath,
+      watermarkPath: wmPath,
+      ignoreWatermark: true
+    })
+    const meetings = await src.list()
+
+    // Three importable: doc-old-001, doc-mid-002, doc-new-003.
+    // Skipped: deleted-004, no-transcript-005, scratchpad-006, malformed-007.
+    expect(meetings).toHaveLength(3)
+    const ids = meetings.map(m => m.id)
+    expect(ids).toEqual(['doc-old-001', 'doc-mid-002', 'doc-new-003'])
+  })
+
+  it('emits the canonical RawMeeting shape (id/title/date/transcript)', async () => {
+    const src = new GranolaCacheV6Source({
+      cachePath,
+      watermarkPath: wmPath,
+      ignoreWatermark: true
+    })
+    const [first] = await src.list()
+    expect(first.id).toBe('doc-old-001')
+    expect(first.title).toBe('Q1 retro — synthetic test data')
+    expect(first.date).toBe('2026-01-10T15:00:00.000Z')
+    expect(first.transcript).toContain('[Microphone]')
+    expect(first.transcript).toContain('[System]')
+    // Welcome…review on the same speaker should be joined into one line.
+    expect(first.transcript).toContain('Welcome everyone to the Q1 retro. Lets review what shipped.')
+  })
+
+  it('skips non-final and empty transcript segments', async () => {
+    const src = new GranolaCacheV6Source({
+      cachePath,
+      watermarkPath: wmPath,
+      ignoreWatermark: true
+    })
+    const [first] = await src.list()
+    // The fixture's doc-old-001 has a non-final segment and an empty-text
+    // segment — neither should appear in the assembled transcript.
+    expect(first.transcript).not.toContain('non-final')
+    // Empty segment had only whitespace; nothing to assert positively beyond
+    // "the assembled string didn't gain a stray empty line"
+    expect(first.transcript.split('\n').every(l => l.trim().length > 0)).toBe(true)
+  })
+
+  it('filters by `since` (drops meetings whose end-ts is earlier)', async () => {
+    const since = new Date('2026-04-01T00:00:00Z')
+    const src = new GranolaCacheV6Source({
+      cachePath,
+      watermarkPath: wmPath,
+      ignoreWatermark: true,
+      since
+    })
+    const meetings = await src.list()
+    // Only doc-new-003 has end-ts (2026-05-01T16:30Z) after the since floor.
+    // doc-old-001 ends 2026-01-10, doc-mid-002 ends 2026-03-15 → both dropped.
+    expect(meetings.map(m => m.id)).toEqual(['doc-new-003'])
+  })
+
+  it('merges since-filter with watermark (later one wins)', async () => {
+    // Watermark is mid-March — later than the explicit early-March since.
+    saveWatermark(wmPath, {
+      lastSeenEndTs: '2026-03-20T00:00:00.000Z',
+      lastImportedIds: []
+    })
+    const src = new GranolaCacheV6Source({
+      cachePath,
+      watermarkPath: wmPath,
+      since: new Date('2026-01-01T00:00:00Z')
+    })
+    const meetings = await src.list()
+    // Only doc-new-003 (2026-05-01) clears the watermark.
+    expect(meetings.map(m => m.id)).toEqual(['doc-new-003'])
+  })
+
+  it('explicit since wins when it is later than the watermark', async () => {
+    saveWatermark(wmPath, {
+      lastSeenEndTs: '2026-01-01T00:00:00.000Z',
+      lastImportedIds: []
+    })
+    const src = new GranolaCacheV6Source({
+      cachePath,
+      watermarkPath: wmPath,
+      since: new Date('2026-04-01T00:00:00Z')
+    })
+    const meetings = await src.list()
+    expect(meetings.map(m => m.id)).toEqual(['doc-new-003'])
+  })
+
+  it('markImported persists watermark — next run skips already-emitted meetings', async () => {
+    const first = new GranolaCacheV6Source({
+      cachePath,
+      watermarkPath: wmPath,
+      ignoreWatermark: true
+    })
+    const meetings1 = await first.list()
+    expect(meetings1).toHaveLength(3)
+
+    // Mark all as imported in oldest-first order
+    for (const m of meetings1) first.markImported(m.id)
+
+    // Watermark file should now reflect the latest end-ts
+    expect(existsSync(wmPath)).toBe(true)
+    const wm = JSON.parse(readFileSync(wmPath, 'utf-8'))
+    expect(wm.lastSeenEndTs).toBe('2026-05-01T16:30:00.000Z')
+    expect(wm.lastImportedIds).toEqual(['doc-old-001', 'doc-mid-002', 'doc-new-003'])
+
+    // Construct a fresh source — it should pick up the watermark and emit
+    // nothing new.
+    const second = new GranolaCacheV6Source({ cachePath, watermarkPath: wmPath })
+    const meetings2 = await second.list()
+    expect(meetings2).toHaveLength(0)
+  })
+
+  it('markImported only advances the watermark forward', async () => {
+    saveWatermark(wmPath, {
+      lastSeenEndTs: '2026-12-31T00:00:00.000Z',
+      lastImportedIds: []
+    })
+    const src = new GranolaCacheV6Source({
+      cachePath,
+      watermarkPath: wmPath,
+      // bypass watermark-as-floor for this test by ignoring it, then re-load.
+      ignoreWatermark: true
+    })
+    // Re-load watermark manually so markImported sees the future timestamp
+    // (we want to assert markImported won't roll it back).
+    ;(src as any).watermark = loadWatermark(wmPath)
+    const meetings = await src.list()
+    expect(meetings.length).toBeGreaterThan(0)
+    src.markImported(meetings[0].id)
+    const wm = JSON.parse(readFileSync(wmPath, 'utf-8'))
+    expect(wm.lastSeenEndTs).toBe('2026-12-31T00:00:00.000Z')
+  })
+})
+
+describe('GranolaCacheV6Source — defensive paths', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'granola-cache-v6-defensive-'))
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('throws a clear error when the cache file is missing', async () => {
+    const src = new GranolaCacheV6Source({
+      cachePath: join(tmpDir, 'nope.json'),
+      watermarkPath: join(tmpDir, 'state.json'),
+      ignoreWatermark: true
+    })
+    await expect(src.list()).rejects.toThrow(/not found/)
+  })
+
+  it('returns [] (no throw) when the cache JSON is mid-write / corrupted', async () => {
+    const cachePath = join(tmpDir, 'cache-v6.json')
+    writeFileSync(cachePath, '{ "cache": { "version": 6, "state": { "doc')  // truncated
+    const src = new GranolaCacheV6Source({
+      cachePath,
+      watermarkPath: join(tmpDir, 'state.json'),
+      ignoreWatermark: true
+    })
+    const out = await src.list()
+    expect(out).toEqual([])
+  })
+
+  it('returns [] when cache.state is missing (schema drift)', async () => {
+    const cachePath = join(tmpDir, 'cache-v6.json')
+    writeFileSync(cachePath, JSON.stringify({ cache: { version: 7 } }))
+    const src = new GranolaCacheV6Source({
+      cachePath,
+      watermarkPath: join(tmpDir, 'state.json'),
+      ignoreWatermark: true
+    })
+    const out = await src.list()
+    expect(out).toEqual([])
+  })
+
+  it('returns [] when transcripts key is absent', async () => {
+    const cachePath = join(tmpDir, 'cache-v6.json')
+    writeFileSync(cachePath, JSON.stringify({
+      cache: { version: 6, state: { documents: { 'a': { id: 'a', type: 'meeting', title: 'x' } } } }
+    }))
+    const src = new GranolaCacheV6Source({
+      cachePath,
+      watermarkPath: join(tmpDir, 'state.json'),
+      ignoreWatermark: true
+    })
+    const out = await src.list()
+    expect(out).toEqual([])
+  })
+})
+
+describe('watermark file IO', () => {
+  let tmpDir: string
+  let wmPath: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'granola-wm-'))
+    wmPath = join(tmpDir, 'state.json')
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('returns a default watermark when the file does not exist', () => {
+    const wm = loadWatermark(wmPath)
+    expect(wm).toEqual({ lastImportedIds: [] })
+  })
+
+  it('returns a default watermark on malformed JSON (no throw)', () => {
+    writeFileSync(wmPath, 'not json')
+    const wm = loadWatermark(wmPath)
+    expect(wm).toEqual({ lastImportedIds: [] })
+  })
+
+  it('round-trips lastSeenEndTs + lastImportedIds', () => {
+    const original: CacheV6Watermark = {
+      lastSeenEndTs: '2026-04-01T00:00:00.000Z',
+      lastImportedIds: ['a', 'b', 'c']
+    }
+    saveWatermark(wmPath, original)
+    const restored = loadWatermark(wmPath)
+    expect(restored).toEqual(original)
+  })
+
+  it('caps lastImportedIds tail at 200', () => {
+    const big: CacheV6Watermark = {
+      lastSeenEndTs: '2026-04-01T00:00:00.000Z',
+      lastImportedIds: Array.from({ length: 500 }, (_, i) => `id-${i}`)
+    }
+    saveWatermark(wmPath, big)
+    const restored = loadWatermark(wmPath)
+    expect(restored.lastImportedIds).toHaveLength(200)
+    // Keeps the tail (most-recent), not the head
+    expect(restored.lastImportedIds[0]).toBe('id-300')
+    expect(restored.lastImportedIds[199]).toBe('id-499')
+  })
+})
+
+describe('assembleTranscript', () => {
+  it('joins adjacent same-source segments into one line', () => {
+    const segs = [
+      { text: 'Hello,',    source: 'microphone', is_final: true },
+      { text: 'how are',   source: 'microphone', is_final: true },
+      { text: 'you?',      source: 'microphone', is_final: true },
+      { text: 'Im fine.',  source: 'system',     is_final: true },
+      { text: 'Thanks.',   source: 'system',     is_final: true }
+    ]
+    const out = assembleTranscript(segs)
+    expect(out).toBe('[Microphone] Hello, how are you?\n[System] Im fine. Thanks.')
+  })
+
+  it('skips non-final and empty/whitespace segments', () => {
+    const segs = [
+      { text: 'real',   source: 'microphone', is_final: true },
+      { text: 'partial', source: 'microphone', is_final: false },
+      { text: '   ',    source: 'microphone', is_final: true },
+      { text: 'more real', source: 'system',  is_final: true }
+    ]
+    const out = assembleTranscript(segs)
+    expect(out).toBe('[Microphone] real\n[System] more real')
+  })
+
+  it('returns empty string for empty/missing input', () => {
+    expect(assembleTranscript([])).toBe('')
+    expect(assembleTranscript(null as any)).toBe('')
+    expect(assembleTranscript(undefined as any)).toBe('')
+  })
+
+  it('labels unknown sources verbatim and "Unknown" for missing', () => {
+    const segs = [
+      { text: 'a', source: 'phone',      is_final: true },
+      { text: 'b', source: undefined,    is_final: true },
+      { text: 'c', source: '',           is_final: true }
+    ]
+    const out = assembleTranscript(segs)
+    // 'phone' kept; '' and undefined → 'Unknown'.
+    expect(out).toContain('[phone] a')
+    expect(out).toContain('[Unknown]')
+  })
+})

--- a/src/__tests__/fixtures/granola-cache-v6.fixture.json
+++ b/src/__tests__/fixtures/granola-cache-v6.fixture.json
@@ -1,0 +1,205 @@
+{
+  "cache": {
+    "version": 6,
+    "state": {
+      "documents": {
+        "doc-old-001": {
+          "id": "doc-old-001",
+          "title": "Q1 retro — synthetic test data",
+          "type": "meeting",
+          "created_at": "2026-01-10T15:00:00.000Z",
+          "updated_at": "2026-01-10T15:30:00.000Z",
+          "deleted_at": null,
+          "valid_meeting": true,
+          "transcribe": true,
+          "google_calendar_event": {
+            "summary": "Q1 retro",
+            "start": { "dateTime": "2026-01-10T15:00:00Z", "timeZone": "UTC" },
+            "end":   { "dateTime": "2026-01-10T15:30:00Z", "timeZone": "UTC" }
+          }
+        },
+        "doc-mid-002": {
+          "id": "doc-mid-002",
+          "title": "Mid-quarter sync — synthetic test data",
+          "type": "meeting",
+          "created_at": "2026-03-15T19:00:00.000Z",
+          "updated_at": "2026-03-15T19:25:00.000Z",
+          "deleted_at": null,
+          "valid_meeting": true,
+          "transcribe": true,
+          "google_calendar_event": {
+            "summary": "Mid-quarter sync",
+            "start": { "dateTime": "2026-03-15T19:00:00Z", "timeZone": "UTC" },
+            "end":   { "dateTime": "2026-03-15T19:25:00Z", "timeZone": "UTC" }
+          }
+        },
+        "doc-new-003": {
+          "id": "doc-new-003",
+          "title": "Project sync — synthetic test data",
+          "type": "meeting",
+          "created_at": "2026-05-01T16:00:00.000Z",
+          "updated_at": "2026-05-01T16:30:00.000Z",
+          "deleted_at": null,
+          "valid_meeting": true,
+          "transcribe": true,
+          "google_calendar_event": {
+            "summary": "Project sync",
+            "start": { "dateTime": "2026-05-01T16:00:00Z", "timeZone": "UTC" },
+            "end":   { "dateTime": "2026-05-01T16:30:00Z", "timeZone": "UTC" }
+          }
+        },
+        "doc-deleted-004": {
+          "id": "doc-deleted-004",
+          "title": "Deleted meeting — should be skipped",
+          "type": "meeting",
+          "created_at": "2026-04-01T15:00:00.000Z",
+          "updated_at": "2026-04-01T15:30:00.000Z",
+          "deleted_at": "2026-04-02T12:00:00.000Z",
+          "valid_meeting": true
+        },
+        "doc-no-transcript-005": {
+          "id": "doc-no-transcript-005",
+          "title": "Meeting without transcript — should be skipped",
+          "type": "meeting",
+          "created_at": "2026-04-15T15:00:00.000Z",
+          "updated_at": "2026-04-15T15:30:00.000Z",
+          "deleted_at": null
+        },
+        "doc-scratchpad-006": {
+          "id": "doc-scratchpad-006",
+          "title": "Scratchpad note — wrong type",
+          "type": "scratchpad",
+          "created_at": "2026-04-20T15:00:00.000Z",
+          "deleted_at": null
+        },
+        "doc-malformed-007": {
+          "id": "doc-malformed-007",
+          "type": "meeting",
+          "created_at": "not-a-date",
+          "deleted_at": null
+        }
+      },
+      "transcripts": {
+        "doc-old-001": [
+          {
+            "id": "seg-old-001",
+            "document_id": "doc-old-001",
+            "start_timestamp": "2026-01-10T15:00:01.000Z",
+            "end_timestamp":   "2026-01-10T15:00:05.000Z",
+            "text": "Welcome everyone to the Q1 retro.",
+            "source": "microphone",
+            "is_final": true
+          },
+          {
+            "id": "seg-old-002",
+            "document_id": "doc-old-001",
+            "start_timestamp": "2026-01-10T15:00:06.000Z",
+            "end_timestamp":   "2026-01-10T15:00:09.000Z",
+            "text": "Lets review what shipped.",
+            "source": "microphone",
+            "is_final": true
+          },
+          {
+            "id": "seg-old-003",
+            "document_id": "doc-old-001",
+            "start_timestamp": "2026-01-10T15:00:10.000Z",
+            "end_timestamp":   "2026-01-10T15:00:15.000Z",
+            "text": "We launched the new dashboard last week.",
+            "source": "system",
+            "is_final": true
+          },
+          {
+            "id": "seg-old-004",
+            "document_id": "doc-old-001",
+            "start_timestamp": "2026-01-10T15:00:16.000Z",
+            "end_timestamp":   "2026-01-10T15:00:18.000Z",
+            "text": "User feedback has been positive.",
+            "source": "system",
+            "is_final": true
+          },
+          {
+            "id": "seg-old-005-partial",
+            "document_id": "doc-old-001",
+            "start_timestamp": "2026-01-10T15:00:19.000Z",
+            "end_timestamp":   "2026-01-10T15:00:20.000Z",
+            "text": "this should be skipped non-final",
+            "source": "system",
+            "is_final": false
+          },
+          {
+            "id": "seg-old-006-empty",
+            "document_id": "doc-old-001",
+            "start_timestamp": "2026-01-10T15:00:21.000Z",
+            "end_timestamp":   "2026-01-10T15:00:22.000Z",
+            "text": "   ",
+            "source": "microphone",
+            "is_final": true
+          }
+        ],
+        "doc-mid-002": [
+          {
+            "id": "seg-mid-001",
+            "document_id": "doc-mid-002",
+            "start_timestamp": "2026-03-15T19:00:01.000Z",
+            "end_timestamp":   "2026-03-15T19:00:03.000Z",
+            "text": "Mid-quarter check-in.",
+            "source": "microphone",
+            "is_final": true
+          },
+          {
+            "id": "seg-mid-002",
+            "document_id": "doc-mid-002",
+            "start_timestamp": "2026-03-15T19:00:04.000Z",
+            "end_timestamp":   "2026-03-15T19:00:08.000Z",
+            "text": "All projects on track for the next milestone.",
+            "source": "system",
+            "is_final": true
+          }
+        ],
+        "doc-new-003": [
+          {
+            "id": "seg-new-001",
+            "document_id": "doc-new-003",
+            "start_timestamp": "2026-05-01T16:00:01.000Z",
+            "end_timestamp":   "2026-05-01T16:00:04.000Z",
+            "text": "Quick project sync.",
+            "source": "microphone",
+            "is_final": true
+          },
+          {
+            "id": "seg-new-002",
+            "document_id": "doc-new-003",
+            "start_timestamp": "2026-05-01T16:00:05.000Z",
+            "end_timestamp":   "2026-05-01T16:00:09.000Z",
+            "text": "Decisions captured in the shared doc.",
+            "source": "system",
+            "is_final": true
+          }
+        ],
+        "doc-deleted-004": [
+          {
+            "id": "seg-deleted-001",
+            "document_id": "doc-deleted-004",
+            "start_timestamp": "2026-04-01T15:00:01.000Z",
+            "end_timestamp":   "2026-04-01T15:00:03.000Z",
+            "text": "This transcript should never surface.",
+            "source": "microphone",
+            "is_final": true
+          }
+        ],
+        "doc-malformed-007": [
+          {
+            "id": "seg-mal-001",
+            "document_id": "doc-malformed-007",
+            "start_timestamp": "2026-04-25T15:00:01.000Z",
+            "end_timestamp":   "2026-04-25T15:00:03.000Z",
+            "text": "transcript exists but document is malformed",
+            "source": "microphone",
+            "is_final": true
+          }
+        ]
+      },
+      "meetingsMetadata": {}
+    }
+  }
+}

--- a/src/scripts/granola-cache-v6-source.ts
+++ b/src/scripts/granola-cache-v6-source.ts
@@ -1,0 +1,479 @@
+/**
+ * GranolaCacheV6Source — autonomous source for the Granola → KMS importer.
+ *
+ * Reads transcripts directly from the Granola desktop app's on-disk cache,
+ * bypassing the claude.ai-bound MCP path. This unblocks cron / launchd
+ * driven autonomous ingestion (the MCP source requires a live Claude session
+ * with the Granola connector, which can't be triggered by a scheduler).
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * Cache schema (cache-v6.json) — observed 2026-05-07
+ * ─────────────────────────────────────────────────────────────────────────
+ *
+ * Path:  ~/Library/Application Support/Granola/cache-v6.json    (~1.7 MB)
+ * Owner: the Granola.app desktop process. The app holds it open and writes
+ *        live updates as meetings are recorded. **READ-ONLY from our side.**
+ *
+ * Top-level shape:
+ *   {
+ *     "cache": {
+ *       "version": 6,
+ *       "state": {
+ *         "documents":        { <docId>: <Document>, ... },     // 88 entries observed
+ *         "transcripts":      { <docId>: <Segment>[], ... },    //  5 entries observed
+ *         "meetingsMetadata": { <docId>: <Metadata>, ... },     //  9 entries observed
+ *         ...many other Zustand-store fields we don't care about
+ *       }
+ *     }
+ *   }
+ *
+ * Document (the keys we use; many other fields exist for app state):
+ *   {
+ *     "id":         "uuid",
+ *     "title":      "Project Caribou core team",
+ *     "type":       "meeting"  | "scratchpad" | ...,
+ *     "created_at": "2026-05-04T16:00:56.892Z",  // ISO
+ *     "updated_at": "2026-05-04T16:35:21.047Z",
+ *     "deleted_at": null | "2026-..." (soft-delete, skip these),
+ *     "valid_meeting": null | true | false,
+ *     "transcribe":     true | false | null,
+ *     "people":         { creator, attendees, conferencing, url } | null,
+ *     "google_calendar_event": { summary, start: { dateTime, timeZone }, end: {...}, ... } | null,
+ *     "notes_plain":    "" | "..." (rarely populated; usually empty),
+ *     "notes_markdown": "" | "...",
+ *     "notes":          { type:"doc", content: ProsemirrorNode[] } (Tiptap doc — usually empty)
+ *     ...
+ *   }
+ *
+ * Transcripts (where the actual spoken content lives):
+ *   <docId> -> [
+ *     {
+ *       "id":               "segment-uuid",
+ *       "document_id":      <docId>,           // back-pointer
+ *       "start_timestamp":  "2026-05-04T16:02:00.964Z",
+ *       "end_timestamp":    "2026-05-04T16:02:01.044Z",
+ *       "text":             "Speaker turn text...",
+ *       "source":           "system" | "microphone",
+ *       "is_final":         true,
+ *       "transcriber_user_id": null
+ *     },
+ *     ...  // many segments per meeting (~1000 for an hour-long call)
+ *   ]
+ *
+ * meetingsMetadata (calendar-derived attendee/creator info):
+ *   <docId> -> {
+ *     "creator":      { name, email, details: { person: { name, employment, ... } } },
+ *     "attendees":    [ { email, details: { person: { name: { fullName }, ... }, company } } ],
+ *     "conferencing": { type, url, title },
+ *     "url":          "https://calendar.google.com/..."
+ *   }
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * Important: only ~5/88 documents have transcripts in the local cache
+ * ─────────────────────────────────────────────────────────────────────────
+ *
+ * The Granola app keeps full transcripts only for meetings recorded ON THIS
+ * MACHINE in the recent window. Older meetings sync metadata (title, calendar
+ * event, attendees) but the transcript array gets evicted. We MUST require
+ * a non-empty transcript before emitting a meeting — meetings without a
+ * usable transcript are not ingestable.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * Watermark
+ * ─────────────────────────────────────────────────────────────────────────
+ *
+ * To support incremental cron runs, we persist the highest meeting end-
+ * timestamp we've seen at `~/.kms-granola-state.json`:
+ *
+ *   { "lastSeenEndTs": "2026-05-04T17:00:00.000Z", "lastImportedIds": [...] }
+ *
+ * On construction, the source reads the file and uses `lastSeenEndTs` as a
+ * floor for `since` (caller's `since` still wins if it's later). After
+ * `markImported(meetingId, endTs)`, we update the watermark on disk so the
+ * next run skips already-emitted meetings.
+ *
+ * The watermark is ADVISORY — the importer's own sync log
+ * (`~/.kms-granola-sync.json`) is the source of truth for whether a meeting
+ * was actually written to KMS. The watermark is here so we can early-skip
+ * cheap (no need to read 1000-segment transcripts for old meetings) without
+ * touching the importer's downstream logic.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'fs'
+import { homedir } from 'os'
+import { join } from 'path'
+
+// ─────────────────────────────────────────────────────────────────────────
+// Shape of a meeting as the importer expects it (matches RawMeeting +
+// GranolaSource interface in scripts/import-granola.ts).
+//
+// Defined here as a local interface — not imported from the script — so the
+// source can compile under tsc's `rootDir: ./src` without reaching out to
+// the scripts/ folder. The scripts/import-granola.ts file structurally
+// matches this shape; type compatibility is duck-typed via the `list()`
+// signature.
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface CacheV6Meeting {
+  id: string
+  title: string
+  date?: string         // ISO start-time of the meeting if known
+  transcript: string    // assembled "[Speaker]: text\n[Speaker]: text\n..."
+}
+
+/** Narrow structural alias of GranolaSource — kept local to avoid a cross-rootDir import. */
+interface GranolaSourceShape {
+  list(): Promise<CacheV6Meeting[]>
+  markImported?(meetingId: string): void
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Watermark file
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface CacheV6Watermark {
+  lastSeenEndTs?: string             // ISO; floor for incremental runs
+  lastImportedIds: string[]          // tail of recently-imported doc ids (advisory)
+}
+
+export const DEFAULT_CACHE_V6_PATH = join(
+  homedir(),
+  'Library',
+  'Application Support',
+  'Granola',
+  'cache-v6.json'
+)
+
+export const DEFAULT_WATERMARK_PATH = join(homedir(), '.kms-granola-state.json')
+
+export function loadWatermark(path: string): CacheV6Watermark {
+  if (!existsSync(path)) return { lastImportedIds: [] }
+  try {
+    const raw = readFileSync(path, 'utf-8')
+    const parsed = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object') {
+      return { lastImportedIds: [] }
+    }
+    const out: CacheV6Watermark = { lastImportedIds: [] }
+    if (typeof parsed.lastSeenEndTs === 'string') out.lastSeenEndTs = parsed.lastSeenEndTs
+    if (Array.isArray(parsed.lastImportedIds)) {
+      out.lastImportedIds = parsed.lastImportedIds.filter((x: unknown) => typeof x === 'string') as string[]
+    }
+    return out
+  } catch {
+    // Malformed watermark = start fresh; the worst case is we re-emit
+    // already-imported meetings, which the importer's sync log dedups.
+    return { lastImportedIds: [] }
+  }
+}
+
+export function saveWatermark(path: string, wm: CacheV6Watermark): void {
+  // Cap the imported-ids tail at 200 to keep the file small.
+  const trimmed: CacheV6Watermark = {
+    lastSeenEndTs: wm.lastSeenEndTs,
+    lastImportedIds: wm.lastImportedIds.slice(-200)
+  }
+  writeFileSync(path, JSON.stringify(trimmed, null, 2), 'utf-8')
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Source
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface GranolaCacheV6SourceOptions {
+  cachePath?: string         // default: DEFAULT_CACHE_V6_PATH
+  watermarkPath?: string     // default: DEFAULT_WATERMARK_PATH
+  since?: Date               // explicit since-filter; merged with watermark (later one wins)
+  ignoreWatermark?: boolean  // for backfills: don't read watermark on construct
+}
+
+export class GranolaCacheV6Source implements GranolaSourceShape {
+  private cachePath: string
+  private watermarkPath: string
+  private since: Date | undefined
+  private watermark: CacheV6Watermark
+  /** Filled in by list(); used by markImported to update the watermark. */
+  private lastEndByMeetingId = new Map<string, string>()
+
+  constructor(opts: GranolaCacheV6SourceOptions = {}) {
+    this.cachePath = opts.cachePath ?? DEFAULT_CACHE_V6_PATH
+    this.watermarkPath = opts.watermarkPath ?? DEFAULT_WATERMARK_PATH
+    this.watermark = opts.ignoreWatermark
+      ? { lastImportedIds: [] }
+      : loadWatermark(this.watermarkPath)
+
+    // Merge: caller's `since` takes precedence ONLY if it's later than the
+    // watermark. Otherwise the watermark is the floor (cron resumability).
+    const wmSince = this.watermark.lastSeenEndTs
+      ? new Date(this.watermark.lastSeenEndTs)
+      : undefined
+    if (opts.since && (!wmSince || opts.since > wmSince)) {
+      this.since = opts.since
+    } else if (wmSince) {
+      this.since = wmSince
+    } else {
+      this.since = opts.since
+    }
+  }
+
+  /**
+   * Read the cache, filter to importable meetings, and assemble a transcript
+   * string for each. Malformed entries are SKIPPED with a warning, never
+   * thrown — Granola is the writer and we don't want a partial write to
+   * crash the cron job.
+   */
+  async list(): Promise<CacheV6Meeting[]> {
+    if (!existsSync(this.cachePath)) {
+      throw new Error(`Granola cache file not found: ${this.cachePath}`)
+    }
+
+    let raw: string
+    try {
+      raw = readFileSync(this.cachePath, 'utf-8')
+    } catch (e) {
+      throw new Error(
+        `Granola cache file unreadable: ${e instanceof Error ? e.message : e}`
+      )
+    }
+
+    let parsed: any
+    try {
+      parsed = JSON.parse(raw)
+    } catch (e) {
+      // Granola may be mid-write. Don't crash — return empty, retry next run.
+      console.warn(
+        `⚠️  Granola cache JSON parse failed (likely mid-write): ` +
+        `${e instanceof Error ? e.message : e}`
+      )
+      return []
+    }
+
+    const state = parsed?.cache?.state
+    if (!state || typeof state !== 'object') {
+      console.warn(
+        `⚠️  Granola cache missing cache.state — schema may have changed. Skipping.`
+      )
+      return []
+    }
+
+    const documents = state.documents
+    const transcripts = state.transcripts
+    if (!documents || typeof documents !== 'object') {
+      console.warn(`⚠️  Granola cache missing cache.state.documents.`)
+      return []
+    }
+    if (!transcripts || typeof transcripts !== 'object') {
+      console.warn(`⚠️  Granola cache missing cache.state.transcripts.`)
+      return []
+    }
+
+    const out: CacheV6Meeting[] = []
+    for (const [docId, doc] of Object.entries(documents) as Array<[string, any]>) {
+      try {
+        const meeting = this.toMeeting(docId, doc, transcripts[docId])
+        if (meeting) {
+          out.push(meeting)
+        }
+      } catch (e) {
+        // Per-document defensiveness — one malformed doc shouldn't poison
+        // the whole batch.
+        console.warn(
+          `⚠️  Skipping malformed cache document ${docId}: ` +
+          `${e instanceof Error ? e.message : e}`
+        )
+      }
+    }
+
+    // Sort oldest-first so that watermark advance is monotonic across
+    // partially-completed runs.
+    out.sort((a, b) => (a.date ?? '').localeCompare(b.date ?? ''))
+    return out
+  }
+
+  /**
+   * Decide whether a document is importable, and assemble its transcript.
+   * Returns null when the document should be silently filtered out
+   * (deleted, no transcript, before `since`, etc.).
+   */
+  private toMeeting(
+    docId: string,
+    doc: any,
+    transcriptSegments: any
+  ): CacheV6Meeting | null {
+    if (!doc || typeof doc !== 'object') return null
+    // Soft-deleted documents are not importable.
+    if (doc.deleted_at) return null
+    // Only the "meeting" document type carries transcripts.
+    if (doc.type && doc.type !== 'meeting') return null
+
+    const id = typeof doc.id === 'string' && doc.id.length > 0 ? doc.id : docId
+    const title = typeof doc.title === 'string' && doc.title.length > 0
+      ? doc.title
+      : '(untitled meeting)'
+
+    const startIso = this.extractStartIso(doc)
+    const endIso = this.extractEndIso(doc, transcriptSegments)
+
+    // We require the document itself to carry a valid start-time. Without
+    // it we can't sort, can't watermark, and can't filter by `since` — the
+    // doc is structurally malformed.
+    if (!startIso) {
+      console.warn(
+        `⚠️  Skipping document ${id} (${title}): no valid created_at or ` +
+        `google_calendar_event.start.dateTime.`
+      )
+      return null
+    }
+
+    // since-filter: drop meetings whose end-ts is at or before the floor.
+    // We use <= rather than < so that the watermark (set to a meeting's
+    // own end-ts after marking it imported) excludes that meeting on the
+    // next run — otherwise we'd re-emit the most recently imported one.
+    if (this.since && endIso) {
+      if (new Date(endIso).getTime() <= this.since.getTime()) {
+        return null
+      }
+    }
+
+    // Must have a non-empty transcript array. Meetings whose transcripts
+    // have been evicted from cache are not importable from this source.
+    if (!Array.isArray(transcriptSegments) || transcriptSegments.length === 0) {
+      return null
+    }
+
+    const transcript = assembleTranscript(transcriptSegments)
+    if (transcript.length === 0) return null
+
+    if (endIso) this.lastEndByMeetingId.set(id, endIso)
+
+    return {
+      id,
+      title,
+      date: startIso,
+      transcript
+    }
+  }
+
+  private extractStartIso(doc: any): string | undefined {
+    // Preferred: calendar event start (real meeting start time).
+    const calStart = doc?.google_calendar_event?.start?.dateTime
+    if (typeof calStart === 'string' && calStart.length > 0) {
+      const d = new Date(calStart)
+      if (!isNaN(d.getTime())) return d.toISOString()
+    }
+    // Fallback: document creation timestamp.
+    if (typeof doc.created_at === 'string') {
+      const d = new Date(doc.created_at)
+      if (!isNaN(d.getTime())) return d.toISOString()
+    }
+    return undefined
+  }
+
+  private extractEndIso(doc: any, segments: any): string | undefined {
+    const calEnd = doc?.google_calendar_event?.end?.dateTime
+    if (typeof calEnd === 'string' && calEnd.length > 0) {
+      const d = new Date(calEnd)
+      if (!isNaN(d.getTime())) return d.toISOString()
+    }
+    // Fallback: last transcript segment end_timestamp (only if present).
+    if (Array.isArray(segments) && segments.length > 0) {
+      for (let i = segments.length - 1; i >= 0; i--) {
+        const ts = segments[i]?.end_timestamp
+        if (typeof ts === 'string') {
+          const d = new Date(ts)
+          if (!isNaN(d.getTime())) return d.toISOString()
+        }
+      }
+    }
+    if (typeof doc.updated_at === 'string') {
+      const d = new Date(doc.updated_at)
+      if (!isNaN(d.getTime())) return d.toISOString()
+    }
+    return undefined
+  }
+
+  /**
+   * Persist that we've imported `meetingId`. Advances the watermark to the
+   * meeting's end-timestamp so the NEXT call to `new GranolaCacheV6Source()`
+   * skips it cheaply.
+   *
+   * Idempotent. Best-effort: a failure here is logged but does not throw.
+   */
+  markImported(meetingId: string): void {
+    const endIso = this.lastEndByMeetingId.get(meetingId)
+    // Append to the imported-ids tail (deduped).
+    if (!this.watermark.lastImportedIds.includes(meetingId)) {
+      this.watermark.lastImportedIds.push(meetingId)
+    }
+    // Advance the watermark only forward.
+    if (endIso) {
+      const cur = this.watermark.lastSeenEndTs ? new Date(this.watermark.lastSeenEndTs) : null
+      const next = new Date(endIso)
+      if (!cur || next > cur) {
+        this.watermark.lastSeenEndTs = next.toISOString()
+      }
+    }
+    try {
+      saveWatermark(this.watermarkPath, this.watermark)
+    } catch (e) {
+      console.warn(
+        `⚠️  Failed to persist Granola watermark to ${this.watermarkPath}: ` +
+        `${e instanceof Error ? e.message : e}`
+      )
+    }
+  }
+
+  /** Test/inspection helper — current in-memory watermark state. */
+  getWatermark(): CacheV6Watermark {
+    return { ...this.watermark, lastImportedIds: [...this.watermark.lastImportedIds] }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Transcript assembly
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Assemble a Granola transcript array into a single string the distiller
+ * can chew on. Format:
+ *   [Microphone] line one
+ *   [System] line two
+ *   ...
+ *
+ * `source` in the cache is "microphone" (the local user's voice) or
+ * "system" (other participants via the system audio loopback). We label
+ * each segment so the distiller can attribute claims correctly.
+ *
+ * Adjacent same-source segments get joined into one line to avoid the
+ * one-segment-per-word fragmentation Granola sometimes produces.
+ */
+export function assembleTranscript(segments: any[]): string {
+  if (!Array.isArray(segments) || segments.length === 0) return ''
+
+  const lines: Array<{ source: string; text: string }> = []
+  for (const seg of segments) {
+    if (!seg || typeof seg !== 'object') continue
+    const text = typeof seg.text === 'string' ? seg.text.trim() : ''
+    if (text.length === 0) continue
+    // Granola flips between "is_final": true and partial in-progress segments.
+    // Skip non-final segments — they're superseded by a later final one.
+    if (seg.is_final === false) continue
+
+    const source = labelSource(seg.source)
+    const last = lines[lines.length - 1]
+    if (last && last.source === source) {
+      last.text += ' ' + text
+    } else {
+      lines.push({ source, text })
+    }
+  }
+
+  return lines.map(l => `[${l.source}] ${l.text}`).join('\n')
+}
+
+function labelSource(source: unknown): string {
+  if (source === 'microphone') return 'Microphone'
+  if (source === 'system') return 'System'
+  if (typeof source === 'string' && source.length > 0) return source
+  return 'Unknown'
+}


### PR DESCRIPTION
## Summary

Adds `GranolaCacheV6Source` — a new `GranolaSource` implementation that reads transcripts directly from the Granola desktop app's on-disk cache at `~/Library/Application Support/Granola/cache-v6.json`, bypassing the claude.ai-session-bound MCP. This unblocks autonomous (cron / launchd-triggered) Granola → KMS ingestion. The existing `FileGranolaSource` (PR #74) is unchanged and remains the default.

## What

- **`src/scripts/granola-cache-v6-source.ts`** — parses the Granola cache, assembles transcripts (with `[Microphone]`/`[System]` speaker labels), and emits the same `RawMeeting` shape `import-granola.ts` already consumes. Watermark file at `~/.kms-granola-state.json` tracks `lastSeenEndTs` + `lastImportedIds` (200-tail cap) so successive cron runs only emit new meetings. Defensive against missing keys, mid-write JSON, and per-document malformations (log + skip, never crash).
- **`scripts/import-granola.ts`** — new flags: `--source=file|cache-v6`, `--cache-v6` shorthand, `--cache-path`, `--watermark-path`, `--since`. `GranolaSource` interface gains an optional `markImported(meetingId)` hook (called from the `ok` branch of `runImport`, never under `--dry-run`).
- **Tests** — 20 new tests in `src/__tests__/GranolaCacheV6Source.test.ts` against a synthetic, PII-free fixture cache. Covers happy path, `since` filter, watermark merge / monotonic advance, defensive paths, transcript assembly.
- **`.gitignore`** — allowlist `src/__tests__/fixtures/*.json` so the fixture cache is tracked.

## Schema findings (cache-v6.json, observed 2026-05-07, 1.7 MB)

```
{
  "cache": {
    "version": 6,
    "state": {
      "documents":        { <docId>: <Document>, ... },     // 88 entries (79 valid meetings)
      "transcripts":      { <docId>: <Segment>[], ... },    //  5 entries
      "meetingsMetadata": { <docId>: <Metadata>, ... }      //  9 entries
      // ...other Zustand store fields
    }
  }
}
```

- `Document` keys we use: `id`, `title`, `type` (`"meeting"` only), `created_at`, `updated_at`, `deleted_at`, `transcribe`, `google_calendar_event.start.dateTime`/`.end.dateTime`.
- `Segment`: `text`, `source` (`"microphone"` = local user; `"system"` = other participants via system audio loopback), `is_final`, `start_timestamp`, `end_timestamp`.
- **Date precedence**: `google_calendar_event.start.dateTime` > `created_at`. Skip docs where neither parses.
- **Transcript availability**: only ~5/88 cached docs have transcripts. Granola evicts old transcripts but keeps metadata. The source requires a non-empty transcript before emitting — meetings without one are silently filtered.
- See the long-form schema doc in the source file header for the full shape.

## Watermark pattern

`~/.kms-granola-state.json`:

```json
{
  "lastSeenEndTs": "2026-05-06T18:30:00.000Z",
  "lastImportedIds": ["<doc-uuid>", "..."]
}
```

- Constructor reads it; effective `since` = `max(opts.since, watermark.lastSeenEndTs)`.
- After each successful import, `markImported(meetingId)` advances `lastSeenEndTs` to the meeting's end-ts (only forward) and appends the id (deduped, tail-capped at 200).
- The since-filter uses `<=` so a meeting whose end-ts equals the watermark is dropped on the next run (otherwise we'd re-emit the most recent one each time).
- `--dry-run` never writes the watermark — it's a no-op verification path.

## Live dry-run (read-only against the running Granola.app)

```
$ npx tsx scripts/import-granola.ts --source=cache-v6 --dry-run

📥 Loaded 5 meeting(s) from source (time-range advisory: last_30_days)
📝 [dry-run] would write summary + 1 claims for "Project Caribou core team"
📝 [dry-run] would write summary + 1 claims for "Rich Y."
📝 [dry-run] would write summary + 1 claims for "Tango product strategy and AI workflow optimization with core values alignment"
📝 [dry-run] would write summary + 1 claims for "Project Caribou core team"
📝 [dry-run] would write summary + 1 claims for "Richard Yaker and Jack Teitel"

══════════════ FINAL REPORT ══════════════
Total meetings:       5
Summary entries:      5
Claim entries:        5
Skipped (sync log):   0
Dedup refused:        0
Failed:               0
```

- Oldest: `Project Caribou core team` — 2026-05-04T16:00Z, 86k char transcript
- Newest: `Richard Yaker and Jack Teitel` — 2026-05-06T18:00Z, 24k char transcript
- All 5 sorted oldest-first (so watermark advance is monotonic across partial runs)

## Constraints honored

- **Read-only** on the live cache. We open + parse, never write or move it.
- **No PII in fixtures.** All names/content in `granola-cache-v6.fixture.json` are synthesized.
- **`@anthropic-ai/sdk` not bumped.**
- **`FileGranolaSource` untouched** — still the default and still works for backfills.

## Test plan

- [x] `npx jest src/__tests__/GranolaCacheV6Source.test.ts` — 20/20 pass
- [x] `npx jest src/__tests__/import-granola.test.ts` — 40/40 pass (no regressions)
- [x] `npx jest` (full suite) — 319/319 pass, 14/14 suites
- [x] `npx tsc --noEmit` — clean
- [x] Live read-only dry-run against `~/Library/Application Support/Granola/cache-v6.json` — 5 meetings detected and listed correctly
- [ ] Real (non-dry-run) cron-mode integration smoke test — out of scope for this PR; validate on first launchd run

🤖 Generated with [Claude Code](https://claude.com/claude-code)