### PR TITLE
fix(search): weight discriminating terms and suppress paraphrase clusters

### DIFF
--- a/src/__tests__/UnifiedSearchTool.discrimination.test.ts
+++ b/src/__tests__/UnifiedSearchTool.discrimination.test.ts
@@ -1,0 +1,453 @@
+/**
+ * Rank-time discrimination tests for UnifiedSearchTool.
+ *
+ * Two named causes from the retrieval baseline (mean P@5 = 0.54, P@1 = 0.70 over 20
+ * real queries), each pinned here by the exact query that scored 0.0:
+ *
+ *   CAUSE 1 — no entity / proper-noun weighting. "Joytopia brand colors" returned five
+ *   OTHER projects' brand colors; the generic phrase matched everywhere and the one
+ *   discriminating proper noun counted for no more than the boilerplate.
+ *
+ *   CAUSE 2 — near-duplicate entries crowd out substance. "LRI binary parsing format"
+ *   returned five near-paraphrases of one governance rule; the single entry describing
+ *   the actual binary format was pushed out of the window.
+ *
+ * Each failing case is set up twice: once through `preFixRank`, an emulation of the
+ * ranker as it was (unweighted coverage, no duplicate suppression), to prove the
+ * fixture really does reproduce the baseline failure, and once through the real
+ * `rankResults`. A fixture that stopped reproducing the bug would make the "after"
+ * assertion vacuous, so both halves are asserted.
+ *
+ * The private members are reached via bracket access rather than being widened to
+ * public purely for testability, matching UnifiedSearchTool.ranking.test.ts.
+ */
+
+import { UnifiedSearchTool } from '../tools/UnifiedSearchTool.js'
+
+const tool = new UnifiedSearchTool({} as any, {} as any)
+
+const rank = (results: any[], query: string) => (tool as any).rankResults(results, query)
+const relevance = (content: string, query: string, weights?: Record<string, number>) =>
+  (tool as any).calculateRelevance(content, query, weights)
+const recency = (ts?: string) => (tool as any).calculateRecency(ts)
+const termWeights = (results: any[], query: string) => (tool as any).computeTermWeights(results, query)
+const contentTokens = (content: string) => (tool as any).contentTokens(content)
+const jaccard = (a: string, b: string) => (tool as any).jaccard(contentTokens(a), contentTokens(b))
+
+const daysAgo = (n: number) => new Date(Date.now() - n * 86_400_000).toISOString()
+const ids = (results: any[]) => results.map(r => r.id)
+
+/**
+ * The ranker as it behaved at the baseline: unweighted lexical coverage, same recency
+ * and confidence mix, no near-duplicate pass. Used only to demonstrate that each
+ * fixture below genuinely reproduces the measured failure.
+ */
+const preFixRank = (results: any[], query: string) => results
+  .map(r => ({ ...r, _s: relevance(r.content, query) * 0.70 + recency(r.timestamp) * 0.25 + (r.confidence ?? 0) * 0.05 }))
+  .sort((a, b) => b._s - a._s)
+
+// ---------------------------------------------------------------------------
+// CAUSE 1 fixture — "Joytopia brand colors"
+//
+// Five short, recent entries about other projects' brand colors, plus the real
+// joytopia-brand-identity entry: a full guidelines document, so it is long (length
+// damping applies) and it is older. Unweighted, the competitors' 2-of-3 term coverage
+// on undamped short text beats the target's 3-of-3 on damped long text — which is
+// exactly how five wrong answers filled the window.
+// ---------------------------------------------------------------------------
+const JOYTOPIA_CANDIDATES = [
+  {
+    id: 'tengo-portal-frontend',
+    timestamp: daysAgo(10),
+    confidence: 1,
+    content: 'Tengo portal-frontend brand colors: the primary brand color is a deep navy with a secondary amber accent; all brand colors live in the tailwind config under theme extend colors.'
+  },
+  {
+    id: 'blockcopy26-rebrand',
+    timestamp: daysAgo(20),
+    confidence: 1,
+    content: 'BlockCopy26 rebrand shipped new brand colors — deep violet primary, slate neutrals. The old brand colors were retired from the design tokens package.'
+  },
+  {
+    id: 'trading-dashboard-theme',
+    timestamp: daysAgo(5),
+    confidence: 1,
+    content: 'Trading dashboard brand colors follow the terminal palette: green for gains, red for losses, and a muted grey chrome. Brand colors are defined in the theme module.'
+  },
+  {
+    id: 'abundance-coach-site',
+    timestamp: daysAgo(30),
+    confidence: 1,
+    content: 'Abundance Coach marketing site brand colors were refreshed: warm coral CTA against cream. Brand colors and typography are documented in the design system.'
+  },
+  {
+    id: 'sparrowdb-docs-theme',
+    timestamp: daysAgo(2),
+    confidence: 1,
+    content: 'SparrowDB docs site brand colors: monochrome with a single teal accent. No other brand colors are permitted in the docs theme.'
+  },
+  {
+    id: 'joytopia-brand-identity',
+    timestamp: daysAgo(150),
+    confidence: 1,
+    content: 'Joytopia brand identity guidelines. ' +
+      'Palette: the primary is a warm teal, the secondary a sunrise gold, with deep indigo for depth and a cream neutral for surfaces. ' +
+      'These brand colors carry across MyMoneyCoach, the Sophia character assets, and every piece of Joytopia marketing collateral. ' +
+      'Typography: display headings are set in a humanist sans at semibold; body copy is the same family at regular with generous line height. ' +
+      'Never letterspace the wordmark and never set the wordmark in all caps. ' +
+      'Logo usage: maintain clear space equal to the height of the mark on all four sides. Do not place the mark on a busy photograph, do not recolour it, do not add a drop shadow, and do not rotate it. ' +
+      'Voice and tone: warm, plain-spoken, never preachy and never scarcity-driven. Write to someone who is capable but tired. Prefer short sentences. Avoid jargon and avoid exclamation marks. ' +
+      'Imagery: Pixar-style 3D renders for character work, natural light photography everywhere else, no stock-photo handshakes and no literal money imagery. ' +
+      'Accessibility: every text and background pairing must clear WCAG AA, which rules out the gold on cream combination for body copy. ' +
+      'Application: presentation decks, one-page PDFs, social cards and the app shell all draw from the same token set so nothing drifts.'
+  },
+]
+
+// ---------------------------------------------------------------------------
+// CAUSE 2 fixture — "LRI binary parsing format"
+//
+// Five rewordings of one governance rule, all of which legitimately contain the query
+// terms (which is why they ranked), plus unrelated investigation notes and the single
+// entry that actually documents the binary format.
+// ---------------------------------------------------------------------------
+const LRI_CANDIDATES = [
+  { id: 'gov-1', timestamp: daysAgo(3), confidence: 1, content: 'LRI binary parsing governance: do not change the binary parsing code under the Phoenix scratch volume without an approved written plan. Parsing work on the LRI format is read-only by default.' },
+  { id: 'gov-2', timestamp: daysAgo(6), confidence: 1, content: 'LRI binary parsing governance rule: the binary parsing code under the Phoenix scratch volume must never be changed without an approved written plan; parsing work on the LRI format stays read-only by default.' },
+  { id: 'gov-3', timestamp: daysAgo(9), confidence: 1, content: 'Governance for LRI binary parsing: never change parsing code under the Phoenix scratch volume unless a written plan is approved. Work on the LRI binary format is read-only by default.' },
+  { id: 'gov-4', timestamp: daysAgo(12), confidence: 1, content: 'LRI parsing process governance: an approved written plan is required before changing the binary parsing code under the Phoenix scratch volume. LRI format parsing work defaults to read-only.' },
+  { id: 'gov-5', timestamp: daysAgo(14), confidence: 1, content: 'Rule for LRI binary parsing work: the parsing code under the Phoenix scratch volume is not to be changed until a written plan has been approved, and all LRI format parsing stays read-only by default.' },
+  { id: 'note-lldb-bridge', timestamp: daysAgo(4), confidence: 1, content: 'The lri_process bridge is attached with LLDB against libcp.dylib; breakpoints on the ISP entry points survive a re-attach but the symbol table has to be reloaded each time.' },
+  { id: 'note-per-camera-isp', timestamp: daysAgo(8), confidence: 1, content: 'Per-camera ISP investigation notes: camera B and camera C share a calibration block, which explains the duplicated gain curves seen in the dump.' },
+  { id: 'note-calibration-payload', timestamp: daysAgo(15), confidence: 1, content: 'Parsing the calibration payload requires the little-endian format flag; otherwise the offsets read as garbage.' },
+  { id: 'lri-binary-format-spec', timestamp: daysAgo(60), confidence: 1, content: 'LRI binary format specification: the file opens with a 32-byte header whose magic is LRI followed by a null byte, then a table of per-camera blocks. Parsing the LRI binary format means reading the block count at offset 0x10 and walking fixed-size descriptors.' },
+]
+
+const isGovernanceVariant = (r: any) => String(r.id).startsWith('gov-')
+
+describe('CAUSE 1 — entity / proper-noun weighting', () => {
+  const QUERY = 'Joytopia brand colors'
+
+  it('reproduces the baseline failure without term weighting', () => {
+    // Pinning the bug: every one of the top five is some other project's brand colors,
+    // and the entry the user asked for does not appear in the window at all. P@5 = 0.0.
+    const before = ids(preFixRank(JOYTOPIA_CANDIDATES, QUERY))
+    expect(before.slice(0, 5)).not.toContain('joytopia-brand-identity')
+    expect(before[5]).toBe('joytopia-brand-identity')
+  })
+
+  it('ranks the entry carrying the proper noun first — the baseline failing case', () => {
+    const ranked = rank(JOYTOPIA_CANDIDATES, QUERY)
+    expect(ranked[0].id).toBe('joytopia-brand-identity')
+  })
+
+  it('separates it from the generic matches by a wide margin, not a hair', () => {
+    // A one-rank flip that a slightly different fixture would undo is not a fix.
+    const ranked = rank(JOYTOPIA_CANDIDATES, QUERY)
+    expect(ranked[0]._score).toBeGreaterThan(ranked[1]._score * 1.4)
+  })
+
+  it('weights the rare discriminating term far above the ubiquitous ones', () => {
+    const weights = termWeights(JOYTOPIA_CANDIDATES, QUERY)
+    expect(weights.joytopia).toBeGreaterThan(weights.brand * 10)
+    expect(weights.joytopia).toBeGreaterThan(weights.colors * 10)
+  })
+
+  it('leaves a term that every candidate shares almost no say in the ranking', () => {
+    // "brand" and "colors" are in all six; on their own they must barely move a score.
+    const weights = termWeights(JOYTOPIA_CANDIDATES, QUERY)
+    const generic = relevance('Some other project brand colors are documented here.', QUERY, weights)
+    expect(generic).toBeLessThan(0.15)
+  })
+
+  it('normalises weights across the terms so _relevance keeps its [0, 1] meaning', () => {
+    const weights = termWeights(JOYTOPIA_CANDIDATES, QUERY)
+    const sum = Object.values(weights).reduce((a: number, b: any) => a + b, 0)
+    expect(sum).toBeCloseTo(1, 3)
+    const ranked = rank(JOYTOPIA_CANDIDATES, QUERY)
+    for (const r of ranked) {
+      expect(r._relevance).toBeGreaterThanOrEqual(0)
+      expect(r._relevance).toBeLessThanOrEqual(1)
+    }
+  })
+
+  it('gives a term present in no candidate zero weight instead of deflating everyone', () => {
+    // A term nobody has cannot discriminate; leaving it in the denominator would scale
+    // every score down by the same factor for no ranking benefit.
+    const weights = termWeights(JOYTOPIA_CANDIDATES, 'Joytopia brand colors zzzunmatched')
+    expect(weights.zzzunmatched).toBe(0)
+    const withNoise = rank(JOYTOPIA_CANDIDATES, 'Joytopia brand colors zzzunmatched')
+    const without = rank(JOYTOPIA_CANDIDATES, 'Joytopia brand colors')
+    expect(withNoise[0].id).toBe(without[0].id)
+    expect(withNoise[0]._relevance).toBeCloseTo(without[0]._relevance, 4)
+  })
+
+  it('does not weight when there is no candidate set to be rare against', () => {
+    // Fewer than two candidates: nothing to discriminate between, so fall back to
+    // uniform rather than inventing a spread from a single document.
+    expect(termWeights([JOYTOPIA_CANDIDATES[0]], 'Joytopia brand colors')).toEqual({})
+    expect(termWeights([], 'Joytopia brand colors')).toEqual({})
+  })
+
+  it('is behaviour-identical to the unweighted scorer when no weights are supplied', () => {
+    // calculateRelevance must stay usable standalone on one document, and every
+    // existing caller and test of the two-argument form must be unaffected.
+    const content = 'Ollama classify timeout raised from 3000ms to 8000ms.'
+    const query = 'Ollama classify timeout'
+    const uniform = { ollama: 1, classify: 1, timeout: 1 }
+    expect(relevance(content, query, undefined)).toBe(relevance(content, query))
+    expect(relevance(content, query, {})).toBe(relevance(content, query))
+    expect(relevance(content, query, uniform)).toBeCloseTo(relevance(content, query), 10)
+  })
+
+  it('exposes the new signal the same inspectable way as _score/_relevance/_recency', () => {
+    const ranked = rank(JOYTOPIA_CANDIDATES, QUERY)
+    for (const r of ranked) {
+      expect(r).toHaveProperty('_score')
+      expect(r).toHaveProperty('_relevance')
+      expect(r).toHaveProperty('_recency')
+      expect(r).toHaveProperty('_termWeights')
+      expect(r).toHaveProperty('_matchedTerms')
+    }
+    const target = ranked.find((r: any) => r.id === 'joytopia-brand-identity')
+    expect(target._matchedTerms.sort()).toEqual(['brand', 'colors', 'joytopia'])
+    const generic = ranked.find((r: any) => r.id === 'sparrowdb-docs-theme')
+    expect(generic._matchedTerms).not.toContain('joytopia')
+  })
+})
+
+describe('CAUSE 2 — near-duplicate suppression', () => {
+  const QUERY = 'LRI binary parsing format'
+
+  it('reproduces the baseline failure without duplicate suppression', () => {
+    // Pinning the bug: the whole window is one governance rule said five ways, and the
+    // entry describing the actual binary format is outside it. P@5 = 0.0.
+    const before = preFixRank(LRI_CANDIDATES, QUERY)
+    expect(before.slice(0, 5).every(isGovernanceVariant)).toBe(true)
+    expect(ids(before).slice(0, 5)).not.toContain('lri-binary-format-spec')
+  })
+
+  it('surfaces the entry describing the actual format — the baseline failing case', () => {
+    const ranked = rank(LRI_CANDIDATES, QUERY)
+    expect(ids(ranked).slice(0, 5)).toContain('lri-binary-format-spec')
+    expect(ids(ranked).indexOf('lri-binary-format-spec')).toBeLessThanOrEqual(1)
+  })
+
+  it('stops one paraphrase cluster owning the window', () => {
+    const ranked = rank(LRI_CANDIDATES, QUERY)
+    expect(ranked.slice(0, 5).filter(isGovernanceVariant).length).toBeLessThanOrEqual(2)
+    // The cluster keeps its single best representative at the top — the rule is still a
+    // legitimate hit for this query, it just may not be five of the five.
+    expect(ranked[0].id).toBe('gov-1')
+    expect(ranked[0]._duplicateOf).toBeNull()
+  })
+
+  it('demotes duplicates rather than dropping them', () => {
+    const ranked = rank(LRI_CANDIDATES, QUERY)
+    expect(ranked).toHaveLength(LRI_CANDIDATES.length)
+    expect(ranked.filter(isGovernanceVariant)).toHaveLength(5)
+  })
+
+  it('compounds the penalty so a large cluster cannot creep back up the list', () => {
+    const ranked = rank(LRI_CANDIDATES, QUERY)
+    const demoted = ranked.filter((r: any) => r._duplicateOf !== null)
+    expect(demoted.length).toBe(4)
+    const penalties = demoted.map((r: any) => r._duplicatePenalty)
+    // Strictly decreasing: 0.45, 0.2025, 0.0911, …
+    for (let i = 1; i < penalties.length; i++) {
+      expect(penalties[i]).toBeLessThan(penalties[i - 1])
+    }
+    for (const r of demoted) {
+      expect(r._duplicateOf).toBe('gov-1')
+      expect(r._duplicateSimilarity).toBeGreaterThanOrEqual(0.5)
+    }
+  })
+
+  it('keeps the demoted variants below the distinct entries they were crowding out', () => {
+    const ranked = rank(LRI_CANDIDATES, QUERY)
+    const spec = ranked.find((r: any) => r.id === 'lri-binary-format-spec')
+    for (const r of ranked.filter((x: any) => x._duplicateOf !== null)) {
+      expect(r._score).toBeLessThan(spec._score)
+    }
+  })
+
+  it('exposes the new signal on every result, demoted or not', () => {
+    const ranked = rank(LRI_CANDIDATES, QUERY)
+    for (const r of ranked) {
+      expect(r).toHaveProperty('_duplicateOf')
+      expect(r).toHaveProperty('_duplicateSimilarity')
+      expect(r).toHaveProperty('_duplicatePenalty')
+      expect(r).toHaveProperty('_score')
+      expect(r).toHaveProperty('_relevance')
+      expect(r).toHaveProperty('_recency')
+    }
+    const untouched = ranked.filter((r: any) => r._duplicateOf === null)
+    for (const r of untouched) expect(r._duplicatePenalty).toBe(1)
+  })
+
+  it('scores real paraphrases above the threshold and distinct entries well below it', () => {
+    // The margin the threshold sits in. Paraphrases of one rule cluster at 0.70-0.89;
+    // distinct entries that merely share vocabulary top out around 0.27.
+    expect(jaccard(LRI_CANDIDATES[0].content, LRI_CANDIDATES[1].content)).toBeGreaterThan(0.6)
+    expect(jaccard(LRI_CANDIDATES[0].content, LRI_CANDIDATES[2].content)).toBeGreaterThan(0.6)
+    expect(jaccard(LRI_CANDIDATES[0].content, LRI_CANDIDATES[8].content)).toBeLessThan(0.3)
+  })
+})
+
+describe('near-duplicate suppression is conservative', () => {
+  // The mandate: genuinely distinct entries that merely share vocabulary must NOT be
+  // collapsed. Every pair below is two different facts; none may be demoted.
+  const distinctPairs: Array<[string, string, string]> = [
+    [
+      'two different Ollama facts',
+      'The Ollama classify timeout was raised from 3000ms to 8000ms after a cold model load measured 5219ms on the LAN host.',
+      'The Ollama availability probe caches its result for 30 seconds, and a failed probe expires fast so one slow check does not disable embedding.',
+    ],
+    [
+      'two steps of one procedure',
+      'Step one of the SparrowDB node build: run the build-sparrowdb-node script from the KMSmcp repo root so the local unpublished artifact is produced.',
+      'Step two of the SparrowDB node build: copy the produced binary over the file that npm installed into node modules, because a plain npm ci silently reverts it.',
+    ],
+    [
+      'templated one-liners about different services',
+      'The KMS MCP server listens on port 8180 and is exposed through the Cloudflare tunnel at kms.yaker.org.',
+      'The Claude Ops dashboard listens on port 9102 and is exposed through the Cloudflare tunnel at cops.yaker.org.',
+    ],
+    [
+      'two rows of one threshold table',
+      'The dedup gate refuse band starts at cosine 0.88; procedure content type overrides that refuse threshold down to 0.85 because refutation rewrites cluster lower.',
+      'The dedup gate confirm band runs from cosine 0.78 to 0.88; pattern content type overrides the refuse threshold up to 0.92 because pattern duplicates are extremely tight.',
+    ],
+    [
+      'two different facts about the same binary format',
+      'The LRI binary format opens with a 32-byte header whose magic is LRI and a null byte, followed by a table of per-camera blocks.',
+      'The LRI binary format block table starts at offset 0x10 with a block count, then fixed-size per-camera descriptors follow immediately.',
+    ],
+    [
+      'two projects\' brand colors',
+      'Tengo portal-frontend brand colors: primary brand color is navy with a secondary amber accent, all brand colors live in the tailwind config theme extend colors block.',
+      'BlockCopy26 rebrand shipped new brand colors, deep violet primary with slate neutrals; the old brand colors were retired from the design tokens package.',
+    ],
+    [
+      'a fact and its correction',
+      'Phoenix camera count is 6 per the March 2026 calibration session run against config 2 with the folded optical path.',
+      'Phoenix camera count is UNKNOWN pending canvas bounds verification; the prior 6-camera claim used the wrong zoom config and an A-only field of view.',
+    ],
+    [
+      'two behaviours of one tool',
+      'kms_supersede stores a new entry with metadata.supersedes set to the old id and flags the old entry SUPERSEDED, so the old one is hidden from search but preserved for audit.',
+      'kms_supersede probes each backend with findById first, builds the required backend set from those probes, and rolls back the new entry if any required flag write fails.',
+    ],
+    [
+      'two distinct prose rules on one topic',
+      'Every subagent must report file paths as absolute paths, never relative ones, because the parent agent resolves them from a different working directory.',
+      'Every subagent should return its findings in the final message rather than writing a report file, because the parent agent reads the text output and not the filesystem.',
+    ],
+  ]
+
+  it.each(distinctPairs)('does not collapse %s', (_label, a, b) => {
+    const ranked = rank(
+      [
+        { id: 'a', content: a, confidence: 1, timestamp: daysAgo(1) },
+        { id: 'b', content: b, confidence: 1, timestamp: daysAgo(1) },
+      ],
+      'irrelevant query terms',
+    )
+    for (const r of ranked) {
+      expect(r._duplicateOf).toBeNull()
+      expect(r._duplicatePenalty).toBe(1)
+    }
+  })
+
+  it('vetoes on conflicting literals even when the prose overlaps heavily', () => {
+    // The port-registry shape: same sentence template, different service. Word overlap
+    // alone puts it uncomfortably near the threshold; the values say they are not the
+    // same fact.
+    const a = 'The KMS MCP server listens on port 8180 and is exposed through the Cloudflare tunnel at kms.yaker.org.'
+    const b = 'The Claude Ops dashboard listens on port 9102 and is exposed through the Cloudflare tunnel at cops.yaker.org.'
+    expect(jaccard(a, b)).toBeGreaterThan(0.3)   // high enough to be a worry
+    const conflict = (tool as any).literalsConflict(
+      (tool as any).literalTokens(contentTokens(a)),
+      (tool as any).literalTokens(contentTokens(b)),
+    )
+    expect(conflict).toBe(true)
+  })
+
+  it('lets a paraphrase drop a detail without tripping the veto', () => {
+    // Containment, not equality: {0.88} inside {0.88, 0.85} is an omission, not a
+    // substitution, so a genuine rewording that mentions fewer numbers still clusters.
+    const full = (tool as any).literalTokens(new Set(['0.88', '0.85']))
+    const partial = (tool as any).literalTokens(new Set(['0.88']))
+    expect((tool as any).literalsConflict(full, partial)).toBe(false)
+    // …and when neither side cites a value there is nothing to veto on.
+    expect((tool as any).literalsConflict(new Set(), new Set(['0.88']))).toBe(false)
+  })
+
+  it('exempts very short entries in both directions', () => {
+    // Jaccard is noise on a handful of tokens: these two score 0.75 while meaning
+    // opposite things, so entries this short are neither demoted nor allowed to demote.
+    const a = 'Rich prefers dark mode in every editor'
+    const b = 'Rich prefers light mode in every editor'
+    expect(jaccard(a, b)).toBeGreaterThan(0.5)
+    const ranked = rank(
+      [
+        { id: 'dark', content: a, confidence: 1, timestamp: daysAgo(1) },
+        { id: 'light', content: b, confidence: 1, timestamp: daysAgo(2) },
+      ],
+      'Rich editor mode',
+    )
+    for (const r of ranked) expect(r._duplicateOf).toBeNull()
+  })
+
+  it('handles empty and single-result sets', () => {
+    expect(rank([], 'anything')).toEqual([])
+    const one = rank([{ id: 'x', content: 'a single entry about parsing the LRI binary format header', confidence: 1, timestamp: daysAgo(1) }], 'LRI format')
+    expect(one).toHaveLength(1)
+    expect(one[0]._duplicateOf).toBeNull()
+    expect(one[0]._duplicatePenalty).toBe(1)
+  })
+
+  it('tolerates results with missing or non-string content', () => {
+    const ranked = rank(
+      [
+        { id: 'ok', content: 'LRI binary format header parsing details', confidence: 1, timestamp: daysAgo(1) },
+        { id: 'empty', content: '', confidence: 1, timestamp: daysAgo(1) },
+        { id: 'missing', confidence: 1, timestamp: daysAgo(1) },
+      ],
+      'LRI binary format',
+    )
+    expect(ranked).toHaveLength(3)
+    expect(ranked[0].id).toBe('ok')
+    for (const r of ranked) expect(Number.isFinite(r._score)).toBe(true)
+  })
+})
+
+describe('both fixes compose without undoing the behaviour already in place', () => {
+  it('still damps a long off-topic note against a short exact match', () => {
+    const megaNote = {
+      id: 'mega',
+      content: 'Session log. ' + 'Assorted unrelated work across many projects. '.repeat(70) + 'Ollama classify timeout mentioned once. ',
+      confidence: 1,
+      timestamp: daysAgo(0),
+    }
+    const precise = { id: 'precise', content: 'Ollama classify timeout raised from 3000ms to 8000ms.', confidence: 1, timestamp: daysAgo(45) }
+    expect(rank([megaNote, precise], 'Ollama classify timeout')[0].id).toBe('precise')
+  })
+
+  it('still uses recency as a tie-breaker, not a trump card', () => {
+    const results = [
+      { id: 'new-irrelevant', content: 'unrelated note about jewellery auctions in the spring catalogue', confidence: 1, timestamp: daysAgo(0) },
+      { id: 'old-relevant', content: 'Ollama classify timeout budget raised; probe widened; classification restored', confidence: 1, timestamp: daysAgo(300) },
+    ]
+    expect(rank(results, 'Ollama classify timeout budget')[0].id).toBe('old-relevant')
+  })
+
+  it('still refuses substring matches once term weighting is in play', () => {
+    const results = [
+      { id: 'substring', content: 'the timeoutvalue setting was left at its default across the whole cluster', confidence: 1, timestamp: daysAgo(0) },
+      { id: 'real', content: 'the classify timeout was raised after the probe measured a slow cold load', confidence: 1, timestamp: daysAgo(200) },
+    ]
+    const ranked = rank(results, 'timeout')
+    expect(ranked[0].id).toBe('real')
+    expect(ranked.find((r: any) => r.id === 'substring')._relevance).toBe(0)
+  })
+})

