### PR TITLE
feat(cron): launchd plists for Granola + Slack huddle importers

### DIFF
--- a/scripts/cron/README.md
+++ b/scripts/cron/README.md
@@ -1,0 +1,109 @@
+# KMS Cron Importers (launchd)
+
+This directory contains the launchd plists and runner script that drive the
+Granola and Slack-huddle KMS importers on a 15-minute schedule.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `run-importer.sh` | Single wrapper invoked by both plists. Resolves Homebrew node, sources `.env`, optionally wraps with `doppler run`, captures all output to `~/Library/Logs/kms-cron/<importer>.log`, and guards concurrent runs with a PID-file lock. |
+| `com.ryaker.kms-granola-importer.plist` | launchd job — fires `run-importer.sh granola` every 900 s. Reads from `~/Library/Application Support/Granola/cache-v6.json`; watermark at `~/.kms-granola-state.json`. |
+| `com.ryaker.kms-slack-huddle-importer.plist` | launchd job — fires `run-importer.sh slack-huddles` every 900 s. Sync log at `~/.kms-slack-huddle-sync.json`. |
+
+## Install
+
+```bash
+# Copy plists into ~/Library/LaunchAgents
+cp scripts/cron/com.ryaker.kms-granola-importer.plist        ~/Library/LaunchAgents/
+cp scripts/cron/com.ryaker.kms-slack-huddle-importer.plist   ~/Library/LaunchAgents/
+
+# Load each job (the -w flag writes the enable bit so it survives reboot)
+launchctl load -w ~/Library/LaunchAgents/com.ryaker.kms-granola-importer.plist
+launchctl load -w ~/Library/LaunchAgents/com.ryaker.kms-slack-huddle-importer.plist
+```
+
+## Verify
+
+```bash
+# Should list both jobs
+launchctl list | grep com.ryaker.kms-
+
+# Tail the rolling logs
+tail -f ~/Library/Logs/kms-cron/granola.log
+tail -f ~/Library/Logs/kms-cron/slack-huddles.log
+
+# Trigger a one-off run (bypasses the 15-min schedule)
+launchctl start com.ryaker.kms-granola-importer
+launchctl start com.ryaker.kms-slack-huddle-importer
+```
+
+## Uninstall
+
+```bash
+launchctl unload -w ~/Library/LaunchAgents/com.ryaker.kms-granola-importer.plist
+launchctl unload -w ~/Library/LaunchAgents/com.ryaker.kms-slack-huddle-importer.plist
+rm ~/Library/LaunchAgents/com.ryaker.kms-granola-importer.plist
+rm ~/Library/LaunchAgents/com.ryaker.kms-slack-huddle-importer.plist
+```
+
+## What runs every 15 min
+
+```
+# granola
+cd /Users/ryaker/Dev/KMSmcp \
+  && doppler run --project ry-local --config dev_personal -- \
+       npx --yes tsx scripts/import-granola.ts --source=cache-v6
+
+# slack-huddles
+cd /Users/ryaker/Dev/KMSmcp \
+  && doppler run --project ry-local --config dev_personal -- \
+       npx --yes tsx src/scripts/import-slack-huddles-cli.ts
+```
+
+The `doppler run` prefix is added automatically when (a) `doppler` is on PATH,
+(b) `KMS_BEARER_TOKEN` is unset, and (c) `KMS_DOPPLER_PROJECT` /
+`KMS_DOPPLER_CONFIG` env vars are set (the plists supply the latter).
+
+## Idempotency
+
+Both importers are safe to run repeatedly:
+
+| Importer | Resumability state |
+| --- | --- |
+| Granola (`--source=cache-v6`) | Watermark file `~/.kms-granola-state.json` tracks the last processed `endTs`; older meetings are skipped. |
+| Slack huddles | Sync log `~/.kms-slack-huddle-sync.json` lists processed huddle IDs; existing IDs are skipped. |
+
+In addition, every successful KMS write goes through the dedup gate
+(`unified_store`), so even if a state file is wiped the gate refuses
+near-duplicates rather than re-storing them.
+
+The wrapper itself takes a PID-file lock at
+`~/Library/Caches/kms-cron/<importer>.pid`. If a previous tick is still
+in flight when the next one fires, the new invocation logs
+`another run still in flight` and exits with code `75` (`EX_TEMPFAIL`).
+launchd treats this as a normal exit and tries again on the next interval.
+
+## Logs
+
+| Path | Contents |
+| --- | --- |
+| `~/Library/Logs/kms-cron/granola.log` | Per-tick wrapper banner + full importer stdout/stderr. Rotates to `.log.1` past 10 MB. |
+| `~/Library/Logs/kms-cron/slack-huddles.log` | Same for the slack-huddle importer. |
+| `~/Library/Logs/kms-cron/<name>.launchd.log` | Tiny wrapper-level launchd capture (process spawn / exit / `set -u` violations). Usually empty. |
+
+## Required environment
+
+The runner expects either:
+
+1. `KMS_BEARER_TOKEN` set in the environment (one-off / debug runs), or
+2. Doppler on `PATH` with the `KMS_DOPPLER_PROJECT` + `KMS_DOPPLER_CONFIG` plist
+   keys pointing at a config that supplies:
+   - `OAUTH_CLIENT_ID`, `OAUTH_CLIENT_SECRET`, `OAUTH_TOKEN_ENDPOINT`,
+     `OAUTH_AUDIENCE` — Auth0 client_credentials for KMS at
+     `http://localhost:8180/mcp`.
+   - `ANTHROPIC_API_KEY` — Haiku 4.5 distillation step.
+   - For slack-huddles only: any creds the live Slack source needs (it falls
+     back to `--source file` and a JSON dump when no Slack tools are wired).
+
+A repo-local `.env` will also be sourced if present.

