### PR TITLE
fix(transport): return 404 from /register so MCP SDK falls through cleanly

### DIFF
--- a/src/__tests__/HttpTransport.oauth_stubs.test.ts
+++ b/src/__tests__/HttpTransport.oauth_stubs.test.ts
@@ -1,0 +1,95 @@
+/**
+ * OAuth discovery / DCR stubs.
+ *
+ * Verifies the four endpoints Claude Code's MCP SDK probes during its OAuth
+ * fallback chain all return a clean JSON 404 so the SDK falls through to an
+ * unauthenticated connection. Previously /register returned 501, which the SDK
+ * surfaces as a fatal "SDK auth failed: Dynamic client registration is not
+ * supported by this MCP server. Auth is tunnel-delegated — connect without
+ * OAuth." error in the UI.
+ *
+ * Also verifies the info-disclosure hardening: the detailed error_description
+ * and the `mcp_auth: "tunnel-delegated"` debug field only ship on localhost
+ * requests. Public-facing responses get a generic body.
+ */
+
+import request from 'supertest'
+import { HttpTransport, HttpTransportConfig } from '../transport/HttpTransport.js'
+
+const CONFIG: HttpTransportConfig = {
+  port: 0, // never actually bound — we drive Express via supertest
+  host: 'localhost',
+  cors: { origin: true, credentials: true },
+  // High limit so the four+ requests in a single test never trip 429.
+  rateLimit: { windowMs: 60_000, max: 1000 }
+}
+
+const LOCAL_ENDPOINTS: Array<{ method: 'get' | 'post'; path: string }> = [
+  { method: 'get',  path: '/.well-known/oauth-protected-resource' },
+  { method: 'get',  path: '/.well-known/oauth-authorization-server' },
+  { method: 'get',  path: '/.well-known/openid-configuration' },
+  { method: 'post', path: '/register' }
+]
+
+describe('HttpTransport — OAuth/DCR stubs', () => {
+  let transport: HttpTransport
+
+  beforeEach(() => {
+    transport = new HttpTransport(CONFIG)
+  })
+
+  afterEach(async () => {
+    await transport.stop()
+  })
+
+  describe('localhost requests (Host: localhost)', () => {
+    for (const { method, path } of LOCAL_ENDPOINTS) {
+      it(`${method.toUpperCase()} ${path} returns 404 with JSON body and debug field`, async () => {
+        const app = (transport as any).app
+
+        const res = await (method === 'get' ? request(app).get(path) : request(app).post(path).send({}))
+          .set('Host', 'localhost')
+
+        expect(res.status).toBe(404)
+        expect(res.headers['content-type']).toMatch(/application\/json/)
+        expect(res.body).toMatchObject({
+          error: 'oauth_not_supported',
+          mcp_auth: 'tunnel-delegated'
+        })
+        expect(typeof res.body.error_description).toBe('string')
+      })
+    }
+
+    it('POST /register specifically returns 404 (was 501 prior to this fix)', async () => {
+      const app = (transport as any).app
+
+      const res = await request(app)
+        .post('/register')
+        .set('Host', 'localhost')
+        .send({ client_name: 'test-client', redirect_uris: ['http://localhost/cb'] })
+
+      // The fix: SDK treats 501 as a fatal DCR-rejected error; 404 as
+      // "no such endpoint, fall through to unauthenticated."
+      expect(res.status).toBe(404)
+      expect(res.status).not.toBe(501)
+      expect(res.body.error).toBe('oauth_not_supported')
+    })
+  })
+
+  describe('public (non-localhost) requests — info-disclosure hardening', () => {
+    for (const { method, path } of LOCAL_ENDPOINTS) {
+      it(`${method.toUpperCase()} ${path} returns 404 JSON WITHOUT mcp_auth debug field`, async () => {
+        const app = (transport as any).app
+
+        const res = await (method === 'get' ? request(app).get(path) : request(app).post(path).send({}))
+          .set('Host', 'kms.yaker.org')
+
+        expect(res.status).toBe(404)
+        expect(res.headers['content-type']).toMatch(/application\/json/)
+        expect(res.body).toMatchObject({ error: 'oauth_not_supported' })
+        // Hardening: tunnel-delegated debug field must not leak to the public.
+        expect(res.body).not.toHaveProperty('mcp_auth')
+      })
+    }
+  })
+})

