### PR TITLE
fix(sparrowdb): delete the 7-char truncation workaround, correct the read caveat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,12 +264,46 @@ literal or $parameter`. Use `executeWithParams` with `$emb`.
    unpublished), which overwrites `node_modules/sparrowdb/sparrowdb.node`. **A plain
    `npm ci` silently breaks vector support** until someone re-runs the build script.
 
-2. **Reads return `null` unless `id(k)` is projected first.** `MATCH (k) RETURN k.id`
-   yields `null`; `MATCH (k) RETURN id(k), k.id` yields the value. `_ensureInternalIdMap`
-   is accidentally immune because it happens to project `id(k)` first — any new query
-   that doesn't will silently read nulls. (Relatedly, the "SparrowDB truncates strings
-   to 7 chars" comment near `SparrowDBStorage.ts:586` is a misdiagnosis: full UUIDs
-   round-trip intact.)
+2. **A `RETURN` alias on a node scan reads the wrong property, or null.** In a plain
+   `MATCH (n:Label) … RETURN`, the engine resolves each property column by its
+   **output name**, not by the expression you projected:
+
+   | Query | Result |
+   |---|---|
+   | `MATCH (k:Knowledge) RETURN k.id` | correct |
+   | `MATCH (k:Knowledge) RETURN k.id AS id` | correct — alias equals the property name |
+   | `MATCH (k:Knowledge) RETURN k.id AS zzz` | `null` |
+   | `MATCH (k:Knowledge) RETURN k.id AS contentType` | **silently returns `k.contentType`** |
+
+   Projecting anything that materialises the node — `id(k)`, `labels(k)`, or the bare
+   variable `k`, in any position — restores correct resolution. Relationship-expansion
+   projections (`MATCH (a)-[r:T]->(b) RETURN a.id AS f`) are unaffected.
+
+   **Rule for new queries: project properties unaliased, or alias them to their own
+   property name.** `_ensureInternalIdMap` is safe because it projects `id(k)`.
+
+   Reproduction: `npx jest src/__tests__/SparrowDBBinding.reads.test.ts` — 15 assertions
+   against a real throwaway DB. Run it before writing anything else about SparrowDB
+   reads into this file.
+
+**Two claims that were in this section and were WRONG — do not reintroduce them:**
+
+- ~~"Reads return `null` unless `id(k)` is projected first."~~ False as stated, and
+  verified false 2026-07-31 on a scratch DB and on a copy of `~/.kms-sparrowdb-v2`:
+  `MATCH (k) RETURN k.id` and `MATCH (k) RETURN id(k), k.id` return **identical**
+  values — on the live copy, 2542 rows, 2497 non-null, same 45 nulls either way. Those
+  45 are genuinely property-less orphan nodes (internal ids 168–214, whole payload
+  `{col_0: 0}`), not a projection artifact. This claim is the alias defect above,
+  observed through an aliased query and then generalised to the wrong cause — which is
+  why one investigation saw nulls and another could not reproduce them.
+- ~~"SparrowDB truncates string properties to 7 characters on read."~~ False. Verified
+  three ways: scratch DB, live-store copy, and the exact query
+  `GraphEdgeIndex.readEdges()` issues (`MATCH (a)-[r:T]->(b) RETURN a.id, b.id,
+  r.strength` → whole 36-char UUIDs on both endpoints). On the live copy 2483 of 2497
+  readable ids are exactly 36 chars and **no** value of any length is 7 chars; the 14
+  shorter ones are genuinely short ids (`caryn_yaker`, `test-set-1778114586557`). This
+  one cost a prefix-matching resolver in `SparrowDBStorage` written to compensate for a
+  non-problem, plus two invalid review findings on PR #87. Removed in this PR.
 
 Before repeating any claim in this section, verify it — that is exactly how the
 superseded version above survived so long.

--- a/src/__tests__/SparrowDBBinding.reads.test.ts
+++ b/src/__tests__/SparrowDBBinding.reads.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Characterisation tests for what the sparrowdb native binding actually does
+ * on a read. These run against a real throwaway database, not a fake, because
+ * their entire purpose is to be the thing you run before writing another
+ * sentence about SparrowDB read behaviour into a comment or into CLAUDE.md.
+ *
+ * Two claims that were documented as fact and were not:
+ *
+ *   1. "SparrowDB truncates string properties to 7 characters on read."
+ *      False. It cost a prefix-matching resolver in SparrowDBStorage written
+ *      to compensate for a non-problem, and two invalid review findings on
+ *      PR #87 reasoning from it.
+ *
+ *   2. "Reads return null unless id(k) is projected first — MATCH (k) RETURN
+ *      k.id yields null, MATCH (k) RETURN id(k), k.id yields the value."
+ *      False as stated: both forms return identical values. One investigation
+ *      saw nulls, another could not reproduce them, and the reason is the real
+ *      defect covered below — it is about the RETURN *alias*, not about id().
+ *
+ * The real defect: in a node-scan projection the engine resolves a property
+ * column by its OUTPUT NAME rather than by the projected expression. So
+ * `RETURN k.id AS zzz` reads a property named `zzz` (null), and
+ * `RETURN k.id AS contentType` silently hands back k.contentType. Projecting
+ * anything that materialises the node (`id(k)`, `labels(k)`, the variable `k`)
+ * restores correct resolution, which is why `_ensureInternalIdMap` is immune.
+ */
+
+import { createRequire } from 'module'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+// Resolved from the working directory rather than `import.meta.url`: the test
+// runner compiles this file to CommonJS, where `import.meta` is a parse error.
+const require_ = createRequire(join(process.cwd(), 'jest-resolve-anchor.cjs'))
+
+interface QueryResult { columns: string[]; rows: Array<Record<string, unknown>> }
+interface Db { execute(cypher: string): QueryResult; checkpoint(): void }
+
+/**
+ * The binding is a locally built darwin-arm64 artifact (see
+ * scripts/build-sparrowdb-node.sh); it is legitimately absent on a machine
+ * that has not run that script. Skip rather than fail there — but never skip
+ * an individual assertion.
+ */
+let SparrowDB: { open(path: string): Db } | null = null
+try {
+  SparrowDB = require_('sparrowdb').SparrowDB
+} catch {
+  SparrowDB = null
+}
+
+const describeIfBinding = SparrowDB ? describe : describe.skip
+
+const UUID_A = '11111111-2222-3333-4444-555555555555'
+const UUID_B = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+const LONG_CONTENT = 'content far longer than seven characters, forty-plus in fact'
+
+describeIfBinding('sparrowdb binding — read behaviour', () => {
+  let dir: string
+  let db: Db
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'kms-sparrow-reads-'))
+    db = SparrowDB!.open(join(dir, 'scratch.db'))
+    db.execute(
+      `CREATE (k:Knowledge {id: '${UUID_A}', contentType: 'insight', ` +
+      `source: 'personal', content: '${LONG_CONTENT}'})`
+    )
+    db.execute(`CREATE (k:Knowledge {id: '${UUID_B}', contentType: 'preference', source: 'personal'})`)
+    db.execute(
+      `MATCH (a:Knowledge {id: '${UUID_A}'}), (b:Knowledge {id: '${UUID_B}'}) ` +
+      `CREATE (a)-[r:RELATED_TO {strength: 85}]->(b)`
+    )
+    db.checkpoint()
+  })
+
+  afterAll(() => {
+    try { rmSync(dir, { recursive: true, force: true }) } catch { /* noop */ }
+  })
+
+  // -------------------------------------------------------------------------
+  // Claim 1: string truncation
+  // -------------------------------------------------------------------------
+
+  describe('string properties are not truncated', () => {
+    it('a 36-char UUID round-trips whole through a bare projection', () => {
+      const ids = db.execute('MATCH (k:Knowledge) RETURN k.id').rows.map(r => r['k.id'])
+      expect(ids).toContain(UUID_A)
+      expect(ids).toContain(UUID_B)
+      expect(ids.every(v => String(v).length === 36)).toBe(true)
+    })
+
+    it('non-id string properties round-trip whole, including a 60-char value', () => {
+      const row = db.execute(
+        `MATCH (k:Knowledge {id: '${UUID_A}'}) RETURN k.id, k.contentType, k.source, k.content`
+      ).rows[0]
+      expect(row['k.id']).toBe(UUID_A)
+      expect(row['k.contentType']).toBe('insight')
+      expect(row['k.source']).toBe('personal')
+      expect(row['k.content']).toBe(LONG_CONTENT)
+    })
+
+    it('the exact query GraphEdgeIndex.readEdges() issues returns whole ids on both endpoints', () => {
+      // Verbatim from GraphEdgeIndex.readEdges().
+      const rows = db.execute('MATCH (a)-[r:RELATED_TO]->(b) RETURN a.id, b.id, r.strength').rows
+      expect(rows).toHaveLength(1)
+      expect(rows[0]['a.id']).toBe(UUID_A)
+      expect(rows[0]['b.id']).toBe(UUID_B)
+      expect(rows[0]['r.strength']).toBe(85)
+    })
+
+    it('every string a read returns is a value we wrote, never a prefix of one', () => {
+      const written = new Set([UUID_A, UUID_B, 'insight', 'preference', 'personal', LONG_CONTENT])
+      const shapes = [
+        'MATCH (k:Knowledge) RETURN k.id',
+        'MATCH (k:Knowledge) RETURN k.contentType',
+        'MATCH (k:Knowledge) RETURN k.content',
+        'MATCH (k:Knowledge) RETURN k.id, k.contentType, k.source, k.content',
+        'MATCH (k:Knowledge) RETURN id(k), k.id',
+        'MATCH (a)-[r:RELATED_TO]->(b) RETURN a.id, b.id',
+      ]
+      const seen: string[] = []
+      for (const cypher of shapes) {
+        for (const row of db.execute(cypher).rows) {
+          for (const value of Object.values(row)) {
+            if (typeof value !== 'string') continue
+            seen.push(value)
+            // A clipped read would be a strict prefix of what we wrote and so
+            // would not be in the set.
+            expect(written).toContain(value)
+          }
+        }
+      }
+      expect(seen.length).toBeGreaterThan(10)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Claim 2: "reads return null unless id(k) is projected first"
+  // -------------------------------------------------------------------------
+
+  describe('projecting id(k) is not what makes a property readable', () => {
+    it('MATCH (k) RETURN k.id and MATCH (k) RETURN id(k), k.id agree exactly', () => {
+      const without = db.execute('MATCH (k:Knowledge) RETURN k.id').rows.map(r => r['k.id'])
+      const withId = db.execute('MATCH (k:Knowledge) RETURN id(k), k.id').rows.map(r => r['k.id'])
+      expect(without.sort()).toEqual([UUID_A, UUID_B].sort())
+      expect(withId.sort()).toEqual(without.sort())
+    })
+
+    it('id(k) projected last works the same as id(k) projected first', () => {
+      const first = db.execute('MATCH (k:Knowledge) RETURN id(k), k.id').rows.map(r => r['k.id'])
+      const last = db.execute('MATCH (k:Knowledge) RETURN k.id, id(k)').rows.map(r => r['k.id'])
+      expect(last.sort()).toEqual(first.sort())
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // The defect that actually exists: RETURN aliases resolve by output name
+  // -------------------------------------------------------------------------
+
+  describe('RETURN aliases on a node scan resolve by output name, not by expression', () => {
+    it('an alias that names no property reads null', () => {
+      const rows = db.execute('MATCH (k:Knowledge) RETURN k.id AS zzz').rows
+      expect(rows).toHaveLength(2)
+      expect(rows.every(r => r['zzz'] === null)).toBe(true)
+    })
+
+    it('an alias naming a DIFFERENT property silently returns that other property', () => {
+      // The dangerous shape: this reads like "give me the id" and returns the
+      // contentType. Not an error, not a null — wrong data.
+      const row = db.execute(
+        `MATCH (k:Knowledge {id: '${UUID_A}'}) RETURN k.id AS contentType`
+      ).rows[0]
+      expect(row['contentType']).toBe('insight')
+      expect(row['contentType']).not.toBe(UUID_A)
+    })
+
+    it('an alias equal to the property name is correct', () => {
+      const rows = db.execute('MATCH (k:Knowledge) RETURN k.id AS id').rows.map(r => r['id'])
+      expect(rows.sort()).toEqual([UUID_A, UUID_B].sort())
+    })
+
+    it('an unaliased projection is correct', () => {
+      const rows = db.execute('MATCH (k:Knowledge) RETURN k.id').rows.map(r => r['k.id'])
+      expect(rows.sort()).toEqual([UUID_A, UUID_B].sort())
+    })
+
+    it.each([
+      ['id(k)', 'MATCH (k:Knowledge) RETURN id(k) AS nid, k.id AS node_id'],
+      ['labels(k)', 'MATCH (k:Knowledge) RETURN labels(k) AS lbl, k.id AS node_id'],
+      ['the node variable', 'MATCH (k:Knowledge) RETURN k, k.id AS node_id'],
+    ])('projecting %s alongside makes an arbitrary alias resolve correctly', (_label, cypher) => {
+      const rows = db.execute(cypher).rows.map(r => r['node_id'])
+      expect(rows.sort()).toEqual([UUID_A, UUID_B].sort())
+    })
+
+    it('_ensureInternalIdMap survives only because it projects id(k)', () => {
+      // Verbatim shape from SparrowDBStorage._ensureInternalIdMap().
+      const rows = db.execute('MATCH (k:Knowledge) RETURN id(k) AS nid, k.id AS node_id').rows
+      expect(rows).toHaveLength(2)
+      for (const row of rows) {
+        expect(typeof row['nid']).toBe('number')
+        expect([UUID_A, UUID_B]).toContain(row['node_id'])
+      }
+      // Drop the id(k) column and the same alias goes null.
+      const stripped = db.execute('MATCH (k:Knowledge) RETURN k.id AS node_id').rows
+      expect(stripped.every(r => r['node_id'] === null)).toBe(true)
+    })
+
+    it('relationship-expansion projections are unaffected by the alias defect', () => {
+      const row = db.execute('MATCH (a)-[r:RELATED_TO]->(b) RETURN a.id AS f, b.id AS t').rows[0]
+      expect(row['f']).toBe(UUID_A)
+      expect(row['t']).toBe(UUID_B)
+    })
+  })
+})

--- a/src/storage/SparrowDBStorage.ts
+++ b/src/storage/SparrowDBStorage.ts
@@ -12,15 +12,41 @@
  *
  * Known SparrowDB constraints handled here:
  *
- *   STRING TRUNCATION (current build limitation):
- *     The current sparrowdb.node binary truncates string property values to 7
- *     characters when decoding from the CSR node store. This is a bug in the
- *     NAPI value decoding path (tracked as SPA issue). Workaround: all full-
- *     length string content is stored in a JSON sidecar file (`content-index.json`)
- *     alongside the SparrowDB directory. The sidecar is loaded at startup and
- *     consulted for search. Graph structure (IDs, labels, relationships, short
- *     metadata) is stored in SparrowDB itself.
+ *   CONTENT SIDECAR (not a truncation workaround):
+ *     Full entry content lives in a JSON sidecar (`content-index.json`) beside
+ *     the SparrowDB directory, loaded at startup and consulted for search.
+ *     The reason is that this build has no Node-reachable fulltext index
+ *     (see below), not that SparrowDB mangles strings. Graph structure (IDs,
+ *     labels, relationships, short metadata) lives in SparrowDB itself, and
+ *     sidecar lookups are exact by id — the graph stores whole ids.
  *
+ *     There is NO 7-character string truncation. A comment here used to claim
+ *     the NAPI decode path truncated string properties to 7 chars; it was a
+ *     misdiagnosis and it cost real work (a prefix-matching "resolver" written
+ *     to compensate, plus two invalid review findings on PR #87). Verified
+ *     2026-07-31 three ways — scratch DB, a copy of the live store, and the
+ *     exact query GraphEdgeIndex.readEdges() issues:
+ *       MATCH (k:Knowledge) RETURN k.id            → full 36-char UUIDs
+ *       MATCH (a)-[r:R]->(b) RETURN a.id, b.id     → full UUIDs on both ends
+ *     On the live store (2542 Knowledge nodes) 2483 ids read back at exactly
+ *     36 chars and not one value of any length is 7 chars. Ids shorter than 36
+ *     are genuinely short ids (`caryn_yaker`, `test-set-1778114586557`), not
+ *     clipped UUIDs.
+ *
+ *   - RETURN aliases on a node-scan projection read the WRONG property, or
+ *     null. In a plain `MATCH (n:Label) … RETURN` the engine resolves each
+ *     property column by its OUTPUT NAME, not by the projected expression:
+ *       RETURN k.id                       → correct
+ *       RETURN k.id AS id                 → correct (alias == property name)
+ *       RETURN k.id AS zzz                → null
+ *       RETURN k.id AS contentType        → silently returns k.contentType (!)
+ *     Adding anything that forces the node to materialise — `id(k)`,
+ *     `labels(k)`, or the bare node variable `k`, in any position — makes
+ *     aliases resolve correctly, which is why `_ensureInternalIdMap` (it
+ *     projects `id(k)`) is unaffected. Relationship-expansion projections
+ *     (`MATCH (a)-[r:T]->(b) RETURN a.id AS f`) are unaffected too. Rule for
+ *     new queries here: either project properties unaliased, or alias them to
+ *     their own property name.
  *   - Floats are bit-cast to i64 when stored via literal float syntax;
  *     workaround: store confidence as a string property.
  *   - No MERGE … SET support — upserts use DELETE + CREATE.
@@ -595,21 +621,22 @@ export class SparrowDBStorage implements StorageSystem {
   private _ensureInternalIdMap(): void {
     if (this.internalIdMapLoaded) return
     try {
+      // `id(k)` is load-bearing twice over: it is the key we are mapping, and
+      // its presence is what makes the aliased `k.id` column resolve at all
+      // (see the RETURN-alias note in the file header).
       const res = this.db.execute(
-        `MATCH (k:Knowledge) RETURN id(k) AS nid, k.id AS short_id`
+        `MATCH (k:Knowledge) RETURN id(k) AS nid, k.id AS node_id`
       )
       for (const row of res.rows) {
         const nid = row['nid']
-        const shortId = row['short_id']
+        const uuid = row['node_id']
         if (nid === null || nid === undefined) continue
-        const internalId = String(nid)
-        const prefix = String(shortId ?? '')
-        // Resolve possibly-truncated short_id to the full UUID via sidecar prefix lookup.
-        // SparrowDB 0.1.22 truncates string properties to 7 chars on read; the sidecar
-        // is the authoritative source for full UUIDs.
-        const entry = this._findEntryByPrefix(prefix)
+        // The graph stores whole ids, so this is an exact sidecar lookup. Nodes
+        // absent from the sidecar stay unmapped: a vector hit we cannot join to
+        // content is not returnable anyway.
+        const entry = this.contentIndex.get(String(uuid ?? ''))
         if (entry) {
-          this.internalIdToUuid.set(internalId, entry.id)
+          this.internalIdToUuid.set(String(nid), entry.id)
         }
       }
       this.internalIdMapLoaded = true
@@ -1120,7 +1147,9 @@ export class SparrowDBStorage implements StorageSystem {
       )
       const totalRelationships = Number(relResult.rows[0]?.['cnt'] ?? 0)
 
-      // Content type distribution from sidecar (authoritative — SparrowDB strings truncated).
+      // Content type distribution from the sidecar: it is the only place every
+      // entry's contentType is guaranteed present (the graph node carries it
+      // only for entries written through the current upsert path).
       const contentTypes: Record<string, number> = {}
       for (const entry of this.contentIndex.values()) {
         contentTypes[entry.contentType] = (contentTypes[entry.contentType] ?? 0) + 1
@@ -1201,14 +1230,8 @@ export class SparrowDBStorage implements StorageSystem {
         `MATCH (n:Person) WHERE toLower(n.name) CONTAINS '${safeNorm}' RETURN n.id LIMIT 5`
       )
       if (partial.rows.length === 1) {
-        const rawId = String(partial.rows[0]['n.id'] ?? '').trim()
-        if (!rawId) return null
-        // SparrowDB may truncate string properties to 7 chars — try to expand prefix
-        if (this.knownPeople && rawId.length <= 7) {
-          const matches = Object.keys(this.knownPeople.people).filter(id => id.startsWith(rawId))
-          if (matches.length === 1) return matches[0]
-        }
-        return rawId || null
+        // Whole id — the graph does not clip strings.
+        return String(partial.rows[0]['n.id'] ?? '').trim() || null
       }
     } catch (e) {
       logger.warn('⚠️ SparrowDB resolvePersonId search error:', e)
@@ -1252,13 +1275,14 @@ export class SparrowDBStorage implements StorageSystem {
           const edgeStrength = rawStrength != null
             ? Math.round(parseFloatSafe(rawStrength)) / 100
             : undefined
-          // rawId may be truncated to 7 chars — use prefix search to
-          // resolve all matching sidecar entries.
-          const matches = this._findAllEntriesByPrefix(rawId)
-          const toProcess: ContentEntry[] = matches.length > 0
-            ? matches
-            : [{ id: rawId, content: '', confidence: 0, contentType: '',
-                 source: '', userId: '', timestamp: '', metadata: {} }]
+          // rawId is the neighbour's whole id. Traverse it even when the
+          // sidecar has no entry — the edge is still a real hop — but do not
+          // invent extra neighbours for it.
+          const match = this.contentIndex.get(rawId)
+          const toProcess: ContentEntry[] = [
+            match ?? { id: rawId, content: '', confidence: 0, contentType: '',
+                       source: '', userId: '', timestamp: '', metadata: {} }
+          ]
 
           for (const fullEntry of toProcess) {
             const fullId = fullEntry.id
@@ -1305,7 +1329,7 @@ export class SparrowDBStorage implements StorageSystem {
       } catch { continue }
       if (result.rows.length === 0) continue
 
-      // Strings from SparrowDB are truncated — use sidecar for content where available.
+      // Content comes from the sidecar; the graph node holds structure only.
       const summary: Record<string, any> = {
         id,
         name: entry?.content?.split(' ').slice(0, 3).join(' ') ?? null,
@@ -1324,7 +1348,7 @@ export class SparrowDBStorage implements StorageSystem {
         summary.top_relationships = rels.rows
           .map(r => {
             const mid = String(r['m.id'] ?? '')
-            const related = this._findEntryByPrefix(mid)
+            const related = this.contentIndex.get(mid)
             return related
               ? { rel: 'RELATED_TO', name: related.content.slice(0, 40), id: related.id }
               : null
@@ -1370,8 +1394,7 @@ export class SparrowDBStorage implements StorageSystem {
         )
         for (const row of r.rows) {
           const nodeId = String(row['n.id'] ?? '')
-          // Resolve full strings from sidecar.
-          const entry = this._findEntryByPrefix(nodeId)
+          const entry = this.contentIndex.get(nodeId)
           results.push({
             id: entry?.id ?? nodeId,
             type: String(row['n.type'] ?? label),
@@ -1407,7 +1430,7 @@ export class SparrowDBStorage implements StorageSystem {
         for (const row of r.rows) {
           const rawId = String(row['n.id'] ?? '')
           if (!rawId) continue
-          const entry = this._findEntryByPrefix(rawId)
+          const entry = this.contentIndex.get(rawId)
           const id = entry?.id ?? rawId
           const name = String(row['n.name'] ?? entry?.content?.split(' ')[0] ?? '')
           if (!name) continue
@@ -1465,40 +1488,6 @@ export class SparrowDBStorage implements StorageSystem {
   // -------------------------------------------------------------------------
   // Private helpers
   // -------------------------------------------------------------------------
-
-  /**
-   * Find a sidecar entry whose ID starts with the (possibly truncated) prefix.
-   * Returns the first match. When multiple IDs share the same 7-char prefix,
-   * disambiguation is impossible — this is a known limitation of the current
-   * SparrowDB build's 7-char string truncation.
-   */
-  private _findEntryByPrefix(prefix: string): ContentEntry | undefined {
-    if (!prefix) return undefined
-    // Exact match first.
-    if (this.contentIndex.has(prefix)) return this.contentIndex.get(prefix)
-    // Prefix search (handles 7-char truncation from SparrowDB native binding).
-    for (const [key, entry] of this.contentIndex) {
-      if (key.startsWith(prefix)) return entry
-    }
-    return undefined
-  }
-
-  /**
-   * Find ALL sidecar entries whose ID starts with the given prefix.
-   * Used by findRelated to handle ambiguous 7-char truncated IDs.
-   */
-  private _findAllEntriesByPrefix(prefix: string): ContentEntry[] {
-    if (!prefix) return []
-    if (this.contentIndex.has(prefix)) {
-      const e = this.contentIndex.get(prefix)
-      return e ? [e] : []
-    }
-    const matches: ContentEntry[] = []
-    for (const [key, entry] of this.contentIndex) {
-      if (key.startsWith(prefix)) matches.push(entry)
-    }
-    return matches
-  }
 
   private async _createRelationship(
     sourceId: string,
@@ -1562,7 +1551,7 @@ export class SparrowDBStorage implements StorageSystem {
     if (!this.edgeIndex) {
       this.edgeIndex = new GraphEdgeIndex(
         this.db,
-        (id: string) => this._findEntryByPrefix(id),
+        (id: string) => this.contentIndex.get(id),
         { debug: (m: string) => logger.debug(`⚡ SparrowDB ${m}`) }
       )
     }


### PR DESCRIPTION
Two documented "facts" about SparrowDB reads were wrong. Both had already caused work: one produced a prefix-matching resolver written to compensate for a non-problem plus two invalid review findings on #87; the other left two investigations contradicting each other. This verifies both empirically, deletes the dead workaround, and rewrites the caveat to say what is actually true.

Verification was done against a scratch DB **and** a copy of the live store (`~/.kms-sparrowdb-v2`, 2542 Knowledge nodes). The live store itself was never queried — single-writer engine, daemon running.

## 1. There is no 7-character string truncation

```
$ MATCH (k:Knowledge) RETURN k.id
    {"k.id":"11111111-2222-3333-4444-555555555555"}
    {"k.id":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"}

$ MATCH (k:Knowledge) RETURN k.id, k.contentType, k.source, k.content
    {"k.id":"11111111-2222-3333-4444-555555555555","k.contentType":"insight",
     "k.source":"personal",
     "k.content":"a fairly long piece of content that exceeds seven characters by a lot"}

$ MATCH (a)-[r:RELATED_TO]->(b) RETURN a.id, b.id, r.strength   # verbatim GraphEdgeIndex.readEdges()
    {"a.id":"11111111-2222-3333-4444-555555555555",
     "b.id":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","r.strength":85}
```

On the live copy:

```
k.id length histogram: {"17":1,"18":2,"19":1,"21":1,"22":1,"23":2,"24":3,"25":2,"28":1,"36":2483}
any exactly-7-char id: false
edges=2604  endpoints: 36-char UUID=4365, short slug=843, null=0, exactly-7-char=2
```

The 14 sub-36-char ids are genuinely short ids, not clipped UUIDs — `caryn_yaker`, `susan_yaker`, `test-set-1778114586557`, `merge-emb-1778114819888`. (The two "7-char endpoints" are slugs of that length, not clipped values.)

### What that means for the code

`_findEntryByPrefix` and `_findAllEntriesByPrefix` existed only to compensate. Every caller was traced before deleting:

| Caller | Value passed | Now |
|---|---|---|
| `_ensureInternalIdMap` | `k.id` from the graph | exact `contentIndex.get` |
| `findRelated` | `b.id` from an edge | exact `contentIndex.get` |
| `getEntitySummary` | `m.id` from an edge | exact `contentIndex.get` |
| `getOperationalNodes` | `n.id` | exact `contentIndex.get` |
| `getEntityCandidates` | `n.id` | exact `contentIndex.get` |
| `GraphEdgeIndex` `EntryResolver` | `a.id` / `b.id` | exact `contentIndex.get` |

All six pass a whole node id, so none needs prefix behaviour. Both helpers are deleted, as is the `rawId.length <= 7` prefix expansion in `resolvePersonId`.

Removing the fan-out also fixes a live bug: `findRelated` used `_findAllEntriesByPrefix`, so any sidecar entry sharing a prefix with a neighbour id was enqueued as a real graph hop and returned as a related node.

## 2. "Reads return null unless `id(k)` is projected first" — false as stated

Identical results either way, on both databases:

```
A  MATCH (k) RETURN k.id        : total=2542 nulls=45 lengths={…,"36":2483}
B  MATCH (k) RETURN id(k), k.id : total=2542 nulls=45 lengths={…,"36":2483}
C  MATCH (k) RETURN k.id, id(k) : total=2542 nulls=45 lengths={…,"36":2483}
A vs B value multisets identical: true
A vs C value multisets identical: true
```

The 45 nulls are real property-less orphan nodes (internal ids 168–214), not a projection artifact — `id(k)` does not rescue them:

```
$ MATCH (k:Knowledge) WHERE id(k) = 168 RETURN id(k), k
    {"id(k)":168,"k":{"col_0":0}}
$ MATCH (k:Knowledge) WHERE id(k) = 0 RETURN id(k), k          # control
    {"id(k)":0,"k":{"col_0":0,"col_926444256":"9bb947e6-6531-4dd0-9ad0-7c596d450824"}}
```

### The defect that does exist: RETURN aliases resolve by output name

On a node scan the engine resolves each property column by its **output name**, not by the projected expression:

```
$ MATCH (k:Knowledge) RETURN k.contentType AS contentType  => [{"contentType":"THE-CT-VALUE"}]   correct
$ MATCH (k:Knowledge) RETURN k.id AS zzz                   => [{"zzz":null}]                     null
$ MATCH (k:Knowledge) RETURN k.contentType AS id           => [{"id":"THE-ID-VALUE"}]            WRONG DATA
$ MATCH (k:Knowledge) RETURN k.id AS contentType           => [{"contentType":"THE-CT-VALUE"}]   WRONG DATA
```

Not a null, not an error — the wrong property, silently. Projecting anything that materialises the node (`id(k)`, `labels(k)`, or the bare variable `k`, in any position) restores correct resolution; relationship-expansion projections (`MATCH (a)-[r:T]->(b) RETURN a.id AS f`) are unaffected.

This reconciles the two investigations: one hit the alias path and saw nulls, the other compared the two literal forms from the caveat and correctly could not reproduce anything. `_ensureInternalIdMap` is immune because it projects `id(k)` — which the code now says out loud, since that column is load-bearing for more than the map key.

## Changes

- `src/storage/SparrowDBStorage.ts` — header comment rewritten (truncation claim retracted, alias rule documented); both prefix helpers and the `resolvePersonId` prefix expansion deleted; six call sites moved to exact lookup; three stale inline comments corrected.
- `CLAUDE.md` — caveat 2 replaced with the alias rule + reproduction command; both retracted claims recorded explicitly with the evidence, so the next reader sees what was wrong rather than a silent edit.
- `src/__tests__/SparrowDBBinding.reads.test.ts` — new, 15 assertions against a real throwaway DB (skips cleanly if the local native build is absent). It covers no-truncation, the two projection forms agreeing, and every branch of the alias rule including the wrong-property case.

## Checks

- `npx tsc --noEmit` → clean
- `npx jest --ci --watchAll=false` → **481 passed** (466 baseline + 15 new), 23 suites, 0 failures

## Could not verify

- **Root cause in the engine.** The alias behaviour is characterised black-box from JS. Reading `k` back shows hashed property columns (`{"col_0":0,"col_926444256":"…"}`), which is consistent with resolution-by-output-name, but confirming that requires the Rust side and is outside this change.
- **Whether the alias defect is fixed in any newer SparrowDB.** Only tested against the local 0.1.22 build (`scripts/build-sparrowdb-node.sh`), the only artifact that works on darwin-arm64.
- **Why 45 Knowledge nodes have no properties at all.** Confirmed they are property-less rather than a read artifact; how they got written is untouched here.
- **`RETURN <literal>`** (e.g. `RETURN k.id AS v, 1`) came back as a `"?"` column of null and appeared to poison its neighbours. Noted, not chased — no code in this repo projects literals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfUP35PJDzrYLpVcbWEbsk