--- a/scripts/cron/com.ryaker.kms-granola-importer.plist
+++ b/scripts/cron/com.ryaker.kms-granola-importer.plist
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.ryaker.kms-granola-importer</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/ryaker/Dev/KMSmcp/scripts/cron/run-importer.sh</string>
+        <string>granola</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/ryaker/Dev/KMSmcp</string>
+
+    <!-- Fire every 15 min while loaded. Don't fire at boot — wait for the
+         user session and the first scheduled tick (mirrors the existing
+         com.ryaker.neo4j-keepalive pattern). -->
+    <key>StartInterval</key>
+    <integer>900</integer>
+
+    <key>RunAtLoad</key>
+    <false/>
+
+    <!-- Avoid runaway concurrent invocations; the runner has its own PID-file
+         guard, but ThrottleInterval gives launchd a backstop. -->
+    <key>ThrottleInterval</key>
+    <integer>60</integer>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/Users/ryaker</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <!-- Tell the runner to wrap with `doppler run` for OAuth / Anthropic
+             secrets. The runner skips Doppler if KMS_BEARER_TOKEN is already set. -->
+        <key>KMS_DOPPLER_PROJECT</key>
+        <string>ry-local</string>
+        <key>KMS_DOPPLER_CONFIG</key>
+        <string>dev_personal</string>
+    </dict>
+
+    <!-- Runner already routes its own per-importer log under
+         ~/Library/Logs/kms-cron/granola.log. These two paths capture only the
+         small wrapper-level launchd noise (process start/exit). -->
+    <key>StandardOutPath</key>
+    <string>/Users/ryaker/Library/Logs/kms-cron/granola.launchd.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/ryaker/Library/Logs/kms-cron/granola.launchd.log</string>
+</dict>
+</plist>

--- a/scripts/cron/com.ryaker.kms-slack-huddle-importer.plist
+++ b/scripts/cron/com.ryaker.kms-slack-huddle-importer.plist
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.ryaker.kms-slack-huddle-importer</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/ryaker/Dev/KMSmcp/scripts/cron/run-importer.sh</string>
+        <string>slack-huddles</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/ryaker/Dev/KMSmcp</string>
+
+    <!-- Fire every 15 min while loaded. Don't fire at boot — wait for the
+         user session and the first scheduled tick (mirrors the existing
+         com.ryaker.neo4j-keepalive pattern). -->
+    <key>StartInterval</key>
+    <integer>900</integer>
+
+    <key>RunAtLoad</key>
+    <false/>
+
+    <!-- Avoid runaway concurrent invocations; the runner has its own PID-file
+         guard, but ThrottleInterval gives launchd a backstop. -->
+    <key>ThrottleInterval</key>
+    <integer>60</integer>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/Users/ryaker</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <!-- Tell the runner to wrap with `doppler run` for OAuth / Anthropic /
+             Slack secrets. The runner skips Doppler if KMS_BEARER_TOKEN is set. -->
+        <key>KMS_DOPPLER_PROJECT</key>
+        <string>ry-local</string>
+        <key>KMS_DOPPLER_CONFIG</key>
+        <string>dev_personal</string>
+    </dict>
+
+    <!-- Runner already routes its own per-importer log under
+         ~/Library/Logs/kms-cron/slack-huddles.log. These paths capture only
+         the small wrapper-level launchd noise (process start/exit). -->
+    <key>StandardOutPath</key>
+    <string>/Users/ryaker/Library/Logs/kms-cron/slack-huddles.launchd.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/ryaker/Library/Logs/kms-cron/slack-huddles.launchd.log</string>
+</dict>
+</plist>

