### PR TITLE
fix(search): surface graph relationships and damp long-entry bias

### DIFF
--- a/src/__tests__/GraphEdgeIndex.test.ts
+++ b/src/__tests__/GraphEdgeIndex.test.ts
@@ -1,0 +1,379 @@
+/**
+ * GraphEdgeIndex — the relationship read path for the SparrowDB graph backend.
+ *
+ * Regression cover for `unified_search` returning `relationships: []` on graph
+ * hits. The previous reader issued, per hit, one RELATED_TO query plus one
+ * ABOUT query for each of six hard-coded entity labels, so:
+ *
+ *   - only 2 of the graph's ~45 relationship types were ever read back. Every
+ *     typed edge `unified_store` writes (SOLVES, REQUIRES, SUPERSEDES,
+ *     IMPLEMENTS, …) went into the graph and never came out of it.
+ *   - only OUTGOING edges were followed, so an entry that other entries point
+ *     at — which is what `_createSemanticRelationships` produces, since it
+ *     links new → existing — reported no relationships at all.
+ *   - SparrowDB ignores a label predicate naming a label with no nodes, so the
+ *     six-label ABOUT loop returned each entity two or three times.
+ *   - `strength` was hard-coded null even where the edge property is readable.
+ *
+ * The fake binding below mirrors the real one's quirks that matter here:
+ * `RETURN type(r)` is not distinct, and endpoint ids can read back null.
+ */
+
+import {
+  GraphEdgeIndex,
+  decodeStrength,
+  DEFAULT_MAX_RELATIONSHIPS_PER_NODE,
+  type EdgeQueryExecutor
+} from '../storage/GraphEdgeIndex.js'
+
+type Edge = { from: string | null; type: string; to: string | null; strength?: number | null }
+
+interface FakeDbOptions {
+  /** Make `MATCH ()-[r]->() RETURN type(r)` throw, forcing the fallback type list. */
+  breakTypeDiscovery?: boolean
+  /** Make the `r.strength` projection throw, forcing the no-strength retry. */
+  breakStrengthProjection?: boolean
+  /** Make every query throw, simulating an unreadable graph. */
+  breakEverything?: boolean
+}
+
+class FakeDb implements EdgeQueryExecutor {
+  readonly queries: string[] = []
+
+  constructor(private edges: Edge[], private opts: FakeDbOptions = {}) {}
+
+  execute(cypher: string) {
+    this.queries.push(cypher)
+    if (this.opts.breakEverything) throw new Error('database is closed')
+
+    if (/RETURN type\(r\) AS rel/.test(cypher)) {
+      if (this.opts.breakTypeDiscovery) throw new Error('type(r) unsupported on this build')
+      // Deliberately NOT distinct — the real binding returns one row per edge.
+      return { columns: ['rel'], rows: this.edges.map(e => ({ rel: e.type })) }
+    }
+
+    const withStrength = cypher.match(
+      /^MATCH \(a\)-\[r:([A-Za-z0-9_]+)\]->\(b\) RETURN a\.id, b\.id, r\.strength$/
+    )
+    if (withStrength) {
+      if (this.opts.breakStrengthProjection) throw new Error('edge property projection unsupported')
+      return {
+        columns: ['a.id', 'b.id', 'r.strength'],
+        rows: this.matching(withStrength[1]).map(e => ({
+          'a.id': e.from,
+          'b.id': e.to,
+          'r.strength': e.strength ?? null
+        }))
+      }
+    }
+
+    const noStrength = cypher.match(/^MATCH \(a\)-\[:([A-Za-z0-9_]+)\]->\(b\) RETURN a\.id, b\.id$/)
+    if (noStrength) {
+      return {
+        columns: ['a.id', 'b.id'],
+        rows: this.matching(noStrength[1]).map(e => ({ 'a.id': e.from, 'b.id': e.to }))
+      }
+    }
+
+    throw new Error(`FakeDb received an unexpected query: ${cypher}`)
+  }
+
+  private matching(type: string): Edge[] {
+    return this.edges.filter(e => e.type === type)
+  }
+}
+
+const CONTENTS: Record<string, string> = {
+  'k-1': 'Ollama timeout budgets widened for a LAN Ollama',
+  'k-2': 'Ollama request budget spec',
+  'k-3': 'Retry policy for unreachable inference hosts',
+  richard_yaker: 'Richard Yaker'
+}
+
+function resolver(contents: Record<string, string> = CONTENTS) {
+  return (id: string) => (contents[id] === undefined ? undefined : { id, content: contents[id] })
+}
+
+function makeIndex(edges: Edge[], opts?: FakeDbOptions, contents?: Record<string, string>) {
+  const db = new FakeDb(edges, opts)
+  return { db, index: new GraphEdgeIndex(db, resolver(contents)) }
+}
+
+describe('GraphEdgeIndex — relationship reads', () => {
+  it('returns typed edges, not just RELATED_TO and ABOUT', () => {
+    const { index } = makeIndex([
+      { from: 'k-1', type: 'SOLVES', to: 'k-2', strength: 100 },
+      { from: 'k-1', type: 'SUPERSEDES', to: 'k-3', strength: 80 },
+      { from: 'k-1', type: 'RELATED_TO', to: 'k-2' },
+      { from: 'k-1', type: 'ABOUT', to: 'richard_yaker' }
+    ])
+
+    const rels = index.relationshipsFor('k-1')
+
+    expect(rels.map(r => r.relationship).sort()).toEqual([
+      'ABOUT',
+      'RELATED_TO',
+      'SOLVES',
+      'SUPERSEDES'
+    ])
+    expect(rels.every(r => r.direction === 'outgoing')).toBe(true)
+  })
+
+  it('includes inbound edges so a node that is only ever a target is not reported as unconnected', () => {
+    const { index } = makeIndex([
+      { from: 'k-1', type: 'RELATED_TO', to: 'k-2' },
+      { from: 'k-3', type: 'REFINES', to: 'k-2' }
+    ])
+
+    // k-2 has no outgoing edges at all — the old reader returned [] for it.
+    const rels = index.relationshipsFor('k-2')
+
+    expect(rels).toHaveLength(2)
+    expect(rels.every(r => r.direction === 'incoming')).toBe(true)
+    expect(rels.map(r => r.relatedNode).sort()).toEqual(['k-1', 'k-3'])
+  })
+
+  it('orders outgoing before incoming and labels each with its direction', () => {
+    const { index } = makeIndex([
+      { from: 'k-2', type: 'RELATED_TO', to: 'k-1' },
+      { from: 'k-1', type: 'SOLVES', to: 'k-3' }
+    ])
+
+    expect(index.relationshipsFor('k-1').map(r => [r.relationship, r.direction])).toEqual([
+      ['SOLVES', 'outgoing'],
+      ['RELATED_TO', 'incoming']
+    ])
+  })
+
+  it('decodes the 0-100 integer strength back into 0-1 and leaves absent strength null', () => {
+    const { index } = makeIndex([
+      { from: 'k-1', type: 'SOLVES', to: 'k-2', strength: 100 },
+      { from: 'k-1', type: 'REFINES', to: 'k-3', strength: 80 },
+      { from: 'k-1', type: 'ABOUT', to: 'richard_yaker', strength: null }
+    ])
+
+    const byType = Object.fromEntries(
+      index.relationshipsFor('k-1').map(r => [r.relationship, r.strength])
+    )
+
+    expect(byType.SOLVES).toBe(1)
+    expect(byType.REFINES).toBeCloseTo(0.8)
+    expect(byType.ABOUT).toBeNull()
+  })
+
+  it('resolves related content from the sidecar and falls back to the raw id', () => {
+    const { index } = makeIndex([
+      { from: 'k-1', type: 'ABOUT', to: 'richard_yaker' },
+      { from: 'k-1', type: 'ABOUT', to: 'not-in-sidecar' }
+    ])
+
+    const rels = index.relationshipsFor('k-1')
+
+    expect(rels[0]).toMatchObject({ relatedNode: 'richard_yaker', relatedContent: 'Richard Yaker' })
+    expect(rels[1]).toMatchObject({ relatedNode: 'not-in-sidecar', relatedContent: '' })
+  })
+
+  it('collapses parallel edges of the same type between the same pair', () => {
+    const { index } = makeIndex([
+      { from: 'k-1', type: 'ABOUT', to: 'richard_yaker' },
+      { from: 'k-1', type: 'ABOUT', to: 'richard_yaker' },
+      { from: 'k-1', type: 'ABOUT', to: 'richard_yaker' }
+    ])
+
+    expect(index.relationshipsFor('k-1')).toHaveLength(1)
+  })
+
+  it('keeps the same pair when the edges differ by type or direction', () => {
+    const { index } = makeIndex([
+      { from: 'k-1', type: 'SOLVES', to: 'k-2' },
+      { from: 'k-1', type: 'REFINES', to: 'k-2' },
+      { from: 'k-2', type: 'SOLVES', to: 'k-1' }
+    ])
+
+    expect(index.relationshipsFor('k-1')).toHaveLength(3)
+  })
+
+  it('caps the relationships returned for a hub node', () => {
+    const edges: Edge[] = []
+    const contents: Record<string, string> = { hub: 'hub node' }
+    for (let i = 0; i < 200; i++) {
+      edges.push({ from: `n-${i}`, type: 'ABOUT', to: 'hub' })
+      contents[`n-${i}`] = `entry ${i}`
+    }
+    const { index } = makeIndex(edges, undefined, contents)
+
+    expect(index.relationshipsFor('hub')).toHaveLength(DEFAULT_MAX_RELATIONSHIPS_PER_NODE)
+  })
+
+  it('skips edges whose endpoint id reads back null', () => {
+    const { index } = makeIndex([
+      { from: 'k-1', type: 'RELATED_TO', to: null },
+      { from: null, type: 'RELATED_TO', to: 'k-1' },
+      { from: 'k-1', type: 'SOLVES', to: 'k-2' }
+    ])
+
+    const rels = index.relationshipsFor('k-1')
+
+    expect(rels).toHaveLength(1)
+    expect(rels[0].relationship).toBe('SOLVES')
+  })
+
+  it('returns [] for a node with no edges', () => {
+    const { index } = makeIndex([{ from: 'k-1', type: 'SOLVES', to: 'k-2' }])
+
+    expect(index.relationshipsFor('k-3')).toEqual([])
+  })
+})
+
+describe('GraphEdgeIndex — degraded bindings', () => {
+  it('de-duplicates the non-distinct type(r) result', () => {
+    const { db, index } = makeIndex([
+      { from: 'k-1', type: 'RELATED_TO', to: 'k-2' },
+      { from: 'k-1', type: 'RELATED_TO', to: 'k-3' },
+      { from: 'k-2', type: 'SOLVES', to: 'k-3' }
+    ])
+
+    expect(index.discoverRelationshipTypes().sort()).toEqual(['RELATED_TO', 'SOLVES'])
+
+    index.build()
+    // One edge query per distinct type, not per edge.
+    expect(db.queries.filter(q => q.startsWith('MATCH (a)'))).toHaveLength(2)
+  })
+
+  it('rejects a relationship type that is not a bare identifier', () => {
+    const { index } = makeIndex([
+      { from: 'k-1', type: 'RELATED_TO', to: 'k-2' },
+      { from: 'k-1', type: 'BAD]->() DELETE (x', to: 'k-3' }
+    ])
+
+    expect(index.discoverRelationshipTypes()).toEqual(['RELATED_TO'])
+  })
+
+  it('falls back to the known type list when type(r) discovery is unsupported', () => {
+    const { index } = makeIndex(
+      [
+        { from: 'k-1', type: 'RELATED_TO', to: 'k-2' },
+        { from: 'k-1', type: 'SOLVES', to: 'k-3' }
+      ],
+      { breakTypeDiscovery: true }
+    )
+
+    // SOLVES is unreachable without discovery, but the reader must not fail closed.
+    expect(index.relationshipsFor('k-1').map(r => r.relationship)).toEqual(['RELATED_TO'])
+  })
+
+  it('retries without the strength projection when the binding rejects edge properties', () => {
+    const { index } = makeIndex(
+      [{ from: 'k-1', type: 'SOLVES', to: 'k-2', strength: 100 }],
+      { breakStrengthProjection: true }
+    )
+
+    const rels = index.relationshipsFor('k-1')
+
+    expect(rels).toHaveLength(1)
+    expect(rels[0].strength).toBeNull()
+  })
+
+  it('returns [] rather than throwing when the graph is unreadable', () => {
+    const { index } = makeIndex([{ from: 'k-1', type: 'SOLVES', to: 'k-2' }], {
+      breakEverything: true
+    })
+
+    expect(index.relationshipsFor('k-1')).toEqual([])
+  })
+})
+
+describe('GraphEdgeIndex — lifecycle', () => {
+  it('builds once and serves later reads from memory', () => {
+    const { db, index } = makeIndex([{ from: 'k-1', type: 'RELATED_TO', to: 'k-2' }])
+
+    index.relationshipsFor('k-1')
+    const afterFirst = db.queries.length
+    expect(afterFirst).toBeGreaterThan(0)
+    expect(index.isBuilt).toBe(true)
+
+    index.relationshipsFor('k-1')
+    index.relationshipsFor('k-2')
+
+    expect(db.queries.length).toBe(afterFirst)
+  })
+
+  it('picks up an edge added after the build without rescanning the graph', () => {
+    const { db, index } = makeIndex([])
+
+    expect(index.relationshipsFor('k-1')).toEqual([])
+    const afterBuild = db.queries.length
+
+    index.addEdge('k-1', 'k-2', 'SOLVES', 0.9)
+
+    expect(index.relationshipsFor('k-1')).toEqual([
+      {
+        relationship: 'SOLVES',
+        relatedNode: 'k-2',
+        relatedContent: 'Ollama request budget spec',
+        direction: 'outgoing',
+        strength: 0.9
+      }
+    ])
+    // Visible from the other end too, and no re-scan.
+    expect(index.relationshipsFor('k-2')[0].direction).toBe('incoming')
+    expect(db.queries.length).toBe(afterBuild)
+  })
+
+  it('ignores addEdge before the index is built, so the build still sees the truth', () => {
+    const { index } = makeIndex([{ from: 'k-1', type: 'SOLVES', to: 'k-2' }])
+
+    index.addEdge('k-1', 'k-3', 'REFINES', 1)
+
+    // Not double-counted: the build reads the graph, which is the source of truth.
+    expect(index.relationshipsFor('k-1').map(r => r.relationship)).toEqual(['SOLVES'])
+  })
+
+  it('drops both sides of every edge when a node is removed', () => {
+    const { index } = makeIndex([
+      { from: 'k-1', type: 'RELATED_TO', to: 'k-2' },
+      { from: 'k-3', type: 'REFINES', to: 'k-1' },
+      { from: 'k-3', type: 'SOLVES', to: 'k-2' }
+    ])
+
+    expect(index.relationshipsFor('k-1')).toHaveLength(2)
+
+    index.removeNode('k-1')
+
+    expect(index.relationshipsFor('k-1')).toEqual([])
+    expect(index.relationshipsFor('k-2').map(r => r.relatedNode)).toEqual(['k-3'])
+    expect(index.relationshipsFor('k-3').map(r => r.relatedNode)).toEqual(['k-2'])
+  })
+
+  it('rebuilds after a reset', () => {
+    const { db, index } = makeIndex([{ from: 'k-1', type: 'RELATED_TO', to: 'k-2' }])
+
+    index.relationshipsFor('k-1')
+    const afterFirst = db.queries.length
+
+    index.reset()
+    expect(index.isBuilt).toBe(false)
+
+    expect(index.relationshipsFor('k-1')).toHaveLength(1)
+    expect(db.queries.length).toBeGreaterThan(afterFirst)
+  })
+})
+
+describe('decodeStrength', () => {
+  it.each([
+    [100, 1],
+    [80, 0.8],
+    [0, 0]
+  ])('maps the stored integer %p to %p', (raw, expected) => {
+    expect(decodeStrength(raw)).toBeCloseTo(expected)
+  })
+
+  it('clamps values outside the stored range', () => {
+    expect(decodeStrength(400)).toBe(1)
+    expect(decodeStrength(-50)).toBe(0)
+  })
+
+  it.each([null, undefined, 'not a number', NaN])('returns null for %p', raw => {
+    expect(decodeStrength(raw)).toBeNull()
+  })
+})

