### PR TITLE
feat(eval): capture pre-ranking candidate pools so rankers can be compared

### DIFF
--- a/src/__tests__/UnifiedSearchTool.dedup.test.ts
+++ b/src/__tests__/UnifiedSearchTool.dedup.test.ts
@@ -106,6 +106,49 @@ describe('UnifiedSearchTool.deduplicateResults', () => {
     expect(dedupe([a, b])).toHaveLength(1)
   })
 
+  it('carries the content-hash fallback key onto the merged object as a string id', () => {
+    // The eval capture joins candidates back to relevance labels by `.id`. If the
+    // fallback hash is only ever used as the internal Map key and never written back
+    // onto the object, every id-less candidate comes out with `id: undefined` and is
+    // unjoinable — silently defeating the harness.
+    const a = { content: 'same text', confidence: 0.5, sourceSystem: 'graph' }
+    const b = { content: 'same text', confidence: 0.9, sourceSystem: 'mongodb' }
+    const [out] = dedupe([a, b])
+    expect(typeof out.id).toBe('string')
+    expect(out.id.length).toBeGreaterThan(0)
+  })
+
+  it('backfills a string id even for a single id-less entry (no merge occurs)', () => {
+    const [out] = dedupe([{ content: 'lonely entry', confidence: 1, sourceSystem: 'mem0' }])
+    expect(typeof out.id).toBe('string')
+    expect(out.id.length).toBeGreaterThan(0)
+  })
+
+  it('preserves metadata.subject and metadata.extractedBy from the losing copy even when neither copy has entityRefs', () => {
+    // Previously the merged metadata object was only assigned when entityRefs was
+    // non-empty; with no entityRefs at all, metadata came solely from the "base" (the
+    // longer-content) copy, silently dropping subject/extractedBy carried only by the
+    // shorter copy. metaShareAtK reads exactly these fields off the eval capture.
+    const short = graphCopy({ metadata: { subject: 'KMS.retrieval.audit', extractedBy: 'kms-session-extract' } })
+    const long = mongoCopy({
+      content: 'Ollama classify timeout raised to 8000ms after measuring 5219ms cold load',
+      metadata: {}
+    })
+    const [out] = dedupe([short, long])
+    expect(out.metadata.subject).toBe('KMS.retrieval.audit')
+    expect(out.metadata.extractedBy).toBe('kms-session-extract')
+  })
+
+  it('lets the base (longer-content) copy win a genuine subject/extractedBy conflict', () => {
+    const short = graphCopy({ metadata: { subject: 'old.subject' } })
+    const long = mongoCopy({
+      content: 'Ollama classify timeout raised to 8000ms after measuring 5219ms cold load',
+      metadata: { subject: 'new.subject' }
+    })
+    const [out] = dedupe([short, long])
+    expect(out.metadata.subject).toBe('new.subject')
+  })
+
   it('handles an empty input', () => {
     expect(dedupe([])).toEqual([])
   })

