### PR TITLE
fix(ollama): widen timeouts for a LAN Ollama and expire failures fast

### DIFF
--- a/src/__tests__/EmbeddingService.test.ts
+++ b/src/__tests__/EmbeddingService.test.ts
@@ -198,4 +198,38 @@ describe('OllamaEmbeddingService', () => {
     // Single underlying call — cache hits avoid extra HTTP traffic.
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
+
+  it('isAvailable: probe budget is well above LAN round-trip, not the old 500ms', async () => {
+    // Regression guard. The probe was hardcoded to 500 ms, which is 10x stricter than
+    // DEFAULT_TIMEOUT_MS and fails against an Ollama on another host. We assert the
+    // AbortSignal handed to fetch has not already fired after a LAN-typical delay.
+    let captured: AbortSignal | undefined
+    fetchMock.mockImplementationOnce(async (_url: unknown, init: unknown) => {
+      captured = (init as { signal?: AbortSignal } | undefined)?.signal
+      await new Promise(r => setTimeout(r, 600))
+      return { ok: true } as unknown as Response
+    })
+    const svc = new OllamaEmbeddingService()
+    expect(await svc.isAvailable()).toBe(true)
+    expect(captured?.aborted).toBe(false)
+  })
+
+  it('isAvailable: a failure expires fast so one slow probe does not disable embedding', async () => {
+    // Previously a negative result was cached for the full 30 s, meaning a single
+    // transient blip suppressed embedding for every write in the next half-minute.
+    fetchMock.mockRejectedValueOnce(new Error('connection refused'))
+    const svc = new OllamaEmbeddingService()
+    expect(await svc.isAvailable()).toBe(false)
+
+    // Advance past the short failure TTL (5 s) but well inside the 30 s success TTL.
+    const realNow = Date.now
+    Date.now = () => realNow() + 6_000
+    try {
+      fetchMock.mockResolvedValueOnce({ ok: true } as unknown as Response)
+      expect(await svc.isAvailable()).toBe(true)
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    } finally {
+      Date.now = realNow
+    }
+  })
 })

--- a/src/__tests__/EmbeddingService.test.ts
+++ b/src/__tests__/EmbeddingService.test.ts
@@ -232,4 +232,29 @@ describe('OllamaEmbeddingService', () => {
       Date.now = realNow
     }
   })
+
+  it('isAvailable: failure TTL is measured from when the probe finished, not when it started', async () => {
+    // A slow probe must still get its full failure TTL. If expiresAt is computed from a
+    // timestamp captured before fetch, a probe that burns 2s of its budget caches the
+    // failure for only ~3s instead of 5s — and re-probes a slow/dead host too eagerly.
+    fetchMock.mockImplementationOnce(async () => {
+      await new Promise(r => setTimeout(r, 400))
+      throw new Error('connection refused')
+    })
+    const svc = new OllamaEmbeddingService()
+    expect(await svc.isAvailable()).toBe(false)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    // 4.7s after the probe *returned*. Still inside the 5s failure TTL, so the cached
+    // negative must hold. With the old start-time arithmetic the 400ms spent probing
+    // would have pushed this past expiry and triggered a second fetch.
+    const realNow = Date.now
+    Date.now = () => realNow() + 4_700
+    try {
+      expect(await svc.isAvailable()).toBe(false)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    } finally {
+      Date.now = realNow
+    }
+  })
 })

--- a/src/embedding/EmbeddingService.ts
+++ b/src/embedding/EmbeddingService.ts
@@ -168,13 +168,15 @@ export class OllamaEmbeddingService implements EmbeddingService {
         signal: controller.signal,
       })
       const value = response.ok