--- a/scripts/cron/run-importer.sh
+++ b/scripts/cron/run-importer.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+#
+# scripts/cron/run-importer.sh
+#
+# One-shot wrapper invoked by launchd every 15 min for each importer.
+# Resolves Homebrew node/npx, sources project .env if present, captures
+# stdout+stderr to a log under ~/Library/Logs/kms-cron/, and guards against
+# concurrent runs with a PID-file lock (macOS doesn't ship `flock`).
+#
+# Usage:
+#   scripts/cron/run-importer.sh granola         # → npx tsx scripts/import-granola.ts --source=cache-v6
+#   scripts/cron/run-importer.sh slack-huddles   # → npx tsx src/scripts/import-slack-huddles-cli.ts
+#
+# Exit codes:
+#   0 = importer exited 0
+#   non-zero = importer exited non-zero (passes through), or wrapper error.
+#   Special: 75 (EX_TEMPFAIL) = another instance still running, skipping this tick.
+#
+# Idempotency: each importer has its own state file
+#   (~/.kms-granola-state.json, ~/.kms-slack-huddle-sync.json) so re-running
+#   the same window just re-walks an already-processed list and stores nothing.
+#   The PID-file lock here guards against a slow run still being in-flight when
+#   the next 15-min tick arrives.
+#
+# Environment expectations:
+#   - KMS at http://localhost:8180/mcp must be reachable.
+#   - OAuth client_credentials env supplied via Doppler (preferred) or via .env.
+#   - ANTHROPIC_API_KEY must be set (required for Haiku 4.5 distillation).
+
+set -uo pipefail
+
+# ─── Resolve repo root (this script lives at <repo>/scripts/cron/) ──────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# ─── PATH: Homebrew first so we get node/npm/npx + doppler if installed ─────
+export PATH="/opt/homebrew/bin:/usr/local/bin:${PATH:-/usr/bin:/bin}"
+
+# ─── Argument: importer name ────────────────────────────────────────────────
+IMPORTER="${1:-}"
+if [[ -z "$IMPORTER" ]]; then
+  echo "❌ usage: $0 <granola|slack-huddles>" >&2
+  exit 64  # EX_USAGE
+fi
+
+# Allow tests / overrides to swap the npx binary (default: whichever `npx`
+# resolves on PATH after the Homebrew prepend above).
+NPX_BIN="${KMS_CRON_NPX:-npx}"
+
+case "$IMPORTER" in
+  granola)
+    IMPORTER_CMD=("$NPX_BIN" --yes tsx scripts/import-granola.ts --source=cache-v6)
+    LOG_NAME="granola"
+    ;;
+  slack-huddles)
+    IMPORTER_CMD=("$NPX_BIN" --yes tsx src/scripts/import-slack-huddles-cli.ts)
+    LOG_NAME="slack-huddles"
+    ;;
+  *)
+    echo "❌ unknown importer: $IMPORTER (expected: granola|slack-huddles)" >&2
+    exit 64
+    ;;
+esac
+
+# ─── Logging ────────────────────────────────────────────────────────────────
+LOG_DIR="${KMS_CRON_LOG_DIR:-$HOME/Library/Logs/kms-cron}"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${LOG_NAME}.log"
+
+# Rotate the log if it's > 10 MB. Crude single-rotation: .log → .log.1.
+if [[ -f "$LOG_FILE" ]]; then
+  size=$(stat -f%z "$LOG_FILE" 2>/dev/null || echo 0)
+  if [[ "$size" -gt 10485760 ]]; then
+    mv -f "$LOG_FILE" "${LOG_FILE}.1" 2>/dev/null || true
+  fi
+fi
+
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" >> "$LOG_FILE"
+}
+
+# ─── PID-file lock (macOS-friendly; no flock) ──────────────────────────────
+LOCK_DIR="${KMS_CRON_LOCK_DIR:-$HOME/Library/Caches/kms-cron}"
+mkdir -p "$LOCK_DIR"
+LOCK_FILE="$LOCK_DIR/${LOG_NAME}.pid"
+
+acquire_lock() {
+  if [[ -f "$LOCK_FILE" ]]; then
+    local existing_pid
+    existing_pid="$(cat "$LOCK_FILE" 2>/dev/null || echo '')"
+    if [[ -n "$existing_pid" ]] && kill -0 "$existing_pid" 2>/dev/null; then
+      log "another run still in flight (pid=$existing_pid). skipping this tick."
+      return 1
+    fi
+    log "stale lock (pid=$existing_pid not running). reclaiming."
+    rm -f "$LOCK_FILE"
+  fi
+  echo "$$" > "$LOCK_FILE"
+  return 0
+}
+
+release_lock() {
+  if [[ -f "$LOCK_FILE" ]]; then
+    local pid
+    pid="$(cat "$LOCK_FILE" 2>/dev/null || echo '')"
+    if [[ "$pid" == "$$" ]]; then
+      rm -f "$LOCK_FILE"
+    fi
+  fi
+}
+
+trap release_lock EXIT INT TERM
+
+if ! acquire_lock; then
+  exit 75  # EX_TEMPFAIL
+fi
+
+# ─── Optional: source repo .env (importers also accept env from launchd /
+# Doppler — sourcing is a fallback when launching via cron-style tools). ────
+if [[ -f "$REPO_ROOT/.env" ]]; then
+  # shellcheck disable=SC1091
+  set -a
+  . "$REPO_ROOT/.env"
+  set +a
+fi
+
+# ─── Run the importer ──────────────────────────────────────────────────────
+cd "$REPO_ROOT"
+
+log "starting ${LOG_NAME} importer: ${IMPORTER_CMD[*]}"
+log "  cwd=$REPO_ROOT  PATH=$PATH"
+
+# Use Doppler if available AND no bearer token is already set (lets a one-off
+# overridden run via KMS_BEARER_TOKEN bypass Doppler).
+RUN_PREFIX=()
+if [[ -z "${KMS_BEARER_TOKEN:-}" ]] && command -v doppler >/dev/null 2>&1; then
+  if [[ -n "${KMS_DOPPLER_PROJECT:-}" && -n "${KMS_DOPPLER_CONFIG:-}" ]]; then
+    RUN_PREFIX=(doppler run --project "$KMS_DOPPLER_PROJECT" --config "$KMS_DOPPLER_CONFIG" --)
+    log "using doppler: project=$KMS_DOPPLER_PROJECT config=$KMS_DOPPLER_CONFIG"
+  fi
+fi
+
+start_ts="$(date +%s)"
+
+# Run the importer, appending stdout+stderr to the rolling log.
+# `${RUN_PREFIX[@]+"${RUN_PREFIX[@]}"}` expands to NOTHING when the array is
+# empty — required because `set -u` (above) treats an unset array as an
+# error. We don't run `set -e` because we want to capture the importer's
+# exit code and propagate it ourselves (see "exit $status" below).
+"${RUN_PREFIX[@]+"${RUN_PREFIX[@]}"}" "${IMPORTER_CMD[@]}" >> "$LOG_FILE" 2>&1
+status=$?
+
+end_ts="$(date +%s)"
+duration=$((end_ts - start_ts))
+log "finished ${LOG_NAME} importer: exit=$status duration=${duration}s"
+log "─────────────────────────────────────────────────────────────"
+
+exit "$status"