--- a/src/__tests__/UnifiedSearchTool.evalCapture.test.ts
+++ b/src/__tests__/UnifiedSearchTool.evalCapture.test.ts
@@ -1,0 +1,101 @@
+/**
+ * KMS_EVAL_CAPTURE tests for UnifiedSearchTool.search().
+ *
+ * The capture exists so a ranker can be replayed offline over the exact
+ * deduplicated pool a live search saw (see src/eval/rankers.ts header). These tests
+ * pin: the capture is off by default, present end-to-end when enabled, exposed on
+ * the declared return type (not just via a cast), and NOT silently dropped on a
+ * cache hit against an entry written before capture was enabled.
+ */
+
+import { UnifiedSearchTool } from '../tools/UnifiedSearchTool.js'
+
+const buildTool = (mem0Results: any[]) => {
+  const mongo = { search: jest.fn().mockResolvedValue([]) }
+  const graph = {
+    search: jest.fn().mockResolvedValue([]),
+    getEntitySummary: jest.fn().mockResolvedValue(null),
+    getOperationalNodes: jest.fn().mockResolvedValue([])
+  }
+  const mem0 = { search: jest.fn().mockResolvedValue(mem0Results) }
+
+  // A minimal in-memory cache stand-in — real enough to round-trip a stored
+  // value back out of get(), which is what the cache-hit tests need.
+  const store = new Map<string, any>()
+  const cache = {
+    get: jest.fn(async (key: string) => store.get(key) ?? null),
+    set: jest.fn(async (key: string, value: any) => { store.set(key, value) }),
+    invalidate: jest.fn().mockResolvedValue(undefined)
+  }
+
+  const tool = new UnifiedSearchTool({ mongodb: mongo, graph, mem0 } as any, cache as any)
+  return { tool, mongo, graph, mem0, cache }
+}
+
+const oneResult = [{
+  id: 'r1',
+  content: 'Ollama classify timeout raised to 8000ms',
+  confidence: 1,
+  metadata: { subject: 'KMS.retrieval.audit', extractedBy: 'kms-session-extract' }
+}]
+
+describe('UnifiedSearchTool — KMS_EVAL_CAPTURE', () => {
+  const ORIGINAL_ENV = process.env.KMS_EVAL_CAPTURE
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) delete process.env.KMS_EVAL_CAPTURE
+    else process.env.KMS_EVAL_CAPTURE = ORIGINAL_ENV
+  })
+
+  it('omits _evalCapture by default (flag unset)', async () => {
+    delete process.env.KMS_EVAL_CAPTURE
+    const { tool } = buildTool(oneResult)
+    const result = await tool.search({ query: 'ollama timeout' })
+    expect(result._evalCapture).toBeUndefined()
+  })
+
+  it('captures the deduplicated pool, joinable by a stable string id, when enabled', async () => {
+    process.env.KMS_EVAL_CAPTURE = '1'
+    const { tool } = buildTool(oneResult)
+    const result = await tool.search({ query: 'ollama timeout' })
+
+    expect(result._evalCapture).toBeDefined()
+    expect(result._evalCapture!.candidates).toHaveLength(1)
+    const candidate = result._evalCapture!.candidates[0]
+    expect(typeof candidate.id).toBe('string')
+    expect(candidate.id).toBe('r1')
+    // metaShareAtK reads exactly these two fields off the capture.
+    expect(candidate.subject).toBe('KMS.retrieval.audit')
+    expect(candidate.extractedBy).toBe('kms-session-extract')
+  })
+
+  it('returns _evalCapture on a cache hit when the cached entry has a full capture', async () => {
+    process.env.KMS_EVAL_CAPTURE = '1'
+    const { tool } = buildTool(oneResult)
+
+    const first = await tool.search({ query: 'ollama timeout' })
+    expect(first.fromCache).toBe(false)
+    expect(first._evalCapture).toBeDefined()
+
+    const second = await tool.search({ query: 'ollama timeout' })
+    expect(second.fromCache).toBe(true)
+    expect(second._evalCapture).toBeDefined()
+    expect(second._evalCapture!.candidates[0].id).toBe('r1')
+  })
+
+  it('treats a cache entry written without capture as a miss when the flag is later enabled', async () => {
+    const { tool, mem0 } = buildTool(oneResult)
+
+    delete process.env.KMS_EVAL_CAPTURE
+    const first = await tool.search({ query: 'ollama timeout' })
+    expect(first._evalCapture).toBeUndefined()
+    expect(mem0.search).toHaveBeenCalledTimes(1)
+
+    process.env.KMS_EVAL_CAPTURE = '1'
+    const second = await tool.search({ query: 'ollama timeout' })
+    // Must NOT be served from the capture-less cache entry as a hit.
+    expect(second.fromCache).toBe(false)
+    expect(second._evalCapture).toBeDefined()
+    expect(mem0.search).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/__tests__/eval-rankers.test.ts
+++ b/src/__tests__/eval-rankers.test.ts
@@ -102,4 +102,27 @@ describe('metrics', () => {
   it('ndcg is 0 when nothing is labelled relevant', () => {
     expect(ndcgAtK(ordered, { '1': 0, '2': 0 }, 5)).toBe(0)
   })
+
+  it('rejects a negative k instead of silently slicing/dividing by it', () => {
+    expect(() => precisionAtK(ordered, labels, -1)).toThrow(RangeError)
+    expect(() => ndcgAtK(ordered, labels, -1)).toThrow(RangeError)
+    expect(() => metaShareAtK(ordered, -1)).toThrow(RangeError)
+  })
+
+  it('rejects a non-integer k instead of silently truncating the slice', () => {
+    expect(() => precisionAtK(ordered, labels, 2.5)).toThrow(RangeError)
+    expect(() => ndcgAtK(ordered, labels, 2.5)).toThrow(RangeError)
+    expect(() => metaShareAtK(ordered, 2.5)).toThrow(RangeError)
+  })
+
+  it('rejects a non-finite k (NaN/Infinity)', () => {
+    expect(() => precisionAtK(ordered, labels, NaN)).toThrow(RangeError)
+    expect(() => precisionAtK(ordered, labels, Infinity)).toThrow(RangeError)
+  })
+
+  it('k=0 is valid and yields 0, not a division-by-zero artifact', () => {
+    expect(precisionAtK(ordered, labels, 0)).toBe(0)
+    expect(ndcgAtK(ordered, labels, 0)).toBe(0)
+    expect(metaShareAtK(ordered, 0)).toBe(0)
+  })
 })

--- a/src/__tests__/eval-rankers.test.ts
+++ b/src/__tests__/eval-rankers.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for the retrieval eval harness.
+ *
+ * These pin the harness itself, not the ranker — a scoring harness that is wrong is
+ * worse than none, because its numbers get trusted. The legacy ranker in particular
+ * must reproduce the ORIGINAL behaviour including its bugs; a "cleaned up" baseline
+ * would flatter every comparison against it.
+ */
+
+import {
+  legacyRanker, shippedRanker,
+  precisionAtK, reciprocalRank, ndcgAtK, metaShareAtK,
+  type EvalCandidate,
+} from '../eval/rankers.js'
+
+const c = (id: string, content: string, over: Partial<EvalCandidate> = {}): EvalCandidate =>
+  ({ id, content, confidence: 1, ...over })
+
+describe('legacyRanker — must reproduce pre-#85 behaviour, bugs included', () => {
+  it('sorts by confidence first when the gap exceeds 0.1', () => {
+    const out = legacyRanker([
+      c('low', 'exact query match here', { confidence: 0.5 }),
+      c('high', 'nothing to do with it', { confidence: 1 }),
+    ], 'exact query match here')
+    // Confidence wins outright — this is the defect that made the ranker inert,
+    // since every stored entry carries confidence 1.
+    expect(out[0].id).toBe('high')
+  })
+
+  it('falls through to relevance when confidences are within 0.1', () => {
+    const out = legacyRanker([
+      c('off', 'unrelated text', { confidence: 1 }),
+      c('on', 'ollama timeout classification', { confidence: 0.95 }),
+    ], 'ollama timeout classification')
+    expect(out[0].id).toBe('on')
+  })
+
+  it('matches substrings, not word boundaries (original defect preserved)', () => {
+    const out = legacyRanker([
+      c('none', 'completely unrelated', { confidence: 1 }),
+      c('substr', 'the timeoutvalue setting', { confidence: 1 }),
+    ], 'timeout')
+    // "timeout" inside "timeoutvalue" counted as a hit for the legacy scorer.
+    expect(out[0].id).toBe('substr')
+  })
+})
+
+describe('shippedRanker', () => {
+  it('orders by the _score the service already computed', () => {
+    const out = shippedRanker([
+      c('b', 'x', { _score: 0.4 }), c('a', 'y', { _score: 0.9 }), c('c', 'z', { _score: 0.6 }),
+    ], 'q')
+    expect(out.map(r => r.id)).toEqual(['a', 'c', 'b'])
+  })
+})
+
+describe('metrics', () => {
+  const ordered = [c('1', 'a'), c('2', 'b'), c('3', 'c'), c('4', 'd'), c('5', 'e')]
+  const labels = { '1': 1, '2': 0, '3': 1, '4': 0, '5': 0 }
+
+  it('precisionAtK divides by k, not by the number returned', () => {
+    // A query returning 2 results with 1 relevant is P@5 = 0.2, not 0.5 — otherwise
+    // low-recall queries score artificially well.
+    expect(precisionAtK(ordered.slice(0, 2), labels, 5)).toBeCloseTo(0.2)
+    expect(precisionAtK(ordered, labels, 5)).toBeCloseTo(0.4)
+  })
+
+  it('reciprocalRank rewards the first relevant hit by position', () => {
+    expect(reciprocalRank(ordered, labels)).toBe(1)
+    expect(reciprocalRank([ordered[1], ordered[0]], labels)).toBeCloseTo(0.5)
+  })
+
+  it('ndcg separates orderings that P@5 cannot', () => {
+    // Same two relevant docs, different positions — P@5 identical, nDCG is not.
+    const front = [ordered[0], ordered[2], ordered[1], ordered[3], ordered[4]]
+    const back = [ordered[1], ordered[3], ordered[4], ordered[0], ordered[2]]
+    expect(precisionAtK(front, labels, 5)).toBeCloseTo(precisionAtK(back, labels, 5))
+    expect(ndcgAtK(front, labels, 5)).toBeGreaterThan(ndcgAtK(back, labels, 5))
+  })
+
+  it('ndcg is 1 when all relevant docs are ranked first', () => {
+    expect(ndcgAtK([ordered[0], ordered[2], ordered[1]], labels, 5)).toBeCloseTo(1)
+  })
+
+  it('metaShareAtK counts auto-extracted and meta-subject entries', () => {
+    const mixed = [
+      c('m1', 'x', { extractedBy: 'kms-session-extract' }),
+      c('m2', 'x', { subject: 'KMS.retrieval.audit' }),
+      c('d1', 'x', { subject: 'WinFlex.carrier.symetra' }),
+      c('d2', 'x', { subject: null }),
+    ]
+    expect(metaShareAtK(mixed, 4)).toBeCloseTo(0.5)
+  })
+
+  it('handles an empty ordering without dividing by zero', () => {
+    expect(precisionAtK([], labels, 5)).toBe(0)
+    expect(ndcgAtK([], labels, 5)).toBe(0)
+    expect(metaShareAtK([], 5)).toBe(0)
+    expect(reciprocalRank([], labels)).toBe(0)
+  })
+
+  it('ndcg is 0 when nothing is labelled relevant', () => {
+    expect(ndcgAtK(ordered, { '1': 0, '2': 0 }, 5)).toBe(0)
+  })
+})

--- a/src/eval/rankers.ts
+++ b/src/eval/rankers.ts
@@ -1,0 +1,103 @@
+/**
+ * Ranker variants, isolated so competing scorers can be replayed over an identical
+ * candidate pool.
+ *
+ * Background: on 2026-08-01 three baseline runs measured retrieval getting WORSE after
+ * two ranking changes shipped (mean P@5 0.54 -> 0.43). The regression could not be
+ * attributed, because the ranker and the corpus changed on the same day AND every
+ * measurement only ever saw the shipped ranker's own top-N. Comparing two rankers on a
+ * set that one of them selected is not a comparison.
+ *
+ * A ranker here is a pure function (candidates, query) -> ordered candidates. Given a
+ * frozen pool captured by KMS_EVAL_CAPTURE, any two can be scored against the same
+ * relevance labels.
+ */
+
+export interface EvalCandidate {
+  id: string
+  content: string
+  confidence?: number
+  timestamp?: string
+  contentType?: string
+  sourceSystem?: string
+  subject?: string | null
+  extractedBy?: string | null
+  [k: string]: unknown
+}
+
+export type Ranker = (candidates: EvalCandidate[], query: string) => EvalCandidate[]
+
+// ── legacy (pre-#85) ─────────────────────────────────────────────────────────
+// Reproduced from git 61e0fe06^ INCLUDING its defects, because an honest baseline
+// must be the thing that actually ran: substring matching, and the exact-phrase bonus
+// applied inside the per-term loop so an N-term match scored it N times.
+
+function legacyRelevance(content: string, query: string): number {
+  if (!content || !query) return 0
+  const cl = content.toLowerCase()
+  const ql = query.toLowerCase()
+  const terms = ql.split(/\s+/).filter(Boolean)
+  if (!terms.length) return 0
+  let score = 0
+  for (const t of terms) {
+    if (cl.includes(t)) {
+      score += 1
+      if (cl.includes(ql)) score += 0.5
+    }
+  }
+  return score / terms.length
+}
+
+export const legacyRanker: Ranker = (candidates, query) =>
+  [...candidates].sort((a, b) => {
+    const cd = (b.confidence ?? 0) - (a.confidence ?? 0)
+    if (Math.abs(cd) > 0.1) return cd
+    return legacyRelevance(b.content, query) - legacyRelevance(a.content, query)
+  })
+
+// ── score-order (whatever the service produced) ──────────────────────────────
+// The pool is captured already ranked, so this replays the shipped ranker without
+// reimplementing it — no risk of the copy drifting from production.
+
+export const shippedRanker: Ranker = candidates =>
+  [...candidates].sort((a, b) => ((b._score as number) ?? 0) - ((a._score as number) ?? 0))
+
+// ── metrics ──────────────────────────────────────────────────────────────────
+
+/** Relevance labels for one query: id -> 1 (relevant) | 0 (marginal/irrelevant). */
+export type Labels = Record<string, number>
+
+export function precisionAtK(ordered: EvalCandidate[], labels: Labels, k: number): number {
+  const top = ordered.slice(0, k)
+  if (!top.length) return 0
+  return top.filter(c => labels[c.id] === 1).length / k
+}
+
+export function reciprocalRank(ordered: EvalCandidate[], labels: Labels): number {
+  const i = ordered.findIndex(c => labels[c.id] === 1)
+  return i === -1 ? 0 : 1 / (i + 1)
+}
+
+/**
+ * nDCG@k with binary gains. Included because P@5 alone cannot distinguish "the one
+ * relevant hit is at rank 1" from "it is at rank 5" — a distinction that matters when
+ * comparing orderings over an identical pool, which is exactly this harness's job.
+ */
+export function ndcgAtK(ordered: EvalCandidate[], labels: Labels, k: number): number {
+  const dcg = ordered.slice(0, k).reduce(
+    (acc, c, i) => acc + (labels[c.id] === 1 ? 1 / Math.log2(i + 2) : 0), 0)
+  const nRelevant = Object.values(labels).filter(v => v === 1).length
+  const ideal = Array.from({ length: Math.min(k, nRelevant) })
+    .reduce<number>((acc, _, i) => acc + 1 / Math.log2(i + 2), 0)
+  return ideal === 0 ? 0 : dcg / ideal
+}
+
+/** Share of the top-k that is meta/self-referential rather than domain knowledge. */
+export function metaShareAtK(ordered: EvalCandidate[], k: number): number {
+  const top = ordered.slice(0, k)
+  if (!top.length) return 0
+  const isMeta = (c: EvalCandidate) =>
+    c.extractedBy === 'kms-session-extract' ||
+    /^(KMS\.|KMSmcp\.|SparrowDB\.bugs|MacMini\.config|orchestration\.)/.test(c.subject ?? '')
+  return top.filter(isMeta).length / k
+}

--- a/src/eval/rankers.ts
+++ b/src/eval/rankers.ts
@@ -67,7 +67,20 @@ export const shippedRanker: Ranker = candidates =>
 /** Relevance labels for one query: id -> 1 (relevant) | 0 (marginal/irrelevant). */
 export type Labels = Record<string, number>
 
+/**
+ * This is a measurement harness — a metric that silently returns NaN/Infinity on a bad
+ * `k` is worse than one that throws, because a bad number gets trusted and reported as
+ * if it meant something. Reject negative and non-integer k consistently rather than
+ * letting `slice`/division absorb it silently.
+ */
+function validateK(k: number): void {
+  if (!Number.isInteger(k) || k < 0) {
+    throw new RangeError(`k must be a non-negative integer, got ${k}`)
+  }
+}
+
 export function precisionAtK(ordered: EvalCandidate[], labels: Labels, k: number): number {
+  validateK(k)
   const top = ordered.slice(0, k)
   if (!top.length) return 0
   return top.filter(c => labels[c.id] === 1).length / k
@@ -84,6 +97,7 @@ export function reciprocalRank(ordered: EvalCandidate[], labels: Labels): number
  * comparing orderings over an identical pool, which is exactly this harness's job.
  */
 export function ndcgAtK(ordered: EvalCandidate[], labels: Labels, k: number): number {
+  validateK(k)
   const dcg = ordered.slice(0, k).reduce(
     (acc, c, i) => acc + (labels[c.id] === 1 ? 1 / Math.log2(i + 2) : 0), 0)
   const nRelevant = Object.values(labels).filter(v => v === 1).length
@@ -94,6 +108,7 @@ export function ndcgAtK(ordered: EvalCandidate[], labels: Labels, k: number): nu
 
 /** Share of the top-k that is meta/self-referential rather than domain knowledge. */
 export function metaShareAtK(ordered: EvalCandidate[], k: number): number {
+  validateK(k)
   const top = ordered.slice(0, k)
   if (!top.length) return 0
   const isMeta = (c: EvalCandidate) =>

--- a/src/tools/UnifiedSearchTool.ts
+++ b/src/tools/UnifiedSearchTool.ts
@@ -7,6 +7,15 @@ import { KnowledgeQuery } from '../types/index.js'
 import { FACTCache } from '../cache/FACTCache.js'
 import { MongoDBStorage, Mem0Storage } from '../storage/index.js'
 import type { GraphStorage } from '../types/index.js'
+import type { EvalCandidate } from '../eval/rankers.js'
+
+/** Shape of the KMS_EVAL_CAPTURE payload — the deduplicated, ranked pool captured
+ *  before `maxResults` slicing so a ranker can be replayed offline over the same set. */
+export interface EvalCapture {
+  poolSize: number
+  rawCount: number
+  candidates: EvalCandidate[]
+}
 
 const debug = (...args: unknown[]) => { if (process.env.KMS_DEBUG) console.error(...args) }
 
@@ -72,6 +81,8 @@ export class UnifiedSearchTool {
       name: string
       actions: string[]
     }>
+    // Present only when KMS_EVAL_CAPTURE=1 — the deduplicated pool pre-slicing.
+    _evalCapture?: EvalCapture
   }> {
     const startTime = Date.now()
     
@@ -105,12 +116,18 @@ export class UnifiedSearchTool {
       results: any[]
       totalFound: number
       sources: { mem0: number, graph: number, mongodb: number }
+      _evalCapture?: EvalCapture
     }>(cacheKey) : null
     const cacheCheckTime = Date.now() - cacheCheckStart
-    
-    if (cached && query.options?.cacheStrategy !== 'realtime') {
+    const wantsEvalCapture = process.env.KMS_EVAL_CAPTURE === '1'
+
+    // A cache entry written before KMS_EVAL_CAPTURE was set (or by a run with it off)
+    // has no _evalCapture. Serving it as a hit would silently hand the harness a
+    // response with no candidate pool. Treat that case as a miss so the full search
+    // path runs and captures fresh.
+    if (cached && query.options?.cacheStrategy !== 'realtime' && (!wantsEvalCapture || cached._evalCapture)) {
       debug(`⚡ CACHE HIT - Returning cached results`)
-      
+
       return {
         query: query.query,
         results: cached.results || [],
@@ -123,7 +140,8 @@ export class UnifiedSearchTool {
           searchTime: 0,
           mergingTime: 0,
           totalTime: Date.now() - startTime
-        }
+        },
+        ...(cached._evalCapture ? { _evalCapture: cached._evalCapture } : {})
       }
     }
 
@@ -180,7 +198,7 @@ export class UnifiedSearchTool {
     // Capturing the deduplicated pool BEFORE slicing fixes that: any scorer can be
     // replayed over the identical candidate set offline, so ranker changes become
     // measurable instead of arguable.
-    const evalCapture = process.env.KMS_EVAL_CAPTURE === '1'
+    const evalCapture: EvalCapture | undefined = wantsEvalCapture
       ? {
           poolSize: uniqueResults.length,
           rawCount: allResults.length,
@@ -468,11 +486,15 @@ export class UnifiedSearchTool {
 
     for (const result of results) {
       // Use ID if available, otherwise use content hash
+      // Every merged/inserted entry gets a stable string id, even when the source
+      // backend supplied none — callers (the eval capture in particular) join
+      // candidates back to relevance labels by id, so `undefined` here makes an
+      // entry silently unjoinable.
       const key = result.id || crypto.createHash('md5').update(result.content).digest('hex')
       const existing = unique.get(key)
 
       if (!existing) {
-        unique.set(key, result)
+        unique.set(key, result.id ? result : { ...result, id: key })
         continue
       }
 
@@ -480,7 +502,7 @@ export class UnifiedSearchTool {
       const base = (result.content?.length ?? 0) > (existing.content?.length ?? 0) ? result : existing
       const other = base === result ? existing : result
 
-      const merged: any = { ...other, ...base }
+      const merged: any = { ...other, ...base, id: base.id || other.id || key }
 
       // Union the fields that only some backends populate, preferring whichever
       // copy actually has them rather than whichever copy won on content length.
@@ -490,13 +512,18 @@ export class UnifiedSearchTool {
       // entityRefs drive downstream entity-context linking (search()'s linkedEntityIds
       // annotation and expandWithEntityContext). Union them the same way as relationships,
       // or whichever copy loses on content length silently drops its refs.
+      //
+      // metadata itself is merged unconditionally (not only when entityRefs is
+      // non-empty) — subject/extractedBy are per-copy fields too, and the eval capture
+      // reads them straight off this merged object. Merging only on the entityRefs
+      // branch meant a subject/extractedBy present solely on the losing copy was
+      // dropped whenever neither copy had entityRefs.
       const entityRefs = Array.from(new Set([
         ...(base.metadata?.entityRefs ?? []),
         ...(other.metadata?.entityRefs ?? []),
       ]))
-      if (entityRefs.length) {
-        merged.metadata = { ...other.metadata, ...base.metadata, entityRefs }
-      }
+      merged.metadata = { ...other.metadata, ...base.metadata }
+      if (entityRefs.length) merged.metadata.entityRefs = entityRefs
 
       // Keep the stored confidence (the author's), not a per-backend match score.
       merged.confidence = Math.max(base.confidence ?? 0, other.confidence ?? 0)

--- a/src/tools/UnifiedSearchTool.ts
+++ b/src/tools/UnifiedSearchTool.ts
@@ -166,8 +166,40 @@ export class UnifiedSearchTool {
 
     // Sort by relevance and confidence
     const maxResults = query.options?.maxResults ?? 10
-    const sortedResults = this.rankResults(uniqueResults, args.query)
-      .slice(0, maxResults)
+    const rankedResults = this.rankResults(uniqueResults, args.query)
+    const sortedResults = rankedResults.slice(0, maxResults)
+
+    // Eval capture (KMS_EVAL_CAPTURE=1). Off by default and zero-cost when off.
+    //
+    // Why this exists: three baseline runs on 2026-08-01 measured retrieval getting
+    // WORSE after two ranking changes shipped (P@5 0.54 -> 0.43), and the cause could
+    // not be attributed — the ranker and the corpus had both changed, and every
+    // measurement only ever saw the ranker's OWN top-N. You cannot compare two rankers
+    // on a set that one of them selected.
+    //
+    // Capturing the deduplicated pool BEFORE slicing fixes that: any scorer can be
+    // replayed over the identical candidate set offline, so ranker changes become
+    // measurable instead of arguable.
+    const evalCapture = process.env.KMS_EVAL_CAPTURE === '1'
+      ? {
+          poolSize: uniqueResults.length,
+          rawCount: allResults.length,
+          candidates: rankedResults.map(r => ({
+            id: r.id,
+            content: r.content,
+            confidence: r.confidence,
+            timestamp: r.timestamp,
+            contentType: r.contentType,
+            sourceSystem: r.sourceSystem,
+            _sourceSystems: r._sourceSystems,
+            subject: r.metadata?.subject ?? null,
+            extractedBy: r.metadata?.extractedBy ?? null,
+            _score: r._score,
+            _relevance: r._relevance,
+            _recency: r._recency,
+          })),
+        }
+      : undefined
 
     const mergingTime = Date.now() - mergingStart
 
@@ -209,7 +241,8 @@ export class UnifiedSearchTool {
         totalTime: Date.now() - startTime
       },
       entity_context,
-      triggered_actions
+      triggered_actions,
+      ...(evalCapture ? { _evalCapture: evalCapture } : {})
     }
 
     // Step 5: Cache the results


### PR DESCRIPTION
## Why

Three baseline runs today measured retrieval getting **worse** after two ranking changes shipped:

| run | ranker | corpus | P@5 | P@1 |
|---|---|---|---|---|
| 1 | pre-#85 | polluted | **0.54** | 0.70 |
| 2 | post-#87 | polluted | 0.44 | 0.50 |
| 3 | post-#87 | source cut | **0.43** | 0.55 |

The regression couldn't be attributed, for two reasons:

1. The ranker and the corpus changed on the same day — confounded variables.
2. **Every measurement only ever saw the shipped ranker's own top-N.** Comparing two rankers on a set that one of them selected is not a comparison.

An offline A/B attempted afterwards hit exactly problem (2): it re-sorted the new ranker's top-10, and could only show the orderings *differ* (139 position changes, 10/20 different #1) — never which is better.

**This PR fixes the measurement gap, not the ranking.**

## What

**Capture** — `UnifiedSearchTool` saves the deduplicated pool *before* slicing to `maxResults`, behind `KMS_EVAL_CAPTURE=1`. Off by default, zero cost when off. Includes `metadata.subject` and `metadata.extractedBy` so meta-vs-domain is measurable.

**Replay** — `src/eval/rankers.ts` holds rankers as pure functions over a frozen pool:
- `legacyRanker` reproduces pre-#85 **including its defects** (substring matching; exact-phrase bonus applied inside the per-term loop). A cleaned-up baseline would flatter every comparison against it.
- `shippedRanker` replays production ordering via `_score` rather than reimplementing it, so the copy can't drift.

**Metrics** — `precision@k`, `reciprocalRank`, `nDCG@k`, `metaShare@k`.
- **nDCG** because P@5 can't distinguish "relevant hit at rank 1" from "rank 5" — exactly the distinction that matters when two orderings see an identical pool.
- **metaShare@k** quantifies the failure the baselines kept surfacing: notes about the KMS work itself occupying slots that belong to domain knowledge.

## Tests

**11 tests on the harness itself** — a scoring harness that is wrong is worse than none, because its numbers get trusted. They pin that `precisionAtK` divides by k (not by results returned, which would flatter low-recall queries), that nDCG separates orderings P@5 can't, and that the legacy ranker still reproduces its original bugs.

`492 passing / 24 suites`, typecheck clean.

## What this unblocks

**PR #89** is currently held — it proposes IDF weighting and near-duplicate suppression, validated on constructed fixtures rather than the live corpus. With this merged, #89 can be judged on measurement instead of argument.

It also makes the open question answerable: *did #85/#87 actually hurt, or did the corpus pollution?* Capture pools once, replay both rankers, compare on identical input.

## Honest note

This is the tool that should have existed **before** any ranking change shipped. It exists now because I shipped three and measured them getting worse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Search results are ranked across the complete set of unique matches before the requested result limit is applied.
  - The most relevant matches now appear first, even when many results are available.
  - Search ranking is evaluated more consistently across different query scenarios.
- **Bug Fixes**
  - Duplicate results now retain useful metadata and stable identifiers, improving result consistency across searches and cached responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->