+      // TTL starts when the probe COMPLETES, not when it started — otherwise a probe
+      // that consumes its full timeout gets a correspondingly shortened TTL.
       this.availableCache = {
         value,
-        expiresAt: now + (value ? AVAILABILITY_CACHE_TTL_MS : AVAILABILITY_CACHE_TTL_FAIL_MS),
+        expiresAt: Date.now() + (value ? AVAILABILITY_CACHE_TTL_MS : AVAILABILITY_CACHE_TTL_FAIL_MS),
       }
       return value
     } catch {
-      this.availableCache = { value: false, expiresAt: now + AVAILABILITY_CACHE_TTL_FAIL_MS }
+      this.availableCache = { value: false, expiresAt: Date.now() + AVAILABILITY_CACHE_TTL_FAIL_MS }
       return false
     } finally {
       clearTimeout(timer)

--- a/src/embedding/EmbeddingService.ts
+++ b/src/embedding/EmbeddingService.ts
@@ -69,7 +69,23 @@ const DEFAULT_MODEL = 'nomic-embed-text'
 const DEFAULT_VERSION = 'v1'  // bump when pre-processing/model changes
 const DEFAULT_DIMENSIONS = 768
 const DEFAULT_TIMEOUT_MS = 5_000
+/**
+ * Reachability probe budget. Was hardcoded to 500 ms inline — 10x stricter than
+ * DEFAULT_TIMEOUT_MS above, which every real operation uses. That is fine against a
+ * loopback Ollama but fails against one on the LAN, where the round-trip alone is
+ * 115-133 ms and DNS can add several hundred more.
+ */
+const AVAILABILITY_TIMEOUT_MS = (() => {
+  const raw = process.env.OLLAMA_AVAILABILITY_TIMEOUT_MS
+  const parsed = raw ? Number.parseInt(raw, 10) : NaN
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 2_000
+})()
+/**
+ * Cache a success for a while, but expire a failure fast. A single slow probe used to
+ * disable embedding for a full 30 s.
+ */
 const AVAILABILITY_CACHE_TTL_MS = 30_000
+const AVAILABILITY_CACHE_TTL_FAIL_MS = 5_000
 
 export interface OllamaEmbeddingServiceConfig {
   /** Ollama base URL (defaults to env OLLAMA_BASE_URL or http://localhost:11434). */
@@ -145,17 +161,20 @@ export class OllamaEmbeddingService implements EmbeddingService {
     }
 
     const controller = new AbortController()
-    const timer = setTimeout(() => controller.abort(), 500)
+    const timer = setTimeout(() => controller.abort(), AVAILABILITY_TIMEOUT_MS)
 
     try {
       const response = await fetch(`${this.baseUrl}/api/tags`, {
         signal: controller.signal,
       })
       const value = response.ok
-      this.availableCache = { value, expiresAt: now + AVAILABILITY_CACHE_TTL_MS }
+      this.availableCache = {
+        value,
+        expiresAt: now + (value ? AVAILABILITY_CACHE_TTL_MS : AVAILABILITY_CACHE_TTL_FAIL_MS),
+      }
       return value
     } catch {
-      this.availableCache = { value: false, expiresAt: now + AVAILABILITY_CACHE_TTL_MS }
+      this.availableCache = { value: false, expiresAt: now + AVAILABILITY_CACHE_TTL_FAIL_MS }
       return false
     } finally {
       clearTimeout(timer)

--- a/src/inference/OllamaInference.ts
+++ b/src/inference/OllamaInference.ts
@@ -10,6 +10,35 @@ export interface EntityMention {
   aliases?: string[]
 }
 
+/**
+ * Timeout budgets. These were originally tuned for an Ollama running on loopback,
+ * where a reachability probe completes in ~1 ms and a model is always resident.
+ * Once Ollama moves to another host on the LAN, every one of them is too tight:
+ * a probe costs 100-150 ms, and the FIRST inference after a model is evicted pays
+ * a multi-second load. Each is overridable by env var so a slower host does not
+ * require a code change.
+ */
+const envMs = (name: string, fallback: number): number => {
+  const raw = process.env[name]
+  if (!raw) return fallback
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+/** Reachability probe. LAN round-trip measured at 115-133 ms; 200 ms left no margin. */
+const AVAILABILITY_TIMEOUT_MS = envMs('OLLAMA_AVAILABILITY_TIMEOUT_MS', 2_000)
+/** Storage classification. Cold qwen3:8b measured 5.2 s, warm ~1.7 s; 3 s truncated every cold call. */
+const CLASSIFY_TIMEOUT_MS = envMs('OLLAMA_CLASSIFY_TIMEOUT_MS', 8_000)
+/** Entity extraction — same cold-load exposure as classification. */
+const ENTITY_TIMEOUT_MS = envMs('OLLAMA_ENTITY_TIMEOUT_MS', 8_000)
+/**
+ * A positive result is stable and worth caching. A negative one must expire quickly:
+ * caching it for 30 s meant a single slow probe disabled LLM routing for every write
+ * in the following half-minute.
+ */
+const AVAILABILITY_CACHE_TTL_OK_MS = envMs('OLLAMA_AVAILABILITY_CACHE_OK_MS', 30_000)
+const AVAILABILITY_CACHE_TTL_FAIL_MS = envMs('OLLAMA_AVAILABILITY_CACHE_FAIL_MS', 5_000)
+
 export class OllamaInference {
   private availableCache: { value: boolean; expiresAt: number } | null = null
 
@@ -25,19 +54,25 @@ export class OllamaInference {
     }
 
     const controller = new AbortController()
-    const timer = setTimeout(() => controller.abort(), 200)
+    const timer = setTimeout(() => controller.abort(), AVAILABILITY_TIMEOUT_MS)
 
     try {
       const response = await fetch(`${this.baseUrl}/api/tags`, {
         signal: controller.signal,
       })
       const value = response.ok
-      this.availableCache = { value, expiresAt: now + 30_000 }
+      this.availableCache = {
+        value,
+        expiresAt: now + (value ? AVAILABILITY_CACHE_TTL_OK_MS : AVAILABILITY_CACHE_TTL_FAIL_MS),
+      }
       console.log(`[OllamaInference] availability check: ${value}`)
       return value
     } catch {
-      this.availableCache = { value: false, expiresAt: now + 30_000 }
-      console.warn('[OllamaInference] availability check failed — Ollama not reachable')
+      this.availableCache = { value: false, expiresAt: now + AVAILABILITY_CACHE_TTL_FAIL_MS }
+      console.warn(
+        `[OllamaInference] availability check failed — Ollama not reachable at ${this.baseUrl} ` +
+        `(timeout ${AVAILABILITY_TIMEOUT_MS}ms)`
+      )
       return false
     } finally {
       clearTimeout(timer)
@@ -58,7 +93,7 @@ Rules:
 
 Text: "${content.slice(0, 500)}"`
 
-    const raw = await this.callOllama(prompt, 3000)
+    const raw = await this.callOllama(prompt, CLASSIFY_TIMEOUT_MS)
     if (raw === null) {
       return null
     }
@@ -122,7 +157,7 @@ Candidates: ${JSON.stringify(candidates.slice(0, 30))}
 
 Text: "${content.slice(0, 600)}"`
 
-    const raw = await this.callOllama(prompt, 4000)
+    const raw = await this.callOllama(prompt, ENTITY_TIMEOUT_MS)
     if (raw === null) {
       return []
     }

--- a/src/inference/OllamaInference.ts
+++ b/src/inference/OllamaInference.ts
@@ -61,14 +61,17 @@ export class OllamaInference {
         signal: controller.signal,
       })
       const value = response.ok
+      // TTL starts when the probe COMPLETES, not when it started. A probe that
+      // consumes the full timeout would otherwise get a TTL shortened by however
+      // long it took — a 2s failed probe would cache for 3s instead of 5s.
       this.availableCache = {
         value,
-        expiresAt: now + (value ? AVAILABILITY_CACHE_TTL_OK_MS : AVAILABILITY_CACHE_TTL_FAIL_MS),
+        expiresAt: Date.now() + (value ? AVAILABILITY_CACHE_TTL_OK_MS : AVAILABILITY_CACHE_TTL_FAIL_MS),
       }
       console.log(`[OllamaInference] availability check: ${value}`)
       return value
     } catch {
-      this.availableCache = { value: false, expiresAt: now + AVAILABILITY_CACHE_TTL_FAIL_MS }
+      this.availableCache = { value: false, expiresAt: Date.now() + AVAILABILITY_CACHE_TTL_FAIL_MS }
       console.warn(
         `[OllamaInference] availability check failed — Ollama not reachable at ${this.baseUrl} ` +
         `(timeout ${AVAILABILITY_TIMEOUT_MS}ms)`


### PR DESCRIPTION
## Problem

Every Ollama timeout in KMSmcp was tuned for a **loopback** server, where a reachability probe costs ~1ms and the model is always resident. Once Ollama moved to another host on the LAN, all of them became too tight — and routing silently fell back to regex on every write.

The failure was invisible because the routing decision reads `regex, confidence=0.50` in *every* failure mode. Only latency distinguishes them.

## Measurements

Against Ollama on the LAN host, `qwen3:8b`:

| Operation | Measured | Old budget | Result |
|---|---|---|---|
| Reachability probe | 115–133ms | 200ms (`OllamaInference`) | almost no margin |
| Reachability probe | 115–133ms | 500ms (`EmbeddingService`) | 10× stricter than that class's own `DEFAULT_TIMEOUT_MS` |
| Classification | **5219ms cold**, ~1690ms warm | 3000ms | every cold call truncated |

## Changes

- `OllamaInference`: probe 200ms → 2000ms, classify 3000ms → 8000ms, entity extraction 4000ms → 8000ms
- `EmbeddingService`: probe 500ms → 2000ms
- All budgets overridable by env var (`OLLAMA_AVAILABILITY_TIMEOUT_MS`, `OLLAMA_CLASSIFY_TIMEOUT_MS`, `OLLAMA_ENTITY_TIMEOUT_MS`, …) so a slower host needs no code change
- **Split the availability cache TTL** — success still caches 30s, failure now expires after 5s. Previously one slow probe disabled LLM routing *and* embedding for the following half-minute.
- Probe failure log now names the URL and the exceeded budget

## Diagnostic note

For future debugging, `routingTime` in the `unified_store` response localises the fault:

- **~1–2ms** — host refused the connection outright (wrong URL)
- **~250ms** — host reached, probe timed out
- **~3000ms** — probe passed, classification hit its ceiling

## Tests

Two regression guards added:
1. The probe must survive a LAN-typical delay (asserts the `AbortSignal` has not fired after 600ms)
2. A negative availability result must expire quickly rather than persisting for the full success TTL

`406 passed, 19 suites` · typecheck clean.

## Out of scope (found, not fixed)

- `npm run lint` is broken repo-wide — ESLint finds no config file. Pre-existing, unrelated to this change.
- The Mem0 search leg fails on every call with a rejected filter shape (`Top-level key must be a logical operator or an allowed field`), silently returning nothing from that backend.
- `nomic-embed-text` was never pulled on the Ollama host, so embeddings 404'd and were silently skipped — fixed operationally, not in code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved availability checks with more reliable timeout handling and shorter recovery periods after failures.
  * Added clearer diagnostics for unavailable inference services.
  * Increased default timeouts for classification and entity extraction to reduce premature failures.

* **Configuration**
  * Added environment-based settings for availability probes, cache durations, and inference operation timeouts.

* **Tests**
  * Added coverage for probe timing and recovery after cached availability failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->