--- a/src/__tests__/UnifiedSearchTool.dedup.test.ts
+++ b/src/__tests__/UnifiedSearchTool.dedup.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Cross-backend deduplication tests for UnifiedSearchTool.
+ *
+ * `unified_store` dual-writes one entry to graph + mem0 + mongodb under a single id,
+ * so the same fact arrives at dedup 2-3 times. The copies differ in ways that matter:
+ * only the graph copy carries `relationships`, and `confidence` means different things
+ * per backend (graph = lexical match score < 1; mongodb = stored author confidence = 1).
+ *
+ * The old implementation kept "the highest confidence copy", which compared those two
+ * different quantities and so reliably discarded the graph copy — the only one with
+ * relationships. Symptom: `sources: {graph: 8}` alongside `relationships: []` on every
+ * result. These tests pin the merge behaviour that replaced it.
+ */
+
+import { UnifiedSearchTool } from '../tools/UnifiedSearchTool.js'
+
+const tool = new UnifiedSearchTool({} as any, {} as any)
+const dedupe = (results: any[]) => (tool as any).deduplicateResults(results)
+
+const graphCopy = (over: any = {}) => ({
+  id: 'shared-id-1',
+  content: 'Ollama classify timeout raised to 8000ms',
+  confidence: 0.6,                     // lexical match score
+  sourceSystem: 'graph',
+  relationships: [{ type: 'SOLVES', targetId: 'other-id', strength: 0.9 }],
+  ...over,
+})
+
+const mongoCopy = (over: any = {}) => ({
+  id: 'shared-id-1',
+  content: 'Ollama classify timeout raised to 8000ms',
+  confidence: 1,                       // stored author confidence
+  sourceSystem: 'mongodb',
+  // note: no `relationships` field at all
+  ...over,
+})
+
+describe('UnifiedSearchTool.deduplicateResults', () => {
+  it('keeps relationships when the mongo copy outranks the graph copy on confidence', () => {
+    // The regression case. Mongo's stored confidence (1) beats the graph's lexical
+    // score (0.6), so the old code kept mongo and silently dropped every relationship.
+    const [out] = dedupe([graphCopy(), mongoCopy()])
+    expect(out.relationships).toHaveLength(1)
+    expect(out.relationships[0].type).toBe('SOLVES')
+  })
+
+  it('keeps relationships regardless of arrival order', () => {
+    const [a] = dedupe([mongoCopy(), graphCopy()])
+    const [b] = dedupe([graphCopy(), mongoCopy()])
+    expect(a.relationships).toHaveLength(1)
+    expect(b.relationships).toHaveLength(1)
+  })
+
+  it('collapses three backend copies of one entry into a single result', () => {
+    const mem0Copy = { id: 'shared-id-1', content: 'Ollama classify timeout raised to 8000ms', confidence: 0.8, sourceSystem: 'mem0' }
+    const out = dedupe([graphCopy(), mongoCopy(), mem0Copy])
+    expect(out).toHaveLength(1)
+    expect(out[0].relationships).toHaveLength(1)
+  })
+
+  it('records every backend the entry came from', () => {
+    const [out] = dedupe([graphCopy(), mongoCopy()])
+    expect(out._sourceSystems.sort()).toEqual(['graph', 'mongodb'])
+  })
+
+  it('keeps the stored confidence, not the lexical match score', () => {
+    const [out] = dedupe([graphCopy(), mongoCopy()])
+    expect(out.confidence).toBe(1)
+  })
+
+  it('prefers the longer content when a backend stores a truncated projection', () => {
+    const full = mongoCopy({ content: 'Ollama classify timeout raised to 8000ms after measuring 5219ms cold load' })
+    const [out] = dedupe([graphCopy(), full])
+    expect(out.content).toContain('5219ms cold load')
+    // …and still keeps the relationships from the shorter graph copy
+    expect(out.relationships).toHaveLength(1)
+  })
+
+  it('does not merge genuinely distinct entries', () => {
+    const other = graphCopy({ id: 'different-id', content: 'unrelated fact' })
+    expect(dedupe([graphCopy(), other])).toHaveLength(2)
+  })
+
+  it('falls back to a content hash when an entry has no id', () => {
+    const a = { content: 'same text', confidence: 0.5, sourceSystem: 'graph' }
+    const b = { content: 'same text', confidence: 0.9, sourceSystem: 'mongodb' }
+    expect(dedupe([a, b])).toHaveLength(1)
+  })
+
+  it('handles an empty input', () => {
+    expect(dedupe([])).toEqual([])
+  })
+
+  it('does not invent a relationships field when no backend has one', () => {
+    const [out] = dedupe([mongoCopy(), mongoCopy({ sourceSystem: 'mem0', confidence: 0.7 })])
+    expect(out.relationships).toBeUndefined()
+  })
+})

