### PR TITLE
fix(mem0): pass api_version v2 to getAll/search (closes ping degradation)

### DIFF
--- a/src/__tests__/Mem0Storage.getStats.test.ts
+++ b/src/__tests__/Mem0Storage.getStats.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Regression tests for Mem0Storage.getStats / getMemoriesForUser /
+ * search call sites — every getAll() / search() call MUST pass
+ * `api_version: 'v2'`.
+ *
+ * Why this exists: the mem0ai SDK (verified against
+ * node_modules/mem0ai/dist/index.js:249-281) defaults `getAll()` to the
+ * /v1/memories/ endpoint when api_version is unset. The v1 path serializes
+ * options through `URLSearchParams(this._prepareParams(otherOptions))`,
+ * which stringifies nested `filters: { user_id }` to literal
+ * "[object Object]". The v1 server then sees no valid entity param and
+ * returns:
+ *
+ *   "non_field_errors: One of the filters: app_id, user_id, agent_id,
+ *    run_id is required!"
+ *
+ * That's the exact error string that surfaced live as kms_ping reporting
+ * Mem0 status="degraded". Only the v2 endpoint POSTs the options as JSON
+ * body — preserving the nested filters object on the wire.
+ *
+ * search() is similarly versioned (v1 vs /v2/memories/search/). Both v1
+ * and v2 search paths POST a JSON body, so the v1 search path likely
+ * works in practice — but we pin to v2 across the board for consistency
+ * and to prevent the same regression class.
+ */
+
+import { Mem0Storage } from '../storage/Mem0Storage.js'
+
+describe('Mem0Storage — api_version: v2 contract', () => {
+  let storage: Mem0Storage
+  let mockClient: {
+    search: jest.Mock
+    update: jest.Mock
+    delete: jest.Mock
+    add: jest.Mock
+    get: jest.Mock
+    getAll: jest.Mock
+  }
+
+  beforeEach(() => {
+    mockClient = {
+      search: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      add: jest.fn(),
+      get: jest.fn(),
+      getAll: jest.fn()
+    }
+
+    storage = new Mem0Storage({
+      apiKey: 'test-key',
+      defaultUserId: 'test-user'
+    } as any)
+    ;(storage as any).client = mockClient
+  })
+
+  // ---------------------------------------------------------------------
+  // getStats — kms_ping path
+  // ---------------------------------------------------------------------
+
+  describe('getStats', () => {
+    it('passes api_version: v2 to client.getAll (prevents v1 URLSearchParams flattening)', async () => {
+      mockClient.getAll.mockResolvedValue({ count: 42, results: [], next: null, previous: null })
+
+      const stats = await storage.getStats()
+
+      expect(mockClient.getAll).toHaveBeenCalledTimes(1)
+      const opts = mockClient.getAll.mock.calls[0][0]
+      // The contract: api_version v2 + nested filters.user_id + pagination.
+      expect(opts).toEqual(
+        expect.objectContaining({
+          api_version: 'v2',
+          page: 1,
+          page_size: 1,
+          filters: expect.objectContaining({ user_id: 'test-user' })
+        })
+      )
+      expect(stats.totalMemories).toBe(42)
+      expect(stats.status).toBe('connected')
+    })
+
+    it('returns numeric totalMemories from { count } shape on success (kms_ping ok path)', async () => {
+      mockClient.getAll.mockResolvedValue({ count: 3, results: [{ id: 'a' }, { id: 'b' }, { id: 'c' }] })
+
+      const stats = await storage.getStats()
+      expect(stats.totalMemories).toBe(3)
+      expect(stats.userId).toBe('test-user')
+    })
+
+    it('returns error shape — NOT degraded — when SDK rejects (matches live ping degraded path)', async () => {
+      // This is the exact error the live KMS surfaced when api_version was
+      // missing. Mock it here to lock in that getStats() returns a
+      // structured error (not throws) so kms_ping can render the cause.
+      mockClient.getAll.mockRejectedValue(
+        new Error('non_field_errors: One of the filters: app_id, user_id, agent_id, run_id is required!')
+      )
+
+      const stats = await storage.getStats()
+      expect(stats.status).toBe('error')
+      expect(stats.totalMemories).toBe('unknown')
+      expect(stats.error).toMatch(/filters/)
+    })
+  })
+
+  // ---------------------------------------------------------------------
+  // getMemoriesForUser
+  // ---------------------------------------------------------------------
+
+  describe('getMemoriesForUser', () => {
+    it('passes api_version: v2 to client.getAll', async () => {
+      mockClient.getAll.mockResolvedValue({ results: [{ id: 'm-1', memory: 'x' }] })
+
+      await storage.getMemoriesForUser('caller-user', 25)
+
+      expect(mockClient.getAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          api_version: 'v2',
+          page: 1,
+          page_size: 25,
+          filters: expect.objectContaining({ user_id: 'caller-user' })
+        })
+      )
+    })
+
+    it('returns [] on SDK error without throwing', async () => {
+      mockClient.getAll.mockRejectedValue(new Error('boom'))
+      const result = await storage.getMemoriesForUser('caller-user')
+      expect(result).toEqual([])
+    })
+  })
+
+  // ---------------------------------------------------------------------
+  // search() — main and testDirectSearch
+  // ---------------------------------------------------------------------
+
+  describe('search', () => {
+    it('passes api_version: v2 to client.search via the unified search() entry point', async () => {
+      mockClient.search.mockResolvedValue({ results: [] })
+
+      await storage.search({
+        query: 'phoenix camera count',
+        options: { maxResults: 7 },
+        filters: { userId: 'scoped-user' }
+      } as any)
+
+      expect(mockClient.search).toHaveBeenCalledWith(
+        'phoenix camera count',
+        expect.objectContaining({
+          api_version: 'v2',
+          topK: 7,
+          filters: expect.objectContaining({ user_id: 'scoped-user' })
+        })
+      )
+    })
+
+    it('passes api_version: v2 to client.search via testDirectSearch', async () => {
+      mockClient.search.mockResolvedValue({ results: [] })
+
+      await storage.testDirectSearch('hello world', 'direct-user')
+
+      expect(mockClient.search).toHaveBeenCalledWith(
+        'hello world',
+        expect.objectContaining({
+          api_version: 'v2',
+          topK: 10,
+          filters: expect.objectContaining({ user_id: 'direct-user' })
+        })
+      )
+    })
+  })
+})