--- a/src/__tests__/cron.run-importer.test.ts
+++ b/src/__tests__/cron.run-importer.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for `scripts/cron/run-importer.sh` and the launchd plists that
+ * drive the Granola + Slack-huddle importers on a 15-min cron.
+ *
+ * What's covered:
+ *   1. `plutil -lint` validates each plist (pure config — that's the right test).
+ *   2. The runner script:
+ *        - exits 64 (EX_USAGE) for missing/unknown importer names
+ *        - prepends `/opt/homebrew/bin` to PATH
+ *        - resolves the right tsx entry point per importer name:
+ *            granola        → scripts/import-granola.ts --source=cache-v6
+ *            slack-huddles  → src/scripts/import-slack-huddles-cli.ts
+ *        - takes a PID-file lock (second concurrent run exits 75 EX_TEMPFAIL)
+ *
+ * Strategy: we don't actually run npx/tsx (no network, no KMS available).
+ * Instead we point the runner at a fake bin dir whose `npx` binary just
+ * echoes "npx <args>" + the live PATH and exits 0. Asserting on that line
+ * lets us pin the runner's wiring without depending on real tooling.
+ */
+
+import { execFileSync, spawnSync } from 'child_process'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, chmodSync } from 'fs'
+import { tmpdir } from 'os'
+import { join, resolve } from 'path'
+
+const REPO_ROOT = resolve(__dirname, '..', '..')
+const SCRIPT_PATH = join(REPO_ROOT, 'scripts', 'cron', 'run-importer.sh')
+const GRANOLA_PLIST = join(REPO_ROOT, 'scripts', 'cron', 'com.ryaker.kms-granola-importer.plist')
+const SLACK_PLIST = join(REPO_ROOT, 'scripts', 'cron', 'com.ryaker.kms-slack-huddle-importer.plist')
+
+describe('scripts/cron — launchd plists', () => {
+  it.each([
+    ['granola', GRANOLA_PLIST],
+    ['slack-huddles', SLACK_PLIST]
+  ])('%s plist passes plutil -lint', (_label: string, path: string) => {
+    expect(existsSync(path)).toBe(true)
+    // `plutil -lint` returns 0 on valid plist, non-zero with a message otherwise.
+    expect(() => execFileSync('plutil', ['-lint', path], { encoding: 'utf-8' })).not.toThrow()
+  })
+
+  it('granola plist labels job + fires every 900 s + does not RunAtLoad', () => {
+    const xml = readFileSync(GRANOLA_PLIST, 'utf-8')
+    expect(xml).toContain('<string>com.ryaker.kms-granola-importer</string>')
+    expect(xml).toMatch(/<key>StartInterval<\/key>\s*<integer>900<\/integer>/)
+    expect(xml).toMatch(/<key>RunAtLoad<\/key>\s*<false\/>/)
+    expect(xml).toContain('scripts/cron/run-importer.sh')
+    expect(xml).toContain('<string>granola</string>')
+    expect(xml).toContain('/Users/ryaker/Library/Logs/kms-cron/granola.launchd.log')
+  })
+
+  it('slack-huddle plist labels job + fires every 900 s + does not RunAtLoad', () => {
+    const xml = readFileSync(SLACK_PLIST, 'utf-8')
+    expect(xml).toContain('<string>com.ryaker.kms-slack-huddle-importer</string>')
+    expect(xml).toMatch(/<key>StartInterval<\/key>\s*<integer>900<\/integer>/)
+    expect(xml).toMatch(/<key>RunAtLoad<\/key>\s*<false\/>/)
+    expect(xml).toContain('scripts/cron/run-importer.sh')
+    expect(xml).toContain('<string>slack-huddles</string>')
+    expect(xml).toContain('/Users/ryaker/Library/Logs/kms-cron/slack-huddles.launchd.log')
+  })
+})
+
+describe('scripts/cron/run-importer.sh', () => {
+  let workdir: string
+  let logDir: string
+  let lockDir: string
+  let fakeBin: string
+
+  beforeEach(() => {
+    workdir = mkdtempSync(join(tmpdir(), 'kms-cron-test-'))
+    logDir = join(workdir, 'logs')
+    lockDir = join(workdir, 'locks')
+    fakeBin = join(workdir, 'fakebin')
+    mkdirSync(logDir, { recursive: true })
+    mkdirSync(lockDir, { recursive: true })
+    mkdirSync(fakeBin, { recursive: true })
+
+    // Stub `npx` — record the args + the live PATH so the test can assert on
+    // both. Touching a sentinel file lets a second concurrent run prove it
+    // never got past the lock.
+    const stubNpx = `#!/bin/bash
+echo "npx-invoked: $*" >&2
+echo "live-path: $PATH" >&2
+echo "called" > "${workdir}/npx-called"
+exit 0
+`
+    writeFileSync(join(fakeBin, 'npx'), stubNpx)
+    chmodSync(join(fakeBin, 'npx'), 0o755)
+  })
+
+  afterEach(() => {
+    rmSync(workdir, { recursive: true, force: true })
+  })
+
+  function runScript(
+    args: string[],
+    extraEnv: Record<string, string> = {}
+  ): { status: number | null; stdout: string; stderr: string } {
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      HOME: workdir,
+      KMS_CRON_LOG_DIR: logDir,
+      KMS_CRON_LOCK_DIR: lockDir,
+      // Sentinel — keeps the runner from trying to source a real .env or
+      // wrap with `doppler run`.
+      KMS_BEARER_TOKEN: 'test-bearer-token',
+      // Hard-pin the npx binary the runner invokes so the test asserts
+      // wiring without depending on the host's npm/tsx install.
+      KMS_CRON_NPX: join(fakeBin, 'npx'),
+      ...extraEnv
+    }
+    const res = spawnSync('/bin/bash', [SCRIPT_PATH, ...args], { env, encoding: 'utf-8' })
+    return { status: res.status, stdout: res.stdout, stderr: res.stderr }
+  }
+
+  it('exits 64 (EX_USAGE) when no importer name is given', () => {
+    const res = runScript([])
+    expect(res.status).toBe(64)
+    expect(res.stderr).toMatch(/usage:/i)
+  })
+
+  it('exits 64 for an unknown importer name', () => {
+    const res = runScript(['mystery-importer'])
+    expect(res.status).toBe(64)
+    expect(res.stderr).toMatch(/unknown importer/i)
+  })
+
+  it('granola: invokes tsx with cache-v6 source flag', () => {
+    const res = runScript(['granola'])
+    expect(res.status).toBe(0)
+    expect(existsSync(join(workdir, 'npx-called'))).toBe(true)
+
+    const log = readFileSync(join(logDir, 'granola.log'), 'utf-8')
+    expect(log).toContain('npx-invoked: --yes tsx scripts/import-granola.ts --source=cache-v6')
+    // Runner must prepend Homebrew to PATH so a real launchd-only env still
+    // resolves node/npm/npx — the live PATH echoed by the stub proves it.
+    expect(log).toContain('/opt/homebrew/bin')
+    expect(log).toMatch(/finished granola importer: exit=0/)
+  })
+
+  it('slack-huddles: invokes tsx with the CLI entry', () => {
+    const res = runScript(['slack-huddles'])
+    expect(res.status).toBe(0)
+
+    const log = readFileSync(join(logDir, 'slack-huddles.log'), 'utf-8')
+    expect(log).toContain('npx-invoked: --yes tsx src/scripts/import-slack-huddles-cli.ts')
+    expect(log).toContain('/opt/homebrew/bin')
+    expect(log).toMatch(/finished slack-huddles importer: exit=0/)
+  })
+
+  it('PID-file lock prevents concurrent runs (second exits EX_TEMPFAIL=75)', () => {
+    // Fake npx that blocks long enough for a second invocation to race in
+    // and observe the lock.
+    const slowNpx = `#!/bin/bash
+echo "slow-npx" > "${workdir}/slow-running"
+sleep 2
+exit 0
+`
+    writeFileSync(join(fakeBin, 'npx'), slowNpx)
+    chmodSync(join(fakeBin, 'npx'), 0o755)
+
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      HOME: workdir,
+      KMS_CRON_LOG_DIR: logDir,
+      KMS_CRON_LOCK_DIR: lockDir,
+      KMS_BEARER_TOKEN: 'test-bearer-token',
+      KMS_CRON_NPX: join(fakeBin, 'npx')
+    }
+
+    // Spawn slow run in background.
+    const { spawn } = require('child_process')
+    const slow = spawn('/bin/bash', [SCRIPT_PATH, 'granola'], { env, stdio: 'ignore' })
+
+    // Wait for the slow run to actually start (lock file written + sleep called).
+    const start = Date.now()
+    while (!existsSync(join(workdir, 'slow-running')) && Date.now() - start < 3000) {
+      // Tiny blocking sleep so we don't spin the event loop.
+      execFileSync('/bin/sleep', ['0.05'])
+    }
+
+    // Second invocation should refuse to run and exit 75 EX_TEMPFAIL.
+    const second = spawnSync('/bin/bash', [SCRIPT_PATH, 'granola'], { env, encoding: 'utf-8' })
+    expect(second.status).toBe(75)
+
+    // Drain the slow run.
+    return new Promise<void>(resolve => {
+      slow.on('exit', () => resolve())
+    })
+  }, 15000)
+})