--- a/src/__tests__/UnifiedSearchTool.dedup.test.ts
+++ b/src/__tests__/UnifiedSearchTool.dedup.test.ts
@@ -76,6 +76,25 @@ describe('UnifiedSearchTool.deduplicateResults', () => {
     expect(out.relationships).toHaveLength(1)
   })
 
+  it('keeps metadata.entityRefs when the copy that has them loses on content length', () => {
+    // Same failure mode as the relationships bug: entityRefs drive linkedEntityIds and
+    // expandWithEntityContext, so losing them on merge silently breaks entity linking.
+    const short = graphCopy({ metadata: { entityRefs: ['richard_yaker'] } })
+    const long = mongoCopy({
+      content: 'Ollama classify timeout raised to 8000ms after measuring 5219ms cold load',
+      metadata: {}
+    })
+    const [out] = dedupe([short, long])
+    expect(out.metadata.entityRefs).toEqual(['richard_yaker'])
+  })
+
+  it('unions entityRefs present on both copies without duplicates', () => {
+    const a = graphCopy({ metadata: { entityRefs: ['richard_yaker', 'susan_yaker'] } })
+    const b = mongoCopy({ metadata: { entityRefs: ['susan_yaker', 'tyler_sue_child'] } })
+    const [out] = dedupe([a, b])
+    expect(out.metadata.entityRefs.sort()).toEqual(['richard_yaker', 'susan_yaker', 'tyler_sue_child'])
+  })
+
   it('does not merge genuinely distinct entries', () => {
     const other = graphCopy({ id: 'different-id', content: 'unrelated fact' })
     expect(dedupe([graphCopy(), other])).toHaveLength(2)

--- a/src/__tests__/UnifiedSearchTool.ranking.test.ts
+++ b/src/__tests__/UnifiedSearchTool.ranking.test.ts
@@ -140,3 +140,42 @@ describe('UnifiedSearchTool ranking', () => {
     })
   })
 })
