### PR TITLE
docs: correct the stale SparrowDB embedding-blocker note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,7 +237,42 @@ Each candidate in a `dedup_required` response now carries an `llm_relation` fiel
 
 **Cost & latency budget:** Haiku 4.5 with 5 s per-candidate timeout, single-word forced response (~12 tokens). LRU-cached at 1000 entries per process so repeated borderline calls in a session are free. Refuse-band candidates skip the LLM entirely.
 
-**Known limitation (upstream)**: As of sparrowdb 0.1.22, the Node.js binding does NOT expose parameter-binding for `execute()` (no `execute_with_params`), and the Cypher parser rejects list literals in `SET` / `CREATE`. This means `storeEmbedding`'s `SET k.embedding = [...]` write path silently fails — the HNSW index stays empty, and the dedup gate is inert in practice (it always finds 0 candidates and proceeds to a normal store). The gate logic, type guards, and threshold dispatch are all correct and will activate the moment the upstream binding gains either (a) `execute_with_params` for vector inserts, or (b) parser support for f32-list literals in SET. Tracked separately from DG-T1-B.
+**Embedding writes work — the gate is live.** (Re-verified 2026-07-31.) An earlier
+revision of this file claimed the opposite: that the Node binding had no
+`execute_with_params`, that `SET k.embedding = [...]` silently failed, that the HNSW
+index stayed empty and the dedup gate was inert. **Every part of that is now false**, and
+it was quoted as a live blocker for months after it stopped being true. Current state:
+
+- The binding exposes `executeWithParams`, `createVectorIndex`, `vectorSearch`,
+  `addToVectorIndex`, `hybridSearch`, `fulltextSearch`.
+- `storeEmbedding` (`src/storage/SparrowDBStorage.ts:481-489`) was migrated off the
+  list-literal path to parameter binding in `30285ef8` (PR #69).
+- The live store at `$SPARROWDB_PATH` (`~/.kms-sparrowdb-v2`) has a populated HNSW
+  index — hundreds of vectors against real `nomic-embed-text:v1` embedder IDs.
+
+Only the *legacy* literal form still fails, and nothing calls it any more:
+`SET k.embedding = [0.1, 0.2]` → `invalid argument: SET property value must be a
+literal or $parameter`. Use `executeWithParams` with `$emb`.
+
+**Two real caveats that DO apply:**
+
+1. **`package.json` declares `sparrowdb: ^0.1.20`, and that is fiction.** The npm
+   tarball ships a Linux ELF that cannot `dlopen` on darwin-arm64, and published
+   0.1.20/0.1.21 have *no vector API at all* — upgrading to them is a severe
+   regression. The working artifact is a local build produced by
+   `scripts/build-sparrowdb-node.sh` from `~/Dev/SparrowDB/npm/sparrowdb` (0.1.22,
+   unpublished), which overwrites `node_modules/sparrowdb/sparrowdb.node`. **A plain
+   `npm ci` silently breaks vector support** until someone re-runs the build script.
+
+2. **Reads return `null` unless `id(k)` is projected first.** `MATCH (k) RETURN k.id`
+   yields `null`; `MATCH (k) RETURN id(k), k.id` yields the value. `_ensureInternalIdMap`
+   is accidentally immune because it happens to project `id(k)` first — any new query
+   that doesn't will silently read nulls. (Relatedly, the "SparrowDB truncates strings
+   to 7 chars" comment near `SparrowDBStorage.ts:586` is a misdiagnosis: full UUIDs
+   round-trip intact.)
+
+Before repeating any claim in this section, verify it — that is exactly how the
+superseded version above survived so long.
 
 ## Best Practices
 


### PR DESCRIPTION
## Why this matters more than a docs tidy-up

`CLAUDE.md` carried a **"Known limitation (upstream)"** paragraph stating that embeddings could not be written to SparrowDB. It was cited — including by me, repeatedly, earlier today — as the live blocker gating **bi-temporal validity intervals, hybrid BM25+vector+graph retrieval, and cross-encoder reranking**.

It blocked work that was never actually blocked.

## Verified 2026-07-31

| Claim in the note | Reality |
|---|---|
| No `execute_with_params` | Binding exposes `executeWithParams`, `createVectorIndex`, `vectorSearch`, `addToVectorIndex`, `hybridSearch`, `fulltextSearch` |
| `storeEmbedding` silently fails | Migrated to parameter binding in `30285ef8` (PR #69), `SparrowDBStorage.ts:481-489` |
| HNSW index stays empty | Live store `~/.kms-sparrowdb-v2` has a populated index with real `nomic-embed-text:v1` embedder IDs |
| Dedup gate inert | Gate is live |

Only the *legacy* literal form still fails, and nothing calls it:
```
SET k.embedding = [0.1, 0.2]
→ invalid argument: SET property value must be a literal or $parameter
```

## Replaced with two caveats that DO apply

**1. `"sparrowdb": "^0.1.20"` in package.json is fiction.** The npm tarball ships a **Linux ELF that cannot `dlopen` on darwin-arm64**, and published 0.1.20/0.1.21 have **no vector API at all** — upgrading to them would be a severe regression. The working artifact is a local 0.1.22 build from `scripts/build-sparrowdb-node.sh`. **A plain `npm ci` silently breaks vector support.**

**2. Reads return `null` unless `id(k)` is projected first.** `MATCH (k) RETURN k.id` → `null`; `MATCH (k) RETURN id(k), k.id` → the value. `_ensureInternalIdMap` is accidentally immune because it projects `id(k)` first; new queries won't be. Also flags that the neighbouring "truncates strings to 7 chars" comment is a misdiagnosis — full UUIDs round-trip intact.

## Follow-ups this surfaces (not in this PR)

- **Backfill is ~25% done** — `src/scripts/backfill-hnsw-embeddings.ts` exists (PR #73) and has never completed a run
- **Pin the real dependency** — publish 0.1.22 or switch to `file:../SparrowDB/npm/sparrowdb`, so CI and fresh clones aren't silently broken
- **`OLLAMA_MODEL=qwen3:8b` in Doppler is a chat model, not an embedder** — harmless only because `EmbeddingService.ts:150` never reads that env var

Docs-only. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)