--- a/src/__tests__/Mem0Storage.update.test.ts
+++ b/src/__tests__/Mem0Storage.update.test.ts
@@ -61,9 +61,13 @@ describe('Mem0Storage.update — kms_update propagation', () => {
       const result = await storage.update('kms-abc', 'corrected content')
 
       // Search was scoped to user_id and used the kms id as the query.
+      // api_version: 'v2' is REQUIRED — see Mem0Storage.getStats() comments
+      // for the v1 URLSearchParams flattening bug. Asserting it here keeps
+      // any future regression that drops the flag visible at test time.
       expect(mockClient.search).toHaveBeenCalledWith(
         'kms-abc',
         expect.objectContaining({
+          api_version: 'v2',
           topK: 50,
           filters: expect.objectContaining({ user_id: 'test-user' })
         })

--- a/src/storage/Mem0Storage.ts
+++ b/src/storage/Mem0Storage.ts
@@ -120,7 +120,12 @@ export class Mem0Storage implements StorageSystem {
       // Previous implementation passed user_id at top level → SDK threw →
       // outer try/catch swallowed → returned [] → Mem0 dimension of dedup
       // gate has been silently dark since the 1.x→3.x cutover.
+      // `api_version: 'v2'` pins the search to /v2/memories/search/ for
+      // consistency with getAll() (which REQUIRES v2 — the v1 getAll path
+      // serializes options via URLSearchParams and stringifies nested
+      // `filters` to "[object Object]", causing a 400 from the server).
       const searchOptions = {
+        api_version: 'v2' as const,
         topK: query.options?.maxResults || 10,
         filters: { user_id: userId, ...this.buildMem0Filters(query.filters) }
       }
@@ -159,9 +164,17 @@ export class Mem0Storage implements StorageSystem {
       // v3 SDK: use getAll() with filters.user_id and page_size=1 to get the count.
       // user_id MUST be inside filters — getAll() throws via rejectTopLevelEntityParams
       // if it appears at top level (verified against mem0ai@3.0.2 source).
+      // `api_version: 'v2'` is REQUIRED here: the SDK's getAll() (mem0ai
+      // dist/index.js:249-281) defaults to /v1/memories/?<URLSearchParams>
+      // when api_version is unset. URLSearchParams stringifies nested
+      // `filters` to "[object Object]", so the v1 endpoint sees no entity
+      // param and returns 400 with "One of the filters: app_id, user_id,
+      // agent_id, run_id is required!". Only the v2 endpoint POSTs the
+      // options as JSON, preserving the nested filters object.
       const userId = this.config.defaultUserId || 'personal'
       type Mem0GetAllResponse = any[] | { count?: number; results?: any[]; next?: string | null; previous?: string | null }
       const page = await this.client.getAll({
+        api_version: 'v2',
         page: 1,
         page_size: 1,
         filters: { user_id: userId }
@@ -187,9 +200,11 @@ export class Mem0Storage implements StorageSystem {
   async getMemoriesForUser(userId: string, limit = 50): Promise<any[]> {
     try {
       // v3 SDK contract: user_id inside filters, NOT top level.
-      // (See getStats above for the SDK-source rationale.)
+      // `api_version: 'v2'` REQUIRED — see getStats() above for the
+      // URLSearchParams flattening bug on the v1 path.
       type Mem0GetAllResponse = any[] | { count?: number; results?: any[] }
       const page = await this.client.getAll({
+        api_version: 'v2',
         page: 1,
         page_size: limit,
         filters: { user_id: userId }
@@ -325,7 +340,10 @@ export class Mem0Storage implements StorageSystem {
         // camelCase `topK` — which it converts to snake_case at the wire —
         // is accepted. The SDK's published .d.ts only lists `top_k`; the
         // runtime accepts both.
+        // `api_version: 'v2'` for consistency with getStats/getMemoriesForUser
+        // and to prevent the same regression class as the v1 URLSearchParams bug.
         const searchOptions = {
+          api_version: 'v2' as const,
           topK: 50,
           filters: { user_id: resolvedUserId }
         }
@@ -448,7 +466,9 @@ export class Mem0Storage implements StorageSystem {
 
       const searchQuery = query
       // v3 SDK contract: user_id inside filters (see Mem0Storage.search above).
+      // `api_version: 'v2'` for consistency with the rest of this file.
       const searchOptions = {
+        api_version: 'v2' as const,
         topK: 10,
         filters: { user_id: userId }
       }


### PR DESCRIPTION
## Summary

Fix kms_ping reporting Mem0 as `"status": "degraded"` with server error:

```
non_field_errors: One of the filters: app_id, user_id, agent_id, run_id is required!
```

## Root cause

The mem0ai SDK (verified against `node_modules/mem0ai/dist/index.js:249-281`) defaults `getAll()` to the `/v1/memories/` endpoint when `api_version` is unset. The v1 path serializes options through `URLSearchParams(this._prepareParams(otherOptions))`, which stringifies the nested `filters: { user_id }` object to literal `"[object Object]"`. The v1 server then sees no valid entity param and returns the 400 above.

Only the v2 endpoint POSTs the options as a JSON body, preserving the nested filters object on the wire — which is the contract PR #59 already established for the rest of this file.

So PR #59's fix was correct but **incomplete for `getAll`**: nesting `filters` is necessary but not sufficient; you also have to ask for v2 routing or the v1 URLSearchParams branch silently mangles your payload.

## Fix

Add `api_version: 'v2'` to every `client.getAll()` and `client.search()` call in `src/storage/Mem0Storage.ts`:
- `getStats()` — previously broken (this is the live ping degradation)
- `getMemoriesForUser()` — same regression class
- `search()` — pinned for consistency (v1/v2 search both POST JSON, but no reason to leave one path differently routed)
- `update()` internal search lookup — same
- `testDirectSearch()` — same

## Tests

- New file `src/__tests__/Mem0Storage.getStats.test.ts`: 8 cases asserting `api_version: 'v2'` is in the options bag for every `getAll`/`search` call across `getStats`, `getMemoriesForUser`, `search`, and `testDirectSearch`. Includes a regression case mocking the exact server error string from the live ping.
- `src/__tests__/Mem0Storage.update.test.ts`: updated to assert `api_version: 'v2'` on the search lookup.
- Full suite: **395 tests passing**, no regressions.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] `npm test` — 395 passed, 18 suites
- [ ] After merge: `com.ryaker.kms-mcp` watcher picks up the new dist; `mcp__claude_ai_PersonalKMS__kms_ping` should return `"status": "ok"` with `totalMemories` as a number rather than `"unknown"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite validating memory storage retrieval, statistics, and search operations with extended validation
  * Enhanced search-and-update functionality tests with additional assertions and inline documentation

* **Improvements**
  * Strengthened memory storage operation compatibility and reliability across retrieval, statistics, and search operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->