+
+describe('UnifiedSearchTool length normalisation', () => {
+  const relevance = (content: string, query: string) => (tool as any).calculateRelevance(content, query)
+  const rank = (results: any[], query: string) => (tool as any).rankResults(results, query)
+  const daysAgo = (n: number) => new Date(Date.now() - n * 86_400_000).toISOString()
+
+  it('does not penalise a short, precisely on-topic entry', () => {
+    const short = 'Ollama classify timeout raised to 8000ms.'
+    expect(relevance(short, 'Ollama classify timeout')).toBeGreaterThan(0.8)
+  })
+
+  it('damps a long multi-topic note that merely mentions the terms', () => {
+    // The "everything I did today" shape: one incidental mention buried in 3k chars.
+    const megaNote = 'Session log. ' + 'Unrelated work on invoices and scheduling. '.repeat(60) +
+      'Also touched Ollama classify timeout. ' + 'More unrelated notes about branding. '.repeat(20)
+    const short = 'Ollama classify timeout raised to 8000ms.'
+    expect(relevance(megaNote, 'Ollama classify timeout')).toBeLessThan(relevance(short, 'Ollama classify timeout'))
+  })
+
+  it('a short older exact match outranks a long same-day note — the baseline failure', () => {
+    // Previously the mega-note won on recency alone despite being off-topic.
+    const megaNote = {
+      content: 'Session log. ' + 'Assorted unrelated work across many projects. '.repeat(70) +
+               'Ollama classify timeout mentioned once. ',
+      confidence: 1, timestamp: daysAgo(0),
+    }
+    const precise = {
+      content: 'Ollama classify timeout raised from 3000ms to 8000ms.',
+      confidence: 1, timestamp: daysAgo(45),
+    }
+    const ranked = rank([megaNote, precise], 'Ollama classify timeout')
+    expect(ranked[0].content).toContain('raised from 3000ms')
+  })
+
+  it('damping is bounded — a long but genuinely on-topic entry is not buried', () => {
+    const longOnTopic = 'Ollama classify timeout. '.repeat(150)
+    expect(relevance(longOnTopic, 'Ollama classify timeout')).toBeGreaterThan(0.55)
+  })
+})