### PR DESCRIPTION
## Summary

Wire PR #80 (Granola `--source=cache-v6`) and PR #76 (Slack huddle importer) onto a 15-min launchd cron via two new plists and a single shared runner script.

- **scripts/cron/run-importer.sh** — bash wrapper. Resolves Homebrew node/npx, sources optional repo `.env`, optionally wraps the importer with `doppler run` for OAuth + `ANTHROPIC_API_KEY`, takes a PID-file lock so a slow tick can't double-fire 15 min later, and tees stdout+stderr into `~/Library/Logs/kms-cron/<importer>.log` (rotates past 10 MB).
- **com.ryaker.kms-granola-importer.plist / com.ryaker.kms-slack-huddle-importer.plist** — `StartInterval=900`, `RunAtLoad=false`, `ThrottleInterval=60`. Mirrors the existing `com.ryaker.neo4j-keepalive` pattern.
- **scripts/cron/README.md** — install / verify / uninstall / one-off-trigger procedure.
- **src/__tests__/cron.run-importer.test.ts** — `plutil -lint` both plists, plus a unit test of the runner that pins the importer command, the Homebrew PATH prepend, and the PID-file lock (second concurrent run exits 75 `EX_TEMPFAIL`).

## What runs every 15 min

```
# granola
cd /Users/ryaker/Dev/KMSmcp \
  && doppler run --project ry-local --config dev_personal -- \
       npx --yes tsx scripts/import-granola.ts --source=cache-v6

# slack-huddles
cd /Users/ryaker/Dev/KMSmcp \
  && doppler run --project ry-local --config dev_personal -- \
       npx --yes tsx src/scripts/import-slack-huddles-cli.ts
```

