### PR TITLE
fix(search): honour the parent entry's flag on Mem0 fan-out shards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,22 @@ KMS has five corrective tools. Pick the right one:
 | Mark an entry partially wrong without replacing it | `kms_flag(id, 'RETRACTED' \| 'UNVERIFIED', note)` | Hides from default reads; original content preserved for audit. Pass `flag=null` to un-flag. |
 | Clean up old flagged entries past the reversibility window | `kms_reap({olderThanDays: 90, dryRun: true})` | Dry-run by default. Set `dryRun: false` to hard-delete. Admin operation. |
 
-**How this interacts with context injection**: `unified_search` (and the `kms-context-fetch.py` UserPromptSubmit hook that calls it) default-exclude flagged entries. The moment you supersede a wrong fact, it **stops leaking into every future session's context** automatically. Pass `options.includeFlagged: true` to see them (audit/reaper paths only).
+**How this interacts with context injection**: `unified_search` (and the `kms-context-fetch.py` UserPromptSubmit hook that calls it) default-exclude flagged entries, across all three backends including Mem0's fan-out shards. Superseding a wrong fact therefore stops it leaking into future sessions' context. Pass `options.includeFlagged: true` to see them (audit/reaper paths only).
+
+> This became true on 2026-08-01 (PR #91) and was **false** for the whole period before
+> it, in the way that mattered most. Mem0's extractor splits every `unified_store` write
+> into several "User described…" rows, each a separate searchable entry whose only link
+> back is `metadata.kms_id`. Mem0 has no flag concept, so `kms_supersede` / `kms_delete`
+> flagged the graph and MongoDB copies and left every shard live — and shards rank *well*,
+> because the extractor restates the source in query-like language. Measured immediately
+> after superseding 2 entries and deleting 5: three of those flagged parents still had 11
+> shards in the top-15 across six queries, serving the exact content the supersede was
+> written to retire. `searchMem0` now drops shards whose parent is flagged.
+>
+> Two things this still does **not** do. It does not make Mem0-only entries correctable —
+> those have no parent to flag (see the corrective-tools gap). And it does not stop the
+> fan-out generating new shards on every write, so one careful `unified_store` still
+> becomes several retrievable rows.
 
 **When in doubt, prefer `kms_supersede` over `kms_delete`**. The mistake is data — future you or a future agent might want to trace why a conclusion changed. Supersede preserves the chain; delete is for actual garbage.
 

--- a/src/__tests__/UnifiedSearchTool.shardFlags.test.ts
+++ b/src/__tests__/UnifiedSearchTool.shardFlags.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Mem0 fan-out shards must inherit their parent KMS entry's flag.
+ *
+ * Background (measured 2026-08-01): every `unified_store` write is fanned out by
+ * Mem0's LLM extractor into several "User described…" rows, each a separate
+ * searchable entry carrying `metadata.kms_id` back to the KMS entry it came from.
+ * Mem0 has no flag concept, so `kms_supersede` / `kms_delete` flagged the graph and
+ * MongoDB copies and left every shard live and retrievable. Three freshly-flagged
+ * parents still had 11 shards surfacing in the top-15 across six real queries.
+ *
+ * That made the documented guarantee — that superseding a fact stops it leaking into
+ * future context injection — false for the highest-volume backend. These tests pin
+ * the read-time join that fixes it, and equally pin the cases where a shard must be
+ * KEPT, because over-filtering silently deletes live knowledge and is the worse bug.
+ */
+
+import { UnifiedSearchTool } from '../tools/UnifiedSearchTool.js'
+
+type Entry = { id: string; flag?: string | null }
+
+const makeTool = (graphEntries: Entry[], mem0Results: any[], opts: { throwOnLookup?: boolean; noFindById?: boolean } = {}) => {
+  const byId = new Map(graphEntries.map(e => [e.id, e]))
+  const graph: any = {}
+  if (!opts.noFindById) {
+    graph.findById = (id: string) => {
+      if (opts.throwOnLookup) throw new Error('backend unavailable')
+      return byId.get(id) ?? null
+    }
+  }
+  const mem0: any = { search: async () => mem0Results }
+  return new UnifiedSearchTool({ mongodb: {} as any, graph, mem0 }, null)
+}
+
+const search = (tool: UnifiedSearchTool, options: any = {}) =>
+  (tool as any).searchMem0({ query: 'q', options })
+
+const shard = (id: string, kms_id?: string) => ({ id, content: `shard ${id}`, metadata: kms_id ? { kms_id } : {} })
+
+describe('Mem0 shards inherit the parent entry flag', () => {
+  it('drops shards whose parent is flagged SUPERSEDED', async () => {
+    const tool = makeTool(
+      [{ id: 'parent-1', flag: 'SUPERSEDED' }, { id: 'parent-2', flag: null }],
+      [shard('s1', 'parent-1'), shard('s2', 'parent-2')]
+    )
+    const out = await search(tool)
+    expect(out.map((r: any) => r.id)).toEqual(['s2'])
+  })
+
+  it('drops shards whose parent is flagged DELETED', async () => {
+    const tool = makeTool([{ id: 'p', flag: 'DELETED' }], [shard('s1', 'p')])
+    expect(await search(tool)).toHaveLength(0)
+  })
+
+  it('drops every shard of one flagged parent, not just the first', async () => {
+    // The real failure was multi-shard: one supersede produced five live copies.
+    const tool = makeTool(
+      [{ id: 'p', flag: 'RETRACTED' }],
+      [shard('s1', 'p'), shard('s2', 'p'), shard('s3', 'p')]
+    )
+    expect(await search(tool)).toHaveLength(0)
+  })
+
+  it('keeps shards when includeFlagged is set (audit path)', async () => {
+    const tool = makeTool([{ id: 'p', flag: 'SUPERSEDED' }], [shard('s1', 'p')])
+    expect(await search(tool, { includeFlagged: true })).toHaveLength(1)
+  })
+})
+
+describe('shards that must NOT be dropped', () => {
+  it('keeps a shard with no kms_id — nothing to inherit', async () => {
+    const tool = makeTool([{ id: 'p', flag: 'DELETED' }], [shard('s1')])
+    expect(await search(tool)).toHaveLength(1)
+  })
+
+  it('keeps a shard whose parent is unknown to the graph', async () => {
+    // findById returns null for Mem0-only entries that never reached the graph.
+    // An unknown parent is not evidence of retraction.
+    const tool = makeTool([], [shard('s1', 'never-seen')])
+    expect(await search(tool)).toHaveLength(1)
+  })
+
+  it('keeps a shard whose parent exists and is unflagged', async () => {
+    const tool = makeTool([{ id: 'p', flag: null }], [shard('s1', 'p')])
+    expect(await search(tool)).toHaveLength(1)
+  })
+
+  it('keeps a self-referential row where kms_id equals its own id', async () => {
+    const tool = makeTool([{ id: 's1', flag: null }], [shard('s1', 's1')])
+    expect(await search(tool)).toHaveLength(1)
+  })
+
+  it('keeps everything when the graph backend cannot answer lookups', async () => {
+    // A backend that throws must degrade to "show the results", never to a silent
+    // blanket drop of the Mem0 tier.
+    const tool = makeTool([{ id: 'p', flag: 'DELETED' }], [shard('s1', 'p')], { throwOnLookup: true })
+    expect(await search(tool)).toHaveLength(1)
+  })
+
+  it('keeps everything when the graph backend has no findById at all', async () => {
+    const tool = makeTool([], [shard('s1', 'p')], { noFindById: true })
+    expect(await search(tool)).toHaveLength(1)
+  })
+
+  it('handles a null/blank metadata object without throwing', async () => {
+    const tool = makeTool([{ id: 'p', flag: 'DELETED' }], [{ id: 's1', content: 'x' }, { id: 's2', content: 'y', metadata: null }])
+    expect(await search(tool)).toHaveLength(2)
+  })
+})
+
+describe('lookup efficiency', () => {
+  it('looks each distinct parent up once regardless of shard count', async () => {
+    // One supersede can produce many shards; an uncached lookup per shard would put
+    // a graph read on every Mem0 row of every search.
+    let calls = 0
+    const graph: any = { findById: (id: string) => { calls++; return { id, flag: null } } }
+    const mem0: any = { search: async () => [shard('s1', 'p'), shard('s2', 'p'), shard('s3', 'p'), shard('s4', 'other')] }
+    const tool = new UnifiedSearchTool({ mongodb: {} as any, graph, mem0 }, null)
+    await (tool as any).searchMem0({ query: 'q', options: {} })
+    expect(calls).toBe(2)
+  })
+})

--- a/src/tools/UnifiedSearchTool.ts
+++ b/src/tools/UnifiedSearchTool.ts
@@ -434,11 +434,55 @@ export class UnifiedSearchTool {
 
   private async searchMem0(query: KnowledgeQuery): Promise<any[]> {
     try {
-      return await this.storage.mem0.search(query)
+      return this.dropShardsOfFlaggedParents(await this.storage.mem0.search(query), query)
     } catch (error) {
       console.warn('⚠️ Mem0 search failed:', error instanceof Error ? error.message : String(error))
       return []
     }
+  }
+
+  /**
+   * Mem0 stores an LLM-extracted fan-out of each `unified_store` write: several
+   * "User described…" shards, each its own searchable row carrying
+   * `metadata.kms_id` back to the KMS entry it was derived from.
+   *
+   * Mem0 has no flag concept, so `kms_supersede` / `kms_delete` flag the graph and
+   * MongoDB copies and leave every shard live. Measured 2026-08-01: three
+   * freshly-flagged parents still had 11 shards surfacing in the top-15 across six
+   * queries, carrying the exact content the supersede was written to retire — a
+   * retracted claim about a retrieval regression kept being served after its parent
+   * was superseded. CLAUDE.md's promise that superseding a fact "stops it leaking
+   * into every future session's context automatically" was false for this path.
+   *
+   * The shards already carry the join key, so honour the parent's flag at read time.
+   * Doing it here rather than in Mem0 also covers shards written before the flag
+   * existed, which no write-time fix could reach.
+   */
+  private dropShardsOfFlaggedParents(results: any[], query: KnowledgeQuery): any[] {
+    if (query.options?.includeFlagged) return results
+    const graph: any = this.storage.graph
+    // Optional on the GraphStorage interface — a backend that cannot answer must not
+    // cause every Mem0 result to be dropped.
+    if (typeof graph?.findById !== 'function') return results
+
+    const parentFlagged = new Map<string, boolean>()
+    return results.filter(r => {
+      const parentId = r?.metadata?.kms_id
+      // No join key, or the shard IS the parent: nothing to inherit.
+      if (!parentId || parentId === r.id) return true
+      if (!parentFlagged.has(parentId)) {
+        let flagged = false
+        try {
+          // findById returns null for a parent this backend has never seen; an unknown
+          // parent is not evidence of retraction, so keep the shard either way.
+          flagged = Boolean(graph.findById(parentId)?.flag)
+        } catch {
+          flagged = false
+        }
+        parentFlagged.set(parentId, flagged)
+      }
+      return !parentFlagged.get(parentId)
+    })
   }
 
   private async searchGraph(query: KnowledgeQuery): Promise<any[]> {


### PR DESCRIPTION
## What's wrong

Every `unified_store` write is fanned out by Mem0's LLM extractor into several "User described…" rows. Each is its own searchable entry carrying `metadata.kms_id` back to the KMS entry it came from. Mem0 has no flag concept, so `kms_supersede` / `kms_delete` flag the graph and MongoDB copies and leave every shard live.

Measured on the live corpus today, right after superseding two entries and deleting five: three of those flagged parents still had **11 shards surfacing in the top-15 across six queries**, serving the exact content the supersede was written to retire.

```
PARENT 0dfa5eec… (SUPERSEDED) — 5 live shard hits
PARENT 4dddeec5… (SUPERSEDED) — 4 live shard hits
PARENT 08bb7f54… (DELETED)    — 2 live shard hits
```

`CLAUDE.md` currently promises that superseding a fact "stops it leaking into every future session's context automatically." That was false for the highest-volume backend — and the worst one to be wrong about, because shards restate their source in query-like language and therefore rank well.

## Fix

The shards already carry the join key, so `searchMem0` drops any shard whose parent is flagged, unless `includeFlagged` is set. Read-time rather than write-time, which also covers every shard already in the corpus — no write-time fix could reach those.

Conservative in the other direction, since over-filtering silently hides live knowledge and is the worse bug. All of these keep the shard: no `kms_id`; a parent the graph has never seen (Mem0-only entries never reach the graph); a self-referential row; a backend without `findById`; a lookup that throws. Parents are looked up once each, not once per shard.

## Verification

Same six queries against the live store: **11 leaked shards before, 0 after, across 89 results.** Then 0 again through the normal cached path after invalidation, so it isn't an artifact of bypassing the cache.

Cache invalidation on retraction was also checked and is already correct — `delete` delegates to `flag`, which clears the search namespace. No change needed there.

Tests 504 → 516. The new suite pins the drop cases, and equally pins all seven keep-the-shard cases.

## How this surfaced

Fallout from the #90 ranker comparison. `metaShare@5` came out at 0.240 — roughly one in four top-5 slots going to meta/session noise — so I purged the worst offenders, re-queried to confirm, and found the deleted content still being served through a backend the corrective tools never reached.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search results now consistently hide entries associated with flagged parent records unless flagged results are explicitly included.
  * Entries with missing metadata, unknown parents, or lookup issues remain available.
  * Improved lookup efficiency by avoiding repeated checks for the same parent.

* **Tests**
  * Added coverage for flagged parent filtering and edge cases across search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->