--- a/src/storage/GraphEdgeIndex.ts
+++ b/src/storage/GraphEdgeIndex.ts
@@ -1,0 +1,259 @@
+/**
+ * Whole-graph adjacency index for the SparrowDB graph backend.
+ *
+ * Exists because reading relationships one node at a time was both incomplete
+ * and slow. The previous reader issued, per search hit, one RELATED_TO query
+ * plus one ABOUT query for each of six hard-coded entity labels, which meant:
+ *
+ *   - Only two relationship types were ever read back. Every typed edge
+ *     `unified_store` writes — SOLVES, REQUIRES, SUPERSEDES, IMPLEMENTS, and
+ *     ~40 more in the live store — went into the graph and never came out.
+ *   - Only outgoing edges were followed. `_createSemanticRelationships` links
+ *     new → existing, so the entries everything else references had no outgoing
+ *     edges and reported no relationships at all.
+ *   - SparrowDB ignores a label predicate that names a label with no nodes, so
+ *     `->(e:Project)` also matched Person and Technology nodes and the six-label
+ *     loop returned each entity two or three times.
+ *   - ~70 Cypher round-trips per search (≈7 s against the live store).
+ *
+ * This builds the adjacency once — one query per relationship type, a fixed
+ * cost independent of result count — and then answers from memory, maintaining
+ * itself incrementally as edges are created and nodes deleted.
+ *
+ * Kept separate from SparrowDBStorage so it can be unit-tested: that module
+ * uses `import.meta.url` at the top level, which the CommonJS-mode test runner
+ * cannot parse, so nothing that imports it is reachable from a test.
+ */
+
+/** The subset of the SparrowDB binding this index needs. */
+export interface EdgeQueryExecutor {
+  execute(cypher: string): { columns: string[]; rows: Array<Record<string, unknown>> }
+}
+
+/** Resolves a node id to its sidecar entry, for relationship content previews. */
+export type EntryResolver = (id: string) => { id: string; content: string } | undefined
+
+/** One directed edge, as seen from one of its endpoints. */
+interface EdgeRef {
+  type: string
+  /** The id at the other end from the node this ref is keyed under. */
+  other: string
+  /** Strength in [0,1], or null when the edge carries no strength property. */
+  strength: number | null
+}
+
+/** A relationship as returned to search callers. */
+export interface GraphRelationship {
+  relationship: string
+  relatedNode: string
+  relatedContent: string
+  direction: 'outgoing' | 'incoming'
+  strength: number | null
+}
+
+export interface GraphEdgeIndexOptions {
+  /**
+   * Cap on relationships returned for one node. Entity hub nodes (the Person
+   * node that hundreds of entries are ABOUT) would otherwise dominate the MCP
+   * response budget and push real results out via response truncation.
+   */
+  maxRelationshipsPerNode?: number
+  /** Optional debug sink; defaults to no-op so this module stays dependency-free. */
+  debug?: (message: string) => void
+}
+
+/** Relationship types assumed when `type(r)` discovery is unavailable. */
+export const FALLBACK_RELATIONSHIP_TYPES = ['RELATED_TO', 'ABOUT']
+
+export const DEFAULT_MAX_RELATIONSHIPS_PER_NODE = 25
+
+/**
+ * Relationship types are interpolated straight into Cypher, so anything coming
+ * back from `type(r)` must be a bare identifier first. The graph holds types
+ * imported from Neo4j alongside ones produced by SparrowDBStorage's sanitiser;
+ * a value that somehow escaped that sanitiser must not reach the parser.
+ */
+const SAFE_TYPE = /^[A-Za-z_][A-Za-z0-9_]*$/
+
+export class GraphEdgeIndex {
+  private out = new Map<string, EdgeRef[]>()
+  private in = new Map<string, EdgeRef[]>()
+  private built = false
+  private readonly maxPerNode: number
+  private readonly debug: (message: string) => void
+
+  constructor(
+    private readonly db: EdgeQueryExecutor,
+    private readonly resolveEntry: EntryResolver,
+    options: GraphEdgeIndexOptions = {}
+  ) {
+    this.maxPerNode = options.maxRelationshipsPerNode ?? DEFAULT_MAX_RELATIONSHIPS_PER_NODE
+    this.debug = options.debug ?? (() => {})
+  }
+
+  /** True once the adjacency has been read out of the graph. */
+  get isBuilt(): boolean {
+    return this.built
+  }
+
+  /**
+   * Every relationship type present in the graph.
+   *
+   * `MATCH ()-[r]->() RETURN type(r)` is not actually distinct in this binding
+   * (one row per edge), so de-duplication happens here.
+   */
+  discoverRelationshipTypes(): string[] {
+    try {
+      const result = this.db.execute(`MATCH ()-[r]->() RETURN type(r) AS rel`)
+      const seen = new Set<string>()
+      for (const row of result.rows) {
+        const type = String(row['rel'] ?? '').trim()
+        if (type && SAFE_TYPE.test(type)) seen.add(type)
+      }
+      if (seen.size > 0) return Array.from(seen)
+    } catch (error) {
+      this.debug(`type(r) discovery unavailable, using fallback types: ${error}`)
+    }
+    return [...FALLBACK_RELATIONSHIP_TYPES]
+  }
+
+  /** Read the adjacency out of the graph. Idempotent — a no-op once built. */
+  build(): void {
+    if (this.built) return
+
+    const out = new Map<string, EdgeRef[]>()
+    const inc = new Map<string, EdgeRef[]>()
+    let edgeCount = 0
+
+    for (const type of this.discoverRelationshipTypes()) {
+      for (const row of this.readEdges(type)) {
+        const from = row['a.id']
+        const to = row['b.id']
+        // A node whose id property reads back null can't be joined to a sidecar
+        // entry, so an edge naming one is not addressable by any caller.
+        if (from === null || from === undefined || to === null || to === undefined) continue
+        const strength = decodeStrength(row['r.strength'])
+        push(out, String(from), { type, other: String(to), strength })
+        push(inc, String(to), { type, other: String(from), strength })
+        edgeCount++
+      }
+    }
+
+    this.out = out
+    this.in = inc
+    this.built = true
+    this.debug(`edge index built: ${edgeCount} edges across ${out.size} source nodes`)
+  }
+
+  /**
+   * Edges of one type. Edge properties are readable on builds that support them
+   * and come back null where they aren't; if the projection itself is rejected
+   * we retry without it rather than dropping the type entirely.
+   */
+  private readEdges(type: string): Array<Record<string, unknown>> {
+    try {
+      return this.db.execute(`MATCH (a)-[r:${type}]->(b) RETURN a.id, b.id, r.strength`).rows
+    } catch {
+      try {
+        return this.db.execute(`MATCH (a)-[:${type}]->(b) RETURN a.id, b.id`).rows
+      } catch (error) {
+        this.debug(`skipping relationship type ${type}: ${error}`)
+        return []
+      }
+    }
+  }
+
+  /** Discard the adjacency; the next read rebuilds it. */
+  reset(): void {
+    this.out = new Map()
+    this.in = new Map()
+    this.built = false
+  }
+
+  /**
+   * Record a newly created edge rather than discarding the index. Invalidating
+   * would force a full rebuild on the next search, so a store/search interleave
+   * would pay the build cost over and over.
+   */
+  addEdge(sourceId: string, targetId: string, type: string, strength: number | null): void {
+    if (!this.built) return
+    push(this.out, sourceId, { type, other: targetId, strength })
+    push(this.in, targetId, { type, other: sourceId, strength })
+  }
+
+  /** Drop every edge incident to `nodeId` (mirrors a DETACH DELETE). */
+  removeNode(nodeId: string): void {
+    if (!this.built) return
+    this.out.delete(nodeId)
+    this.in.delete(nodeId)
+    prune(this.out, nodeId)
+    prune(this.in, nodeId)
+  }
+
+  /**
+   * Relationships incident to `nodeId`, outgoing first, then incoming.
+   *
+   * Returns [] rather than throwing when the graph is unreadable — a search hit
+   * with no relationship data is degraded, but a search that fails outright is
+   * broken.
+   */
+  relationshipsFor(nodeId: string): GraphRelationship[] {
+    try {
+      this.build()
+    } catch (error) {
+      this.debug(`edge index build failed: ${error}`)
+      return []
+    }
+
+    const relationships: GraphRelationship[] = []
+    const seen = new Set<string>()
+
+    const add = (ref: EdgeRef, direction: 'outgoing' | 'incoming') => {
+      if (!ref.other) return
+      if (relationships.length >= this.maxPerNode) return
+      // Parallel edges of the same type between the same pair are duplicates to
+      // a reader, and re-storing an entry can create them.
+      const key = `${direction}:${ref.type}:${ref.other}`
+      if (seen.has(key)) return
+      seen.add(key)
+      const target = this.resolveEntry(ref.other)
+      relationships.push({
+        relationship: ref.type,
+        relatedNode: target?.id ?? ref.other,
+        relatedContent: (target?.content ?? '').slice(0, 80),
+        direction,
+        strength: ref.strength
+      })
+    }
+
+    for (const ref of this.out.get(nodeId) ?? []) add(ref, 'outgoing')
+    for (const ref of this.in.get(nodeId) ?? []) add(ref, 'incoming')
+
+    return relationships
+  }
+}
+
+function push(map: Map<string, EdgeRef[]>, key: string, ref: EdgeRef): void {
+  const list = map.get(key)
+  if (list) list.push(ref)
+  else map.set(key, [ref])
+}
+
+function prune(map: Map<string, EdgeRef[]>, nodeId: string): void {
+  for (const [key, list] of map) {
+    const kept = list.filter(e => e.other !== nodeId)
+    if (kept.length === 0) map.delete(key)
+    else if (kept.length !== list.length) map.set(key, kept)
+  }
+}
+
+/**
+ * SparrowDBStorage stores strength as an integer 0–100 because SparrowDB panics
+ * on float edge properties (SparrowDB#229). Undo that here.
+ */
+export function decodeStrength(raw: unknown): number | null {
+  if (raw === null || raw === undefined) return null
+  const n = typeof raw === 'number' ? raw : Number(raw)
+  if (!Number.isFinite(n)) return null
+  return Math.min(1, Math.max(0, n / 100))
+}