The `doppler run` prefix is added automatically when `doppler` is on PATH, `KMS_BEARER_TOKEN` is unset, and the plist-supplied `KMS_DOPPLER_PROJECT` / `KMS_DOPPLER_CONFIG` are present.

## Idempotency notes

- **Granola**: watermark file `~/.kms-granola-state.json` tracks last-processed `endTs`; older meetings are skipped.
- **Slack huddles**: sync log `~/.kms-slack-huddle-sync.json` lists processed huddle IDs; existing IDs are skipped.
- **Dedup gate**: every KMS write goes through `unified_store`, which refuses near-duplicates even if state files are wiped.
- **Concurrent-run guard**: PID-file at `~/Library/Caches/kms-cron/<importer>.pid`. A second invocation that arrives while the first is still in flight logs `another run still in flight` and exits with `75` (`EX_TEMPFAIL`); launchd treats this as normal and tries again on the next tick.

## Install / uninstall

Plists are committed but **NOT installed by this PR**. Per README, the install is manual:

```bash
cp scripts/cron/com.ryaker.kms-granola-importer.plist        ~/Library/LaunchAgents/
cp scripts/cron/com.ryaker.kms-slack-huddle-importer.plist   ~/Library/LaunchAgents/
launchctl load -w ~/Library/LaunchAgents/com.ryaker.kms-granola-importer.plist
launchctl load -w ~/Library/LaunchAgents/com.ryaker.kms-slack-huddle-importer.plist
```