--- a/src/transport/HttpTransport.ts
+++ b/src/transport/HttpTransport.ts
@@ -148,8 +148,15 @@ export class HttpTransport {
     // this unconditionally on reconnect). Without these stubs, Express returns
     // its default HTML 404 body, which the MCP client tries to parse as JSON and
     // crashes with "SyntaxError: Unrecognized token '<'". The stubs return a
-    // well-formed JSON 404/501 so the client's OAuth probe completes cleanly
+    // well-formed JSON 404 so the client's OAuth probe completes cleanly
     // and falls back to unauthenticated connection.
+    //
+    // Return 404 (not 501) on /register — Claude Code's MCP SDK treats 501 as a
+    // fatal DCR-rejected error ("SDK auth failed: Dynamic client registration is
+    // not supported…"), but 404 as "no such endpoint, fall through to
+    // unauthenticated." Routing /register through the same handler as the
+    // .well-known endpoints gives a single, consistent "no OAuth, anywhere"
+    // signal to the SDK.
     //
     // Info-disclosure hardening: the detailed error_description and the
     // `mcp_auth: "tunnel-delegated"` debug field ONLY ship on localhost
@@ -179,20 +186,7 @@ export class HttpTransport {
     this.app.get('/.well-known/oauth-authorization-server', oauthNotSupported)
     this.app.get('/.well-known/oauth-protected-resource', oauthNotSupported)
     this.app.get('/.well-known/openid-configuration', oauthNotSupported)
-    this.app.post('/register', (req: Request, res: Response) => {
-      if (isLocalRequest(req)) {
-        res.status(501).json({
-          error: 'registration_not_supported',
-          error_description: 'Dynamic client registration is not supported by this MCP server. Auth is tunnel-delegated — connect without OAuth.',
-          mcp_auth: 'tunnel-delegated'
-        })
-      } else {
-        res.status(501).json({
-          error: 'registration_not_supported',
-          error_description: 'Dynamic client registration is not supported.'
-        })
-      }
-    })
+    this.app.post('/register', oauthNotSupported)
 
     // MCP endpoints - No internal auth, trust the tunnel
     this.app.post('/mcp', this.handleMcpPostRequest.bind(this))


### PR DESCRIPTION
## Summary

- **Problem**: Claude Code's MCP UI shows `SDK auth failed: Dynamic client registration is not supported by this MCP server. Auth is tunnel-delegated — connect without OAuth.` when connecting to the local KMS at `http://localhost:8180/mcp`.
- **Root cause**: PR #38 (51cbdb87) added OAuth discovery stubs for /.well-known/* (returns 404 JSON) and POST /register (returns **501** JSON). The .well-known 404s work correctly. The /register 501 is interpreted by Claude Code's MCP SDK as a **fatal DCR-rejected** error, instead of "no such endpoint, fall through to unauthenticated."
- **Fix**: Route POST /register through the same `oauthNotSupported` handler the .well-known endpoints already use. Single source of truth for "no OAuth, anywhere," returning a JSON 404 the SDK treats as "fall through."

## What changed

`src/transport/HttpTransport.ts`:
- Replaced inline 501-returning handler for POST /register with `this.app.post('/register', oauthNotSupported)`.
- Updated the comment block explaining why 404 (not 501) is the right code for /register.

`src/__tests__/HttpTransport.oauth_stubs.test.ts` (new, 9 cases):
- All four endpoints (/.well-known/oauth-protected-resource, /.well-known/oauth-authorization-server, /.well-known/openid-configuration, /register) return:
  - status 404 (was 501 for /register before this PR)
  - Content-Type application/json
  - body has `error: "oauth_not_supported"`
  - body has `error_description` (string)
- On localhost: body includes `mcp_auth: "tunnel-delegated"` debug field.
- On non-localhost (Host: kms.yaker.org): body does **NOT** include `mcp_auth` — info-disclosure hardening preserved.

## What this doesn't solve

The Claude Code SDK arguably shouldn't probe DCR after the .well-known endpoints all return 404 — that's an upstream concern. The 404 workaround is the pragmatic server-side fix and unblocks the user immediately. After merge & rebuild, Rich needs to click "Reconnect" in the Claude Code MCP UI to pick up the change.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 404/404 passing (19 suites, 9 new test cases)
- [x] `npm run build` — clean (dist diff matches source change exactly)
- [x] Baseline curl confirmed: `POST /register` currently returns 501 against the live daemon
- [ ] Post-merge live verification: `curl -s -o /dev/null -w "HTTP %{http_code}\n" -X POST http://localhost:8180/register -H "Content-Type: application/json" -d '{}'` should return `HTTP 404`
- [ ] Rich clicks "Reconnect" in Claude Code MCP UI and the "SDK auth failed" banner is gone

## Constraints honored

- /mcp behavior unchanged
- .well-known endpoints unchanged (they already worked)
- No new dependencies
- No version bumps of @anthropic-ai/sdk or mem0ai
- dist/ not touched in this PR (gitignored; will be rebuilt post-merge)
- localhost-only debug field hardening preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth discovery endpoints now consistently return HTTP 404 responses with standardized error messages.

* **Tests**
  * Added comprehensive test suite validating OAuth stub behavior for both local and remote requests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryaker/KMSmcp/pull/83)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->