--- a/src/storage/SparrowDBStorage.ts
+++ b/src/storage/SparrowDBStorage.ts
@@ -308,11 +308,22 @@ export class SparrowDBStorage implements StorageSystem {
     logger.debug(`⚡ Storing in SparrowDB: ${knowledge.id}`)
 
     // Delete any existing node (upsert via DELETE+CREATE, since MERGE+SET is unsupported).
+    // Mirrors delete(): SparrowDB refuses to DELETE a node with incident edges, so
+    // relationships must go first or the DELETE below throws (silently, into this
+    // catch), the stale node survives, and the CREATE further down duplicates it
+    // under the same id. removeNode() then keeps the in-memory adjacency in sync
+    // with what was just deleted from the graph.
+    try {
+      this.db.execute(
+        `MATCH (k:Knowledge {id: ${cypherStr(knowledge.id)}})-[r]-() DELETE r`
+      )
+    } catch { /* may have no relationships */ }
     try {
       this.db.execute(
         `MATCH (k:Knowledge {id: ${cypherStr(knowledge.id)}}) DELETE k`
       )
     } catch { /* node may not exist */ }
+    this._edges().removeNode(knowledge.id)
 
     const ts = knowledge.timestamp instanceof Date
       ? knowledge.timestamp.toISOString()

--- a/src/storage/SparrowDBStorage.ts
+++ b/src/storage/SparrowDBStorage.ts
@@ -49,6 +49,7 @@ import { join, dirname } from 'path'
 import { fileURLToPath } from 'url'
 import { PENDING_EMBEDDING_KEY, PENDING_EMBEDDER_ID_KEY } from '../embedding/EmbeddingService.js'
 import { computeFingerprint } from '../dedup/Fingerprint.js'
+import { GraphEdgeIndex } from './GraphEdgeIndex.js'
 import { StorageSystem, UnifiedKnowledge, KnowledgeQuery, KnownPersonEntry, KnownPeopleConfig, KnowledgeFlag } from '../types/index.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -206,6 +207,12 @@ export class SparrowDBStorage implements StorageSystem {
   // "graph-only" rather than crashing the store path.
   private vectorIndexAvailable = false
 
+  // Whole-graph adjacency, built lazily on first relationship read and then
+  // maintained incrementally. Replaces a per-node, per-label query fan-out that
+  // cost ~7 Cypher round-trips per search hit while only ever seeing two of the
+  // graph's relationship types. See GraphEdgeIndex.
+  private edgeIndex: GraphEdgeIndex | null = null
+
   constructor(config?: SparrowDBConfig) {
     this.dbPath =
       config?.dbPath ||
@@ -225,6 +232,10 @@ export class SparrowDBStorage implements StorageSystem {
     }
     const native = loadNativeBinding()
     this.db = native.SparrowDB.open(this.dbPath)
+
+    // A re-initialize points at a different handle — the adjacency index built
+    // from the previous one no longer describes this graph.
+    this.edgeIndex = null
 
     // Load content sidecar
     this._loadSidecar()
@@ -753,6 +764,7 @@ export class SparrowDBStorage implements StorageSystem {
         `MATCH (k:Knowledge {id: ${cypherStr(id)}}) DELETE k`
       )
     } catch { /* node may not exist */ }
+    this._edges().removeNode(id)
 
     if (hadEntry) {
       this.contentIndex.delete(id)
@@ -1429,6 +1441,7 @@ export class SparrowDBStorage implements StorageSystem {
           `(e {id: ${cypherStr(targetId)}}) ` +
           `CREATE (k)-[:ABOUT {strength: 100}]->(e)`
         )
+        this._edges().addEdge(sourceId, targetId, 'ABOUT', 1)
       } catch (error) {
         logger.warn(`⚠️ SparrowDB createAboutRelationships ${sourceId} → ${targetId}:`, error)
       }
@@ -1499,6 +1512,12 @@ export class SparrowDBStorage implements StorageSystem {
         `(b:Knowledge {id: ${cypherStr(targetId)}}) ` +
         `CREATE (a)-[:${safeRelType}${props}]->(b)`
       )
+      this._edges().addEdge(
+        sourceId,
+        targetId,
+        safeRelType,
+        strength !== undefined && strength >= 0 && strength <= 1 ? strength : null
+      )
     } catch (error) {
       logger.warn(`⚠️ SparrowDB createRelationship ${relationshipType}:`, error)
     }