Verify: `launchctl list | grep com.ryaker.kms-`
Tail: `tail -f ~/Library/Logs/kms-cron/granola.log`
One-off: `launchctl start com.ryaker.kms-granola-importer`

Uninstall:
```bash
launchctl unload -w ~/Library/LaunchAgents/com.ryaker.kms-granola-importer.plist
launchctl unload -w ~/Library/LaunchAgents/com.ryaker.kms-slack-huddle-importer.plist
rm ~/Library/LaunchAgents/com.ryaker.kms-{granola,slack-huddle}-importer.plist
```

## Log paths

| Path | Contents |
| --- | --- |
| `~/Library/Logs/kms-cron/granola.log` | Per-tick wrapper banner + full importer stdout/stderr. Rotates to `.log.1` past 10 MB. |
| `~/Library/Logs/kms-cron/slack-huddles.log` | Same for slack-huddle importer. |
| `~/Library/Logs/kms-cron/<name>.launchd.log` | Tiny wrapper-level launchd capture (process spawn / exit). Usually empty. |

## Test plan

- [x] `npm test` — 328 passed across 15 suites (incl. new `cron.run-importer.test.ts` — 9 tests).
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run build` — clean.
- [x] `plutil -lint` on both plists — OK.
- [x] Manual smoke: `bash scripts/cron/run-importer.sh granola` against a stubbed `npx` — runner exits 0, log records the right invocation, lock file released on exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)