--- a/src/tools/UnifiedSearchTool.ts
+++ b/src/tools/UnifiedSearchTool.ts
@@ -496,19 +496,323 @@ export class UnifiedSearchTool {
    * Scoring is now explicit and inspectable: lexical relevance, recency, and a small
    * confidence contribution, combined into `_score` and attached to each result so a
    * caller can see WHY something ranked where it did.
+   *
+   * Two rank-time passes run on top of that composite:
+   *
+   *  1. TERM WEIGHTING (IDF over the candidate set). Query terms are no longer equal.
+   *     A term present in nearly every candidate cannot discriminate between them; a
+   *     term present in one or two is what the user actually asked about. See
+   *     `computeTermWeights`.
+   *  2. NEAR-DUPLICATE SUPPRESSION. A cluster of paraphrases of one entry can no
+   *     longer occupy the whole top-N. See `suppressNearDuplicates`.
    */
   private rankResults(results: any[], query: string): any[] {
+    // IDF is computed over the candidates actually in hand — no global corpus index
+    // is needed, and none exists. Discriminating power is a property of the set being
+    // ranked, which is exactly the set we have.
+    const termWeights = this.computeTermWeights(results, query)
+
     const scored = results.map(r => {
-      const relevance = this.calculateRelevance(r.content, query)
+      const relevance = this.calculateRelevance(r.content, query, termWeights)
       const recency = this.calculateRecency(r.timestamp)
       // Relevance dominates; recency breaks ties between comparably relevant hits
       // (memory is corrected over time, so newer entries about the same topic usually
       // supersede older ones). Confidence contributes only marginally — it is nearly
       // always 1 and carries almost no ranking signal.
       const score = relevance * 0.70 + recency * 0.25 + (r.confidence ?? 0) * 0.05
-      return { ...r, _score: Number(score.toFixed(4)), _relevance: Number(relevance.toFixed(4)), _recency: Number(recency.toFixed(4)) }
+      return {
+        ...r,
+        _score: Number(score.toFixed(4)),
+        _relevance: Number(relevance.toFixed(4)),
+        _recency: Number(recency.toFixed(4)),
+        // New signals, exposed the same inspectable way as _score/_relevance/_recency:
+        // a caller can see which query terms this entry actually hit and how much each
+        // was worth against this candidate set.
+        _termWeights: termWeights,
+        _matchedTerms: this.matchedTerms(r.content, query)
+      }
     })
-    return scored.sort((a, b) => b._score - a._score)
+
+    scored.sort((a, b) => b._score - a._score)
+    return this.suppressNearDuplicates(scored)
+  }
+
+  /**
+   * IDF-style weight per query term, computed over the candidate set being ranked.
+   *
+   * WHY: query "Joytopia brand colors" scored 0.0 on the retrieval baseline. Every
+   * candidate was some project's brand colors — Tengo's, BlockCopy26's — because
+   * "brand" and "colors" matched everywhere and the one term that actually named the
+   * target, "Joytopia", counted for exactly as much as they did (1/3 of coverage
+   * each). Unweighted coverage cannot tell a discriminating proper noun apart from
+   * boilerplate vocabulary.
+   *
+   * The weight is the BM25 IDF form, `ln(1 + (N - df + 0.5) / (df + 0.5))`, which is
+   * smooth, needs no global corpus, and stays finite at df = N. For the failing query
+   * with 6 candidates of which 1 contains "joytopia" and all 6 contain "brand", that
+   * is ~1.54 vs ~0.07 — a 20x spread — so the single candidate carrying the proper
+   * noun takes nearly all of the available coverage.
+   *
+   * Weights are normalised to sum to 1 across the terms that appear at all, so
+   * `_relevance` keeps the same [0, 1] meaning it had before and stays comparable to
+   * the unweighted case.
+   *
+   * Terms with df = 0 (present in no candidate) get weight 0 and drop out of the
+   * denominator: a term nobody has cannot discriminate either, and leaving it in
+   * would deflate every score by the same factor for no ranking benefit.
+   *
+   * Returns {} — meaning "fall back to uniform weights" — when there is nothing to
+   * discriminate (fewer than 2 candidates, or no term present anywhere).
+   */
+  private computeTermWeights(results: any[], query: string): Record<string, number> {
+    const terms = this.extractQueryTerms(query)
+    if (terms.length === 0) return {}
+
+    const N = results.length
+    // With 0 or 1 candidate there is no "rest of the set" to be rare relative to.
+    if (N < 2) return {}
+
+    const contents = results.map(r => String(r?.content ?? '').toLowerCase())
+
+    const raw: Record<string, number> = {}
+    let total = 0
+    for (const term of terms) {
+      let df = 0
+      for (const content of contents) {
+        if (this.countOccurrences(content, term) > 0) df++
+      }
+      const idf = df === 0 ? 0 : Math.log(1 + (N - df + 0.5) / (df + 0.5))
+      raw[term] = idf
+      total += idf
+    }
+
+    if (total <= 0) return {}
+
+    const weights: Record<string, number> = {}
+    for (const term of terms) {
+      weights[term] = Number((raw[term] / total).toFixed(6))
+    }
+    return weights
+  }
+
+  /**
+   * Query terms after tokenisation and stopword removal — the unit both relevance
+   * scoring and term weighting operate on. Extracted so the two can never drift:
+   * an IDF weight keyed on a term the matcher never looks up is silently inert.
+   */
+  private extractQueryTerms(query: string): string[] {
+    if (!query) return []
+    // Drop stopwords and 1-char fragments so common filler does not inflate coverage.
+    const STOP = new Set(['the', 'a', 'an', 'and', 'or', 'of', 'to', 'in', 'for', 'on', 'is', 'it'])
+    return Array.from(new Set(
+      query.trim().toLowerCase().split(/[^a-z0-9_.-]+/).filter(t => t.length > 1 && !STOP.has(t))
+    ))
+  }
+
+  /**
+   * Word-boundary occurrence count of one term in already-lowercased content.
+   *
+   * Bounded on BOTH sides. A leading \b alone still prefix-matches, so "timeout"
+   * would score against "timeoutvalue" — the substring defect this matcher exists to
+   * remove, in its prefix form.
+   *
+   * A short inflectional suffix is allowed so "timeout" matches "timeouts" and
+   * "abort" matches "aborted"; that is real recall, not accidental overlap. Terms
+   * ending in "e" get that "e" made optional so "route" also reaches "routing"
+   * (rout + ing). Anything beyond these suffixes must clear its own word boundary.
+   */
+  private countOccurrences(contentLower: string, term: string): number {
+    if (!contentLower || !term) return 0
+    const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const stem = escaped.endsWith('e') ? `${escaped.slice(0, -1)}e?` : escaped
+    return (contentLower.match(new RegExp(`\\b${stem}(?:s|es|ed|ing)?\\b`, 'g')) || []).length
+  }
+
+  /** Which query terms this entry actually contains — the per-result half of `_termWeights`. */
+  private matchedTerms(content: string, query: string): string[] {
+    if (!content) return []
+    const contentLower = String(content).toLowerCase()
+    return this.extractQueryTerms(query).filter(t => this.countOccurrences(contentLower, t) > 0)
+  }
+
+  /**
+   * Demote near-duplicates so one cluster of paraphrases cannot own the top-N.
+   *
+   * WHY: query "LRI binary parsing format" scored 0.0 on the retrieval baseline. The
+   * top five hits were all near-paraphrases of the SAME governance/process rule —
+   * the corpus holds 3+ close variants of it — and the single entry that actually
+   * described the binary format sat at ~8th. Every one of those five was individually
+   * a defensible hit; collectively they were one hit repeated, and they consumed the
+   * entire result window.
+   *
+   * Note this is a different problem from `deduplicateResults`, which collapses the
+   * same entry id arriving from several backends. These are genuinely distinct rows
+   * with distinct ids whose *content* is a rewording of each other.
+   *
+   * Measure: Jaccard over content-word token sets, vetoed by literal conflict. No
+   * embeddings, no model, O(n²) on a result set that is tens of items at most.
+   * Deliberately conservative — a missed duplicate costs one wasted slot, a wrongly
+   * collapsed pair costs a real answer:
+   *
+   *  - Threshold 0.50 of the combined vocabulary, sitting in the middle of a measured
+   *    gap. Against real corpus shapes, reworded variants of one rule land at
+   *    0.70-0.89, while distinct entries that merely share vocabulary top out at 0.27
+   *    (two different Ollama facts 0.04, two brand-colors entries 0.11, the
+   *    contradicting Phoenix camera-count entries 0.15, two steps of one procedure
+   *    0.19, two facts about kms_supersede 0.20, two distinct prose rules on one topic
+   *    0.27).
+   *  - LITERAL CONFLICT VETO. Two shapes defeat word overlap on its own: templated
+   *    one-liners ("service X listens on port N at host H" — 0.38 between entries about
+   *    entirely different services) and enumerated tables ("the refuse band starts at
+   *    0.88 / the confirm band runs 0.78 to 0.88" — 0.41, and they are not the same
+   *    fact). Both would otherwise sit uncomfortably close to the threshold, and both
+   *    are common in this corpus. What separates them from real paraphrases is that a
+   *    rewording preserves
+   *    the VALUES while a different fact changes them. So when both entries carry
+   *    literals — tokens holding a digit or an internal dot: numbers, versions, ports,
+   *    hostnames, filenames, hex offsets — and the smaller literal set is less than 60%
+   *    contained in the larger, the pair is never a duplicate no matter how much prose
+   *    it shares. Containment rather than Jaccard, so a paraphrase that simply drops a
+   *    detail is not vetoed. If either side has no literals the veto cannot fire.
+   *  - Entries with fewer than 8 content tokens are neither demoted nor allowed to
+   *    demote others. Jaccard is unstable on very short text — "Rich prefers dark
+   *    mode" vs "Rich prefers light mode" scores 0.75 while meaning opposite things —
+   *    so short entries are exempt in both directions.
+   *  - Single-linkage clustering: a candidate is compared against every member of a
+   *    cluster, not just its representative. Paraphrase chains drift, and variant 4 of
+   *    a rule is often closer to variant 2 than to the one that happened to rank first.
+   *  - Results are DEMOTED, never dropped. The cluster's best-scoring member keeps its
+   *    full score; the second gets 0.45x, the third 0.2x, and so on. A caller who
+   *    wants the variants can still page down to them, and `_duplicateOf` /
+   *    `_duplicateSimilarity` / `_duplicatePenalty` say exactly what happened.
+   *
+   * Input must already be sorted best-first: the first member of a cluster reached is
+   * the one kept at full score.
+   */
+  private suppressNearDuplicates(sorted: any[]): any[] {
+    const DUP_SIMILARITY = 0.50   // shared fraction of combined vocabulary
+    const MIN_TOKENS = 8          // below this, Jaccard is noise
+    const DEMOTE = 0.45           // multiplicative, compounding per extra cluster member
+
+    const clusters: Array<{ key: string, members: Array<{ tokens: Set<string>, literals: Set<string> }> }> = []
+
+    for (let i = 0; i < sorted.length; i++) {
+      const r = sorted[i]
+      r._duplicateOf = null
+      r._duplicateSimilarity = 0
+      r._duplicatePenalty = 1
+
+      const tokens = this.contentTokens(r.content)
+      if (tokens.size < MIN_TOKENS) continue
+      const literals = this.literalTokens(tokens)
+
+      let best: { key: string, members: Array<{ tokens: Set<string>, literals: Set<string> }> } | null = null
+      let bestSim = 0
+      for (const cluster of clusters) {
+        for (const member of cluster.members) {
+          if (this.literalsConflict(literals, member.literals)) continue
+          const sim = this.jaccard(tokens, member.tokens)
+          if (sim > bestSim) {
+            bestSim = sim
+            best = cluster
+          }
+        }
+      }
+
+      if (best && bestSim >= DUP_SIMILARITY) {
+        const penalty = Math.pow(DEMOTE, best.members.length)
+        best.members.push({ tokens, literals })
+        r._duplicateOf = best.key
+        r._duplicateSimilarity = Number(bestSim.toFixed(4))
+        r._duplicatePenalty = Number(penalty.toFixed(4))
+        r._score = Number((r._score * penalty).toFixed(4))
+      } else {
+        clusters.push({ key: r.id ?? `#${i}`, members: [{ tokens, literals }] })
+      }
+    }
+
+    // Stable re-sort: demoted members fall below the distinct entries they were
+    // crowding out, while untouched results keep their relative order.
+    return sorted.sort((a, b) => b._score - a._score)
+  }
+
+  /**
+   * Content-word token set for near-duplicate comparison.
+   *
+   * A wider stopword list than query-term extraction uses on purpose: function words
+   * are shared by *every* pair of English sentences, so leaving them in inflates
+   * Jaccard uniformly and pushes unrelated entries toward the threshold. Duplicate
+   * detection wants to compare what the entries are ABOUT.
+   */
+  private contentTokens(content: string): Set<string> {
+    if (!content) return new Set()
+    const STOP = new Set([
+      'the', 'a', 'an', 'and', 'or', 'of', 'to', 'in', 'for', 'on', 'is', 'it', 'be',
+      'are', 'was', 'were', 'been', 'as', 'at', 'by', 'with', 'from', 'that', 'this',
+      'these', 'those', 'but', 'not', 'no', 'do', 'does', 'did', 'has', 'have', 'had',
+      'will', 'would', 'can', 'could', 'should', 'must', 'may', 'if', 'then', 'than',
+      'so', 'such', 'all', 'any', 'each', 'its', 'we', 'you', 'they', 'them', 'their',
+      'our', 'us', 'via', 'per', 'into', 'onto', 'out', 'up', 'over', 'under', 'when',
+      'while', 'until', 'unless', 'also', 'only', 'just', 'more', 'most', 'other',
+      'there', 'here', 'how', 'what', 'which', 'who', 'why'
+    ])
+    const tokens = String(content).toLowerCase().split(/[^a-z0-9_.-]+/)
+    const out = new Set<string>()
+    for (const raw of tokens) {
+      // Trailing sentence punctuation rides along because "." and "-" are kept inside
+      // tokens (they have to be, for "0.88", "kms.yaker.org" and "read-only"). Trim it
+      // at the edges only, so "default." and "default" are the same word — and so the
+      // literal test below is not fooled into treating every sentence-final word as a
+      // dotted identifier.
+      const t = raw.replace(/^[.-]+/, '').replace(/[.-]+$/, '')
+      if (t.length <= 1 || STOP.has(t)) continue
+      // Fold trivial inflections so "modified"/"modify" style rewordings of one rule
+      // are not treated as different vocabulary.
+      out.add(t.replace(/(?:ing|ed|es|s)$/, ''))
+    }
+    return out
+  }
+
+  /**
+   * The subset of tokens that carry a VALUE rather than prose: anything with a digit
+   * (8180, 0.88, 32-byte, 0x10, v2) or an internal dot (kms.yaker.org, sparrowdb.node,
+   * metadata.subject). These are what a reworded entry preserves and a different fact
+   * changes — see the literal-conflict veto in `suppressNearDuplicates`.
+   */
+  private literalTokens(tokens: Set<string>): Set<string> {
+    const out = new Set<string>()
+    for (const t of tokens) {
+      if (/\d/.test(t) || t.includes('.')) out.add(t)
+    }
+    return out
+  }
+
+  /**
+   * True when two entries cite materially different values, which rules out their
+   * being rewordings of each other.
+   *
+   * Containment of the smaller set in the larger, not Jaccard: a paraphrase is allowed
+   * to drop details ({0.88} inside {0.88, 0.85} is not a conflict), but it may not
+   * substitute them ({8180} vs {9102} is). If either side cites no literals at all
+   * there is nothing to compare and the veto stays silent.
+   */
+  private literalsConflict(a: Set<string>, b: Set<string>): boolean {
+    if (a.size === 0 || b.size === 0) return false
+    const MIN_CONTAINMENT = 0.6
+    const [small, large] = a.size <= b.size ? [a, b] : [b, a]
+    let shared = 0
+    for (const t of small) if (large.has(t)) shared++
+    return (shared / small.size) < MIN_CONTAINMENT
+  }
+
+  /** |A ∩ B| / |A ∪ B|. Empty on either side means "no evidence of duplication". */
+  private jaccard(a: Set<string>, b: Set<string>): number {
+    if (a.size === 0 || b.size === 0) return 0
+    let intersection = 0
+    const [small, large] = a.size <= b.size ? [a, b] : [b, a]
+    for (const t of small) if (large.has(t)) intersection++
+    const union = a.size + b.size - intersection
+    return union === 0 ? 0 : intersection / union
   }
 
   /**
@@ -519,42 +823,51 @@ export class UnifiedSearchTool {
    * an *Ollama* timeout, because "timeout" appeared somewhere in the text. Coverage
    * (what fraction of query terms appear at all) is the dominant signal, with bounded
    * bonuses for repetition and for the full query appearing as a phrase.
+   *
+   * `termWeights` (optional) makes coverage WEIGHTED rather than uniform, so a rare,
+   * discriminating term counts for more of the score than boilerplate vocabulary the
+   * whole candidate set shares. See `computeTermWeights` for how they are derived and
+   * why. Omitted or empty → every term weighs 1, i.e. the original behaviour exactly;
+   * the function stays usable standalone on a single document with no candidate set.
    */
-  private calculateRelevance(content: string, query: string): number {
+  private calculateRelevance(content: string, query: string, termWeights?: Record<string, number>): number {
     if (!content || !query) return 0
 
     const contentLower = content.toLowerCase()
     const queryLower = query.trim().toLowerCase()
-    // Drop stopwords and 1-char fragments so common filler does not inflate coverage.
-    const STOP = new Set(['the', 'a', 'an', 'and', 'or', 'of', 'to', 'in', 'for', 'on', 'is', 'it'])
-    const terms = Array.from(new Set(
-      queryLower.split(/[^a-z0-9_.-]+/).filter(t => t.length > 1 && !STOP.has(t))
-    ))
+    const terms = this.extractQueryTerms(query)
     if (terms.length === 0) return 0
 
-    let matched = 0
-    let density = 0
+    const weightFor = (term: string): number => {
+      if (termWeights && Object.prototype.hasOwnProperty.call(termWeights, term)) {
+        const w = termWeights[term]
+        // A legitimate 0 (term present in no candidate) must survive; only garbage
+        // falls back to the neutral weight.
+        if (typeof w === 'number' && Number.isFinite(w) && w >= 0) return w
+      }
+      return 1
+    }
+
+    let totalWeight = 0
+    let matchedWeight = 0
+    let densityWeight = 0
     for (const term of terms) {
-      const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-      // Bounded on BOTH sides. A leading \b alone still prefix-matches, so "timeout"
-      // would score against "timeoutvalue" — the substring defect this function exists
-      // to remove, in its prefix form.
-      //
-      // A short inflectional suffix is allowed so "timeout" matches "timeouts" and
-      // "abort" matches "aborted"; that is real recall, not accidental overlap. Terms
-      // ending in "e" get that "e" made optional so "route" also reaches "routing"
-      // (rout + ing). Anything beyond these suffixes must clear its own word boundary.
-      const stem = escaped.endsWith('e') ? `${escaped.slice(0, -1)}e?` : escaped
-      const occurrences = (contentLower.match(new RegExp(`\\b${stem}(?:s|es|ed|ing)?\\b`, 'g')) || []).length
+      const weight = weightFor(term)
+      totalWeight += weight
+      const occurrences = this.countOccurrences(contentLower, term)
       if (occurrences > 0) {
-        matched++
+        matchedWeight += weight
         // Diminishing returns — a term repeated 20x is not 20x more relevant.
-        density += Math.min(occurrences, 5) / 5
+        densityWeight += weight * (Math.min(occurrences, 5) / 5)
       }
     }
 
-    const coverage = matched / terms.length          // how much of the query is present
-    const densityScore = density / terms.length      // how emphatically
+    // Every term weighed 0 → nothing in this query can discriminate. Score 0 rather
+    // than divide by zero.
+    if (totalWeight <= 0) return 0
+
+    const coverage = matchedWeight / totalWeight      // how much of the query is present
+    const densityScore = densityWeight / totalWeight  // how emphatically
 
     // Phrase bonus must be word-boundary matched too. A plain includes() would fire on
     // "value" inside "timeoutvalue" — the same substring bug this rewrite exists to fix,


### PR DESCRIPTION
## What

Fixes the two named causes of poor retrieval from the baseline measurement (mean P@5 = 0.54, P@1 = 0.70 over 20 real queries). Both were measured, neither was addressed.

Scope: `src/tools/UnifiedSearchTool.ts` and a new test file. Nothing else touched.

## Cause 1 — no entity / proper-noun weighting

`"Joytopia brand colors"` scored **0.0**. All five hits were other projects' brand colors (Tengo portal-frontend, BlockCopy26 rebrand); the real `joytopia-brand-identity` content never surfaced. Coverage counted every query term equally, so the generic phrase that matched everywhere outvoted the one proper noun that named the target 2:1.

`rankResults` now derives an **IDF weight per query term over the candidate set it has in hand** — no global corpus index needed, because discriminating power is a property of the set being ranked. BM25 IDF form `ln(1 + (N - df + 0.5) / (df + 0.5))`, normalised to sum to 1 so `_relevance` keeps its `[0,1]` meaning.

`calculateRelevance` takes the weights as an optional third argument and is **behaviour-identical without them** — it stays usable standalone on a single document, and every existing caller and test of the two-argument form is unaffected.

## Cause 2 — near-duplicate entries crowd out substance

`"LRI binary parsing format"` scored **0.0**. The top five were all rewordings of one governance rule while the entry describing the actual binary format sat below the window.

This is a different problem from `deduplicateResults`, which collapses one entry id arriving from several backends. These are separate rows whose *content* is a paraphrase of each other.

`suppressNearDuplicates` clusters at rank time on Jaccard over content-word token sets — no embeddings — keeps each cluster's best-scoring member at full score and **demotes** the rest by a compounding 0.45x. Demoted, never dropped, and annotated so the decision is auditable.

### Kept deliberately conservative

A wrongly collapsed pair costs a real answer; a missed duplicate costs one slot. So the bias is toward missing:

- **Threshold 0.50, sitting mid-gap.** Measured on real corpus shapes: rewordings of one rule land at **0.70–0.89**, distinct entries that merely share vocabulary top out at **0.27**.
- **Literal-conflict veto.** Two shapes defeat word overlap on its own — templated one-liners (two different services on different ports, 0.38) and rows of one table (two dedup-gate bands, 0.41). Both sit uncomfortably near the threshold and both are common in this corpus. What separates them from real paraphrases: a rewording preserves the *values* while a different fact changes them. So when both entries cite literals (tokens with a digit or an internal dot — ports, versions, hostnames, hex offsets) and they conflict, the pair is never a duplicate. Containment rather than equality, so a paraphrase may drop a detail without tripping it.
- **Entries under 8 content tokens are exempt in both directions.** Jaccard is noise there: `"prefers dark mode"` vs `"prefers light mode"` scores 0.75 while meaning opposite things.
- **Single-linkage clustering**, since variant 4 of a rule is often closer to variant 2 than to whichever one happened to rank first.

## Measured effect

Both failing queries, against local fixtures built to the described corpus shapes:

**`Joytopia brand colors`** — target moves from outside the window to rank 1:

| | before | after |
|---|---|---|
| 1 | sparrowdb-docs-theme | **joytopia-brand-identity** |
| 2 | tengo-portal-frontend | sparrowdb-docs-theme |
| 3 | trading-dashboard-theme | trading-dashboard-theme |
| 4 | blockcopy26-rebrand | tengo-portal-frontend |
| 5 | abundance-coach-site | blockcopy26-rebrand |
| 6 | **joytopia-brand-identity** | abundance-coach-site |

P@5 0.0 → 1.0, P@1 0 → 1. Term weights `{joytopia: 0.912, brand: 0.044, colors: 0.044}` — a 20x spread. Score margin over the runner-up is 1.5x, not a hair.

**`LRI binary parsing format`** — the format entry moves from outside the window to rank 2:

| | before | after |
|---|---|---|
| 1 | gov-1 | gov-1 |
| 2 | gov-2 | **lri-binary-format-spec** |
| 3 | gov-3 | note-calibration-payload |
| 4 | gov-4 | gov-2 *(dup of gov-1, 0.76, 0.45x)* |
| 5 | gov-5 | note-lldb-bridge |
| 6 | **lri-binary-format-spec** | note-per-camera-isp |

P@5 0.0 → the real answer at rank 2. One representative of the governance cluster is kept at the top (it *is* a legitimate hit for this query) — it just no longer occupies all five slots.

## Inspectability

Both new signals are exposed the same way as `_score` / `_relevance` / `_recency`, on every result:

- `_termWeights` — the IDF weight each query term earned against this candidate set
- `_matchedTerms` — which of them this entry actually contains
- `_duplicateOf`, `_duplicateSimilarity`, `_duplicatePenalty` — null / 0 / 1 when untouched

## Preserved

Word-boundary matching with inflection, stopword filtering, 90-day-half-life recency as tie-breaker rather than trump card, length damping (`NEUTRAL_LEN` 500, floor 0.6). Each is re-pinned against the new composite in `both fixes compose without undoing the behaviour already in place`.

## Tests

**466 → 501, all passing. `npx tsc --noEmit` clean. No existing assertion weakened or skipped.**

Each failing case is pinned **twice**: once through `preFixRank`, an emulation of the ranker as it was, asserting the fixture genuinely reproduces the baseline failure, and once through the real `rankResults`. A fixture that quietly stopped reproducing the bug would make the "after" assertion vacuous, so both halves are asserted.

Nine distinct-pair cases pin the conservatism — two different Ollama facts, two steps of one procedure, two services on different ports, two rows of a threshold table, two facts about the same binary format, two projects' brand colors, a fact and its correction, two behaviours of one tool, two distinct prose rules on one topic. None may be collapsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfUP35PJDzrYLpVcbWEbsk


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved search ranking so distinctive names and terms receive more relevant results.
  * Reduced clutter from near-duplicate results while preserving content with meaningful differences.
  * Added safeguards for exact wording conflicts and short entries.
  * Improved handling of inflections, word boundaries, unmatched terms, and malformed searches.

* **Bug Fixes**
  * Improved relevance scoring while preserving recency, length, and substring-match behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->