@@ -1524,45 +1543,30 @@ export class SparrowDBStorage implements StorageSystem {
     }
   }
 
-  private async _getRelationships(nodeId: string): Promise<any[]> {
-    const relationships: any[] = []
-    try {
-      const out = this.db.execute(
-        `MATCH (a:Knowledge {id: ${cypherStr(nodeId)}})-[:RELATED_TO]->(b:Knowledge) ` +
-        `RETURN b.id`
+  /**
+   * The adjacency index, created on first use so it always wraps the current
+   * db handle (initialize() may replace it).
+   */
+  private _edges(): GraphEdgeIndex {
+    if (!this.edgeIndex) {
+      this.edgeIndex = new GraphEdgeIndex(
+        this.db,
+        (id: string) => this._findEntryByPrefix(id),
+        { debug: (m: string) => logger.debug(`⚡ SparrowDB ${m}`) }
       )
-      for (const row of out.rows) {
-        const rawId = String(row['b.id'] ?? '')
-        const target = this._findEntryByPrefix(rawId)
-        relationships.push({
-          relationship: 'RELATED_TO',
-          relatedNode: target?.id ?? rawId,
-          relatedContent: (target?.content ?? '').slice(0, 80),
-          strength: null
-        })
-      }
-
-      // ABOUT links to entity labels.
-      for (const label of ['Person', 'Organization', 'Project', 'Technology', 'Concept', 'Service']) {
-        try {
-          const about = this.db.execute(
-            `MATCH (k:Knowledge {id: ${cypherStr(nodeId)}})-[:ABOUT]->(e:${label}) ` +
-            `RETURN e.id, e.name`
-          )
-          for (const row of about.rows) {
-            relationships.push({
-              relationship: 'ABOUT',
-              relatedNode: String(row['e.id'] ?? ''),
-              relatedContent: String(row['e.name'] ?? ''),
-              strength: null
-            })
-          }
-        } catch { continue }
-      }
-    } catch (error) {
-      logger.warn('⚠️ SparrowDB _getRelationships error:', error)
     }
-    return relationships.filter(r => r.relatedNode)
+    return this.edgeIndex
+  }
+
+  /**
+   * Relationships incident to `nodeId`, outgoing first, then incoming.
+   *
+   * See GraphEdgeIndex for why this reads a whole-graph adjacency rather than
+   * querying per node: the per-node reader saw only two of the graph's ~45
+   * relationship types and only followed edges outward.
+   */
+  private async _getRelationships(nodeId: string): Promise<any[]> {
+    return this._edges().relationshipsFor(nodeId)
   }
 
   // -------------------------------------------------------------------------

--- a/src/tools/UnifiedSearchTool.ts
+++ b/src/tools/UnifiedSearchTool.ts
@@ -411,19 +411,64 @@ export class UnifiedSearchTool {
   /**
    * Remove duplicate results based on content similarity
    */
+  /**
+   * Collapse the same knowledge item returned by more than one backend.
+   *
+   * `unified_store` dual-writes an entry to graph + mem0 + mongodb under one id, so a
+   * single fact routinely arrives here 2-3 times. The copies are NOT interchangeable:
+   * only the graph copy carries `relationships`, and each backend reports a different
+   * `confidence` — the graph's is a *lexical match score* (matchedTerms/totalTerms,
+   * usually < 1) while MongoDB's is the *stored, author-assigned* confidence (usually
+   * exactly 1).
+   *
+   * Keeping "the highest confidence copy" therefore compared two different quantities
+   * and reliably discarded the graph copy — the only one with relationships. That is
+   * why searches reported `sources: {graph: N}` while every returned result had
+   * `relationships: []`: the graph hits were fetched, then dropped right here.
+   *
+   * Now the copies are MERGED rather than raced. Fields present on one backend and
+   * absent on another are unioned, so relationships survive regardless of which
+   * backend "wins" the scalar fields.
+   */
   private deduplicateResults(results: any[]): any[] {
     const unique = new Map<string, any>()
-    
+
     for (const result of results) {
       // Use ID if available, otherwise use content hash
       const key = result.id || crypto.createHash('md5').update(result.content).digest('hex')
-      
-      // Keep the result with highest confidence
-      if (!unique.has(key) || (result.confidence > unique.get(key).confidence)) {
+      const existing = unique.get(key)
+
+      if (!existing) {
         unique.set(key, result)
+        continue
       }
+
+      // Prefer the longer content — a backend may store a truncated projection.
+      const base = (result.content?.length ?? 0) > (existing.content?.length ?? 0) ? result : existing
+      const other = base === result ? existing : result
+
+      const merged: any = { ...other, ...base }
+
+      // Union the fields that only some backends populate, preferring whichever
+      // copy actually has them rather than whichever copy won on content length.
+      const rels = (base.relationships?.length ? base.relationships : other.relationships) ?? []
+      if (rels.length) merged.relationships = rels
+
+      // Keep the stored confidence (the author's), not a per-backend match score.
+      merged.confidence = Math.max(base.confidence ?? 0, other.confidence ?? 0)
+
+      // Record every backend this item came from — previously the surviving copy
+      // claimed a single source, which made `sources` counts unreconcilable with
+      // the returned set.
+      const sourceSystems = new Set<string>([
+        ...(base._sourceSystems ?? [base.sourceSystem]),
+        ...(other._sourceSystems ?? [other.sourceSystem]),
+      ].filter(Boolean))
+      merged._sourceSystems = Array.from(sourceSystems)
+
+      unique.set(key, merged)
     }
-    
+
     return Array.from(unique.values())
   }
 
@@ -509,7 +554,27 @@ export class UnifiedSearchTool {
       if (new RegExp(`\\b${escapedPhrase}\\b`).test(contentLower)) phraseBonus = 0.15
     }
 
-    return Math.min(1, coverage * 0.7 + densityScore * 0.15 + phraseBonus)
+    const raw = Math.min(1, coverage * 0.7 + densityScore * 0.15 + phraseBonus)
+
+    // Length normalisation. Without it, long multi-topic entries dominate unrelated
+    // queries: a 3,000-char "everything I did today" note is keyword-dense enough to
+    // contain an incidental hit for almost any query, and if it is also recent it
+    // scores near-maximum on recency too — so it parks at the top of searches it has
+    // nothing to do with. A retrieval baseline over 20 real queries (P@5 0.54) named
+    // this as one of four causes.
+    //
+    // Damping is deliberately gentle and floored at 0.6: length correlates with
+    // substance as well as with noise, and a hard penalty would bury genuinely
+    // detailed entries. A ~500-char entry is unpenalised; a 3,000-char one loses
+    // roughly a fifth of its score, enough to lose a tie to a short exact match
+    // without being excluded.
+    const len = content.length
+    const NEUTRAL_LEN = 500
+    const damping = len <= NEUTRAL_LEN
+      ? 1
+      : Math.max(0.6, 1 / (1 + Math.log10(len / NEUTRAL_LEN)))
+
+    return raw * damping
   }
 
   /**

--- a/src/tools/UnifiedSearchTool.ts
+++ b/src/tools/UnifiedSearchTool.ts
@@ -454,6 +454,17 @@ export class UnifiedSearchTool {
       const rels = (base.relationships?.length ? base.relationships : other.relationships) ?? []
       if (rels.length) merged.relationships = rels
 
+      // entityRefs drive downstream entity-context linking (search()'s linkedEntityIds
+      // annotation and expandWithEntityContext). Union them the same way as relationships,
+      // or whichever copy loses on content length silently drops its refs.
+      const entityRefs = Array.from(new Set([
+        ...(base.metadata?.entityRefs ?? []),
+        ...(other.metadata?.entityRefs ?? []),
+      ]))
+      if (entityRefs.length) {
+        merged.metadata = { ...other.metadata, ...base.metadata, entityRefs }
+      }
+
       // Keep the stored confidence (the author's), not a per-backend match score.
       merged.confidence = Math.max(base.confidence ?? 0, other.confidence ?? 0)
 
@@ -565,9 +576,10 @@ export class UnifiedSearchTool {
     //
     // Damping is deliberately gentle and floored at 0.6: length correlates with
     // substance as well as with noise, and a hard penalty would bury genuinely
-    // detailed entries. A ~500-char entry is unpenalised; a 3,000-char one loses
-    // roughly a fifth of its score, enough to lose a tie to a short exact match
-    // without being excluded.
+    // detailed entries. A ~500-char entry is unpenalised; the floor activates at
+    // ~2,321 chars, past which every length flattens to the same 0.6 factor — a
+    // 3,000-char entry already sits on that floor, a 40% reduction, enough to
+    // lose a tie to a short exact match without being excluded.
     const len = content.length
     const NEUTRAL_LEN = 500
     const damping = len <= NEUTRAL_LEN


### PR DESCRIPTION
Three retrieval defects, found by a **measured baseline** (20 real queries, **P@5 0.54 / P@1 0.70**, median ~6s) rather than by inspection.

## 1. Graph relationships never reached callers

`_getRelationships` read only `RELATED_TO` and `ABOUT` — **2 of 44 relationship types** in the live store. Every typed edge `unified_store` writes went in and never came out:

`SOLVES` ×18 · `SIMILAR_TO` ×48 · `REQUIRES` ×24 · `PART_OF` ×24 · `IMPLEMENTS` · `CORRECTS` · `BLOCKS` · `REFINES` · `SUPERSEDES` · `VALIDATES` · `FIXES` — **206 edges across 42 types.**

Also: outgoing edges only (so the most-referenced entries returned `[]` while sitting at a cluster centre), a 6-label loop that triplicated results because the engine ignores a label predicate naming a zero-node label, and `strength` hard-coded `null`.

Replaced with `GraphEdgeIndex` — whole-graph adjacency, all types, both directions, deduped, strength decoded, 25-per-node cap, maintained incrementally on `addEdge`/`removeNode`.

| | before | after |
|---|---|---|
| hits carrying relationships | 40/80 | **49/80** |
| distinct types surfaced | 2 | **8** |
| latency | ~7.0s *every* search | 2.3s first, **5ms** after |

## 2. Dedup discarded the only copy that had relationships

This is why searches showed `sources: {graph: 8}` next to `relationships: []` on every result.

`unified_store` dual-writes one entry to graph + mem0 + mongodb under a single id. The copies are **not** equivalent:

- only the **graph** copy carries `relationships`
- `confidence` means different things: graph = *lexical match score* (< 1); mongodb = *stored author confidence* (= 1)

`deduplicateResults` kept "the highest confidence copy" — comparing two different quantities — so the Mongo copy won every time and the graph copy was dropped three lines after being fetched. Copies are now **merged rather than raced**, unioning fields present on one backend and absent on another.

## 3. Long entries dominated unrelated queries

A 3,000-char multi-topic note is keyword-dense enough to hit almost any query incidentally, and when recent it also scored near-maximum recency — parking it atop searches it had nothing to do with.

Relevance is now damped by `log10` of content length: neutral below 500 chars, floored at 0.6 so genuinely detailed entries aren't buried.

**This one was my own regression from #85.** The recency weighting introduced it; the baseline caught it inside a day.

## Tests

`464 passed / 22 suites`, typecheck clean. New: `GraphEdgeIndex.test.ts` (28), `UnifiedSearchTool.dedup.test.ts` (10), plus 4 length-normalisation cases including the exact baseline failure — a short older exact match must outrank a long same-day note.

## Not addressed

Entity/proper-noun weighting (a query for "Joytopia brand colors" returns five *other* projects' brand colors) and near-duplicate meta entries crowding out substance. Both are named causes from the baseline, both are larger changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added faster, more reliable relationship lookups across the graph.
  - Preserved relationship strength, direction, content previews, and result limits.
  - Added resilient handling for unavailable or incomplete relationship data.

- **Improvements**
  - Unified search results now merge duplicates across sources while preserving the best content, confidence, relationships, and source details.
  - Improved relevance ranking by reducing the impact of incidental matches in lengthy content.

- **Tests**
  - Added comprehensive coverage for graph relationships, search deduplication, ranking, lifecycle behavior, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->