### PR TITLE
feat(search): hybrid vector+lexical retrieval fused with RRF, behind KMS_HYBRID_RETRIEVAL

### DIFF
--- a/src/__tests__/UnifiedSearchTool.hybrid.test.ts
+++ b/src/__tests__/UnifiedSearchTool.hybrid.test.ts
@@ -70,6 +70,23 @@ const buildTool = (opts: HarnessOpts = {}) => {
   return { tool, graph, mem0, mongodb, findSimilar, embedder }
 }
 
+/**
+ * Runs `fn` with KMS_EVAL_CAPTURE='1', then restores whatever the variable held
+ * beforehand — absent if it was absent, or its prior value if some other test (or the
+ * environment) had set one. An unconditional `delete` in the finally block would clobber
+ * that prior value instead of restoring it, leaking state into whatever runs next.
+ */
+async function withEvalCapture<T>(fn: () => Promise<T>): Promise<T> {
+  const original = process.env.KMS_EVAL_CAPTURE
+  process.env.KMS_EVAL_CAPTURE = '1'
+  try {
+    return await fn()
+  } finally {
+    if (original === undefined) delete process.env.KMS_EVAL_CAPTURE
+    else process.env.KMS_EVAL_CAPTURE = original
+  }
+}
+
 const QUERY = 'quarterly revenue forecast'
 
 /** Lexically strong: contains every query term. */
@@ -157,8 +174,7 @@ describe('UnifiedSearchTool — hybrid retrieval', () => {
     })
 
     it('captures the same eval fields it captured before this change', async () => {
-      process.env.KMS_EVAL_CAPTURE = '1'
-      try {
+      await withEvalCapture(async () => {
         const { tool } = buildTool({ mem0: [LEX_STRONG], similar: [vectorHit()] })
         const res = await tool.search({ query: QUERY })
         const candidate = res._evalCapture!.candidates[0]
@@ -167,9 +183,7 @@ describe('UnifiedSearchTool — hybrid retrieval', () => {
           'confidence', 'content', 'contentType', 'extractedBy', 'id',
           'sourceSystem', 'subject', 'timestamp',
         ])
-      } finally {
-        delete process.env.KMS_EVAL_CAPTURE
-      }
+      })
     })
   })
 
@@ -234,8 +248,7 @@ describe('UnifiedSearchTool — hybrid retrieval', () => {
     })
 
     it('carries the hybrid signals into the KMS_EVAL_CAPTURE pool', async () => {
-      process.env.KMS_EVAL_CAPTURE = '1'
-      try {
+      await withEvalCapture(async () => {
         const { tool } = buildTool({
           mem0: [LEX_STRONG],
           similar: [vectorHit({ id: SEMANTIC_ONLY.id, similarity: 0.83 })],
@@ -250,9 +263,7 @@ describe('UnifiedSearchTool — hybrid retrieval', () => {
         expect(captured['sem-only']._rrf).toBeCloseTo(1 / 61, 6)
         expect(captured['lex-strong']._lexicalRank).toBe(1)
         expect(typeof captured['lex-strong']._lexicalScore).toBe('number')
-      } finally {
-        delete process.env.KMS_EVAL_CAPTURE
-      }
+      })
     })
 
     it('deduplicates a document found by both arms into ONE candidate scoring in both', async () => {
@@ -402,6 +413,24 @@ describe('UnifiedSearchTool — hybrid retrieval', () => {
       expect(res.results.map(r => r.id)).toEqual(['a'])
     })
 
+    it('excludes a vector-only hit whose source is not in filters.source', async () => {
+      // `findSimilar` has no `source` parameter to push a filter down into (unlike
+      // contentType/subject), so this filter can ONLY be enforced as a post-filter here.
+      // Without it, a caller asking for filters.source: ['technical'] would get results
+      // the vector arm found under 'personal' — candidates it explicitly excluded.
+      const { tool } = buildTool({
+        similar: [
+          vectorHit({ id: 'wrong-source', source: 'personal' }),
+          vectorHit({ id: 'right-source', source: 'technical' }),
+        ],
+      })
+      const res = await tool.search({
+        query: QUERY,
+        filters: { source: ['technical'] },
+      })
+      expect(res.results.map(r => r.id)).toEqual(['right-source'])
+    })
+
     it('propagates includeFlagged to the vector arm', async () => {
       const { tool, findSimilar } = buildTool({ similar: [] })
       await tool.search({ query: QUERY, options: { includeFlagged: true } })
@@ -448,5 +477,22 @@ describe('UnifiedSearchTool — hybrid retrieval', () => {
     const again = await tool.search({ query: QUERY })
     expect(again.fromCache).toBe(true)
     expect((again as any)._hybridRetrieval).toBe(true)
+  })
+
+  it('restores a pre-existing KMS_EVAL_CAPTURE value instead of deleting it', async () => {
+    const SENTINEL = 'set-by-something-else-in-the-process'
+    process.env.KMS_EVAL_CAPTURE = SENTINEL
+    try {
+      await withEvalCapture(async () => {
+        expect(process.env.KMS_EVAL_CAPTURE).toBe('1')
+        const { tool } = buildTool({ mem0: [LEX_STRONG], similar: [vectorHit()] })
+        await tool.search({ query: QUERY })
+      })
+      // An unconditional `delete` here would leave this `undefined`, leaking state
+      // into whatever test or process runs next instead of restoring it.
+      expect(process.env.KMS_EVAL_CAPTURE).toBe(SENTINEL)
+    } finally {
+      delete process.env.KMS_EVAL_CAPTURE
+    }
   })
 })

--- a/src/__tests__/UnifiedSearchTool.hybrid.test.ts
+++ b/src/__tests__/UnifiedSearchTool.hybrid.test.ts
@@ -1,0 +1,452 @@
+/**
+ * Hybrid (vector + lexical) retrieval in UnifiedSearchTool.search().
+ *
+ * The feature is gated on KMS_HYBRID_RETRIEVAL=1 and defaults OFF, because a ranking
+ * change shipped on reasoning alone on 2026-08-01 measured WORSE and had to be reverted.
+ * These tests pin both halves of that contract: with the flag off nothing about the read
+ * path changes at all, and with it on the vector arm both adds recall and can actually
+ * surface what it adds.
+ */
+
+import { UnifiedSearchTool } from '../tools/UnifiedSearchTool.js'
+import type { EmbeddingService } from '../embedding/EmbeddingService.js'
+
+const FLAG = 'KMS_HYBRID_RETRIEVAL'
+
+/** A vector hit as SparrowDBStorage.findSimilar returns it (preview, not full entry). */
+const vectorHit = (over: Partial<Record<string, any>> = {}) => ({
+  id: 'v1',
+  similarity: 0.87,
+  contentType: 'insight',
+  source: 'personal',
+  subject: undefined,
+  created: '2026-01-01T00:00:00.000Z',
+  flag: null,
+  content_preview: 'preview',
+  ...over,
+})
+
+const stubEmbedder = (over: Partial<EmbeddingService> = {}): jest.Mocked<EmbeddingService> => ({
+  embedderId: 'stub-embed:v1',
+  dimensions: 768,
+  embed: jest.fn().mockResolvedValue(new Float32Array(768)),
+  isAvailable: jest.fn().mockResolvedValue(true),
+  ...over,
+} as unknown as jest.Mocked<EmbeddingService>)
+
+interface HarnessOpts {
+  mem0?: any[]
+  mongodb?: any[]
+  graph?: any[]
+  similar?: any[] | Error
+  /** Omit findSimilar entirely, as an older/non-vector backend would. */
+  withoutFindSimilar?: boolean
+  /** Entries hydrateFromGraph() can resolve, keyed by id. */
+  entries?: Record<string, any>
+  embedder?: jest.Mocked<EmbeddingService> | null
+}
+
+const buildTool = (opts: HarnessOpts = {}) => {
+  const findSimilar = jest.fn(async () => {
+    if (opts.similar instanceof Error) throw opts.similar
+    return opts.similar ?? []
+  })
+
+  const graph: any = {
+    search: jest.fn().mockResolvedValue(opts.graph ?? []),
+    getEntitySummary: jest.fn().mockResolvedValue(null),
+    getOperationalNodes: jest.fn().mockResolvedValue([]),
+    findById: jest.fn((id: string) => opts.entries?.[id] ?? null),
+  }
+  if (!opts.withoutFindSimilar) graph.findSimilar = findSimilar
+
+  const mem0 = { search: jest.fn().mockResolvedValue(opts.mem0 ?? []) }
+  const mongodb = { search: jest.fn().mockResolvedValue(opts.mongodb ?? []) }
+  const embedder = opts.embedder === undefined ? stubEmbedder() : opts.embedder
+
+  // Cache is null throughout: these tests are about retrieval, and a shared cache would
+  // let one test's ordering leak into the next.
+  const tool = new UnifiedSearchTool({ mongodb, graph, mem0 } as any, null, embedder)
+  return { tool, graph, mem0, mongodb, findSimilar, embedder }
+}
+
+const QUERY = 'quarterly revenue forecast'
+
+/** Lexically strong: contains every query term. */
+const LEX_STRONG = {
+  id: 'lex-strong',
+  content: 'The quarterly revenue forecast was revised upward after the March close.',
+  confidence: 1,
+  timestamp: '2026-07-01T00:00:00.000Z',
+  contentType: 'fact',
+  metadata: {},
+}
+
+/** Lexically weak: shares one term. */
+const LEX_WEAK = {
+  id: 'lex-weak',
+  content: 'Revenue recognition policy for hardware bundles.',
+  confidence: 1,
+  timestamp: '2026-06-01T00:00:00.000Z',
+  contentType: 'fact',
+  metadata: {},
+}
+
+/**
+ * Zero term overlap with QUERY — no "quarterly", no "revenue", no "forecast".
+ * Lexical relevance for this content is exactly 0, so under the shipped composite it can
+ * never rank above anything. It is only reachable through the vector arm.
+ */
+const SEMANTIC_ONLY = {
+  id: 'sem-only',
+  content: 'Top-line projections for the next three months were rebuilt from the pipeline.',
+  confidence: 1,
+  timestamp: '2026-05-01T00:00:00.000Z',
+  contentType: 'insight',
+  source: 'personal',
+  metadata: {},
+}
+
+describe('UnifiedSearchTool — hybrid retrieval', () => {
+  const ORIGINAL = process.env[FLAG]
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env[FLAG]
+    else process.env[FLAG] = ORIGINAL
+  })
+
+  // ── flag OFF: byte-identical to current main ───────────────────────────────
+
+  describe('flag off (default)', () => {
+    beforeEach(() => { delete process.env[FLAG] })
+
+    it('never embeds and never touches the vector index', async () => {
+      const { tool, findSimilar, embedder } = buildTool({
+        mem0: [LEX_STRONG],
+        similar: [vectorHit()],
+      })
+      await tool.search({ query: QUERY })
+
+      expect(findSimilar).not.toHaveBeenCalled()
+      expect(embedder!.embed).not.toHaveBeenCalled()
+      expect(embedder!.isAvailable).not.toHaveBeenCalled()
+    })
+
+    it('emits no hybrid signals and no vector source count', async () => {
+      const { tool } = buildTool({ mem0: [LEX_STRONG, LEX_WEAK], similar: [vectorHit()] })
+      const res = await tool.search({ query: QUERY })
+
+      expect(Object.keys(res.sources)).toEqual(['mem0', 'graph', 'mongodb'])
+      expect(res.sources.vector).toBeUndefined()
+      expect((res as any)._hybridRetrieval).toBeUndefined()
+
+      for (const r of res.results) {
+        for (const field of ['_rrf', '_lexicalRank', '_vectorRank', '_vectorSimilarity', '_lexicalScore']) {
+          expect(field in r).toBe(false)
+        }
+      }
+    })
+
+    it('keeps _score as the lexical composite (relevance*0.70 + recency*0.25 + confidence*0.05)', async () => {
+      const { tool } = buildTool({ mem0: [LEX_STRONG] })
+      const res = await tool.search({ query: QUERY })
+      const r = res.results[0]
+
+      expect(r._score).toBeCloseTo(r._relevance * 0.70 + r._recency * 0.25 + 1 * 0.05, 4)
+      // Firmly in lexical-composite territory, nowhere near an RRF magnitude (~0.016).
+      expect(r._score).toBeGreaterThan(0.3)
+    })
+
+    it('captures the same eval fields it captured before this change', async () => {
+      process.env.KMS_EVAL_CAPTURE = '1'
+      try {
+        const { tool } = buildTool({ mem0: [LEX_STRONG], similar: [vectorHit()] })
+        const res = await tool.search({ query: QUERY })
+        const candidate = res._evalCapture!.candidates[0]
+        expect(Object.keys(candidate).sort()).toEqual([
+          '_recency', '_relevance', '_score', '_sourceSystems',
+          'confidence', 'content', 'contentType', 'extractedBy', 'id',
+          'sourceSystem', 'subject', 'timestamp',
+        ])
+      } finally {
+        delete process.env.KMS_EVAL_CAPTURE
+      }
+    })
+  })
+
+  // ── flag ON: recall + an ordering that can surface it ──────────────────────
+
+  describe('flag on', () => {
+    beforeEach(() => { process.env[FLAG] = '1' })
+
+    it('surfaces a vector-only hit with zero term overlap above a weak lexical hit', async () => {
+      const { tool } = buildTool({
+        mem0: [LEX_STRONG, LEX_WEAK],
+        similar: [vectorHit({ id: SEMANTIC_ONLY.id, similarity: 0.83 })],
+        entries: { [SEMANTIC_ONLY.id]: SEMANTIC_ONLY },
+      })
+      const res = await tool.search({ query: QUERY })
+
+      const semantic = res.results.find(r => r.id === SEMANTIC_ONLY.id)
+      expect(semantic).toBeDefined()
+      // The premise of the whole change: the lexical scorer gives it nothing.
+      expect(semantic!._relevance).toBe(0)
+      // …yet RRF ranks it on its vector standing (#1 in that arm), so it lands ahead of
+      // the weak lexical hit (#2 in the lexical arm) rather than at the bottom.
+      expect(res.results.map(r => r.id)).toEqual(['lex-strong', 'sem-only', 'lex-weak'])
+      expect(res.sources.vector).toBe(1)
+    })
+
+    it('would have buried that same hit under the lexical ranker', async () => {
+      // Control for the test above: identical inputs, flag off. It is not merely lower —
+      // the vector arm never runs, so the candidate does not exist at all. This is why
+      // adding recall without changing the ordering would have accomplished nothing.
+      delete process.env[FLAG]
+      const { tool } = buildTool({
+        mem0: [LEX_STRONG, LEX_WEAK],
+        similar: [vectorHit({ id: SEMANTIC_ONLY.id, similarity: 0.83 })],
+        entries: { [SEMANTIC_ONLY.id]: SEMANTIC_ONLY },
+      })
+      const res = await tool.search({ query: QUERY })
+      expect(res.results.map(r => r.id)).toEqual(['lex-strong', 'lex-weak'])
+    })
+
+    it('exposes _lexicalRank, _vectorRank, _vectorSimilarity and _rrf on every result', async () => {
+      const { tool } = buildTool({
+        mem0: [LEX_STRONG],
+        similar: [vectorHit({ id: SEMANTIC_ONLY.id, similarity: 0.83 })],
+        entries: { [SEMANTIC_ONLY.id]: SEMANTIC_ONLY },
+      })
+      const res = await tool.search({ query: QUERY })
+      const byId = Object.fromEntries(res.results.map(r => [r.id, r]))
+
+      expect(byId['lex-strong']._lexicalRank).toBe(1)
+      expect(byId['lex-strong']._vectorRank).toBeUndefined()
+      expect(byId['lex-strong']._rrf).toBeCloseTo(1 / 61, 6)
+
+      expect(byId['sem-only']._vectorRank).toBe(1)
+      expect(byId['sem-only']._vectorSimilarity).toBe(0.83)
+      expect(byId['sem-only']._lexicalRank).toBeUndefined()
+
+      // _score is the fused value, so the eval harness's shippedRanker (which re-sorts
+      // by _score) replays the ordering the service actually served.
+      for (const r of res.results) expect(r._score).toBe(r._rrf)
+      expect((res as any)._hybridRetrieval).toBe(true)
+    })
+
+    it('carries the hybrid signals into the KMS_EVAL_CAPTURE pool', async () => {
+      process.env.KMS_EVAL_CAPTURE = '1'
+      try {
+        const { tool } = buildTool({
+          mem0: [LEX_STRONG],
+          similar: [vectorHit({ id: SEMANTIC_ONLY.id, similarity: 0.83 })],
+          entries: { [SEMANTIC_ONLY.id]: SEMANTIC_ONLY },
+        })
+        const res = await tool.search({ query: QUERY })
+        const captured = Object.fromEntries(res._evalCapture!.candidates.map(c => [c.id, c]))
+
+        expect(res._evalCapture!.poolSize).toBe(2)
+        expect(captured['sem-only']._vectorRank).toBe(1)
+        expect(captured['sem-only']._vectorSimilarity).toBe(0.83)
+        expect(captured['sem-only']._rrf).toBeCloseTo(1 / 61, 6)
+        expect(captured['lex-strong']._lexicalRank).toBe(1)
+        expect(typeof captured['lex-strong']._lexicalScore).toBe('number')
+      } finally {
+        delete process.env.KMS_EVAL_CAPTURE
+      }
+    })
+
+    it('deduplicates a document found by both arms into ONE candidate scoring in both', async () => {
+      const { tool } = buildTool({
+        mem0: [LEX_STRONG],
+        mongodb: [LEX_WEAK],
+        similar: [vectorHit({ id: LEX_STRONG.id, similarity: 0.91, content_preview: LEX_STRONG.content.slice(0, 20) })],
+        entries: { [LEX_STRONG.id]: LEX_STRONG },
+      })
+      const res = await tool.search({ query: QUERY })
+
+      expect(res.results.filter(r => r.id === LEX_STRONG.id)).toHaveLength(1)
+      const merged = res.results.find(r => r.id === LEX_STRONG.id)!
+      expect(merged._sourceSystems.sort()).toEqual(['mem0', 'vector'])
+      expect(merged._lexicalRank).toBe(1)
+      expect(merged._vectorRank).toBe(1)
+      // Agreement across arms: both RRF terms accrue to the single merged candidate.
+      expect(merged._rrf).toBeCloseTo(2 / 61, 6)
+      // The truncated preview must not overwrite the full stored content.
+      expect(merged.content).toBe(LEX_STRONG.content)
+      // Raw count still sees three rows; the pool sees two documents.
+      expect(res.totalFound).toBe(3)
+      expect(res._evalCapture).toBeUndefined()
+    })
+
+    it('rehydrates a vector-only hit to full content, not the 200-char preview', async () => {
+      const { tool } = buildTool({
+        similar: [vectorHit({ id: SEMANTIC_ONLY.id, content_preview: 'Top-line projections for the' })],
+        entries: { [SEMANTIC_ONLY.id]: SEMANTIC_ONLY },
+      })
+      const res = await tool.search({ query: QUERY })
+      expect(res.results[0].content).toBe(SEMANTIC_ONLY.content)
+      expect(res.results[0].confidence).toBe(1)
+    })
+
+    it('falls back to the preview when the backend cannot rehydrate', async () => {
+      const { tool } = buildTool({
+        similar: [vectorHit({ id: 'unknown-id', content_preview: 'a preview only' })],
+        entries: {},
+      })
+      const res = await tool.search({ query: QUERY })
+      expect(res.results[0].content).toBe('a preview only')
+    })
+
+    // ── degradation ─────────────────────────────────────────────────────────
+
+    it('falls back to lexical when the embedder throws', async () => {
+      const embedder = stubEmbedder({
+        embed: jest.fn().mockRejectedValue(new Error('connect ECONNREFUSED 127.0.0.1:11434')),
+      } as any)
+      const { tool, findSimilar } = buildTool({ mem0: [LEX_STRONG, LEX_WEAK], embedder })
+
+      const res = await tool.search({ query: QUERY })
+      expect(res.results.map(r => r.id)).toEqual(['lex-strong', 'lex-weak'])
+      expect(res.sources.vector).toBe(0)
+      expect(findSimilar).not.toHaveBeenCalled()
+      expect(res.results.every(r => r._vectorRank === undefined)).toBe(true)
+    })
+
+    it('falls back to lexical when Ollama reports itself unavailable (without paying the embed timeout)', async () => {
+      const embedder = stubEmbedder({ isAvailable: jest.fn().mockResolvedValue(false) } as any)
+      const { tool } = buildTool({ mem0: [LEX_STRONG], embedder })
+
+      const res = await tool.search({ query: QUERY })
+      expect(res.results.map(r => r.id)).toEqual(['lex-strong'])
+      expect(embedder.embed).not.toHaveBeenCalled()
+    })
+
+    it('falls back to lexical when no embedder is injected and Ollama is unreachable', async () => {
+      // No embedder injected → the lazy fallback constructs an Ollama client. Point it
+      // at a closed port so the outcome is decided by this test rather than by whether
+      // the machine running it happens to have Ollama up.
+      const originalUrl = process.env.OLLAMA_BASE_URL
+      process.env.OLLAMA_BASE_URL = 'http://127.0.0.1:1'
+      try {
+        const { tool, findSimilar } = buildTool({ mem0: [LEX_STRONG], embedder: null })
+        const res = await tool.search({ query: QUERY })
+        expect(res.results.map(r => r.id)).toEqual(['lex-strong'])
+        expect(findSimilar).not.toHaveBeenCalled()
+      } finally {
+        if (originalUrl === undefined) delete process.env.OLLAMA_BASE_URL
+        else process.env.OLLAMA_BASE_URL = originalUrl
+      }
+    })
+
+    it('falls back to lexical when the backend has no findSimilar (older binding)', async () => {
+      const { tool, embedder } = buildTool({
+        mem0: [LEX_STRONG, LEX_WEAK],
+        withoutFindSimilar: true,
+      })
+      const res = await tool.search({ query: QUERY })
+
+      expect(res.results.map(r => r.id)).toEqual(['lex-strong', 'lex-weak'])
+      expect(res.sources.vector).toBe(0)
+      // Cheapest check first — no point embedding a query nothing can search with it.
+      expect(embedder!.embed).not.toHaveBeenCalled()
+    })
+
+    it('falls back to lexical when findSimilar itself throws', async () => {
+      const { tool } = buildTool({
+        mem0: [LEX_STRONG],
+        similar: new Error('vector index unavailable'),
+      })
+      const res = await tool.search({ query: QUERY })
+      expect(res.results.map(r => r.id)).toEqual(['lex-strong'])
+      expect(res.sources.vector).toBe(0)
+    })
+
+    it('returns lexical results when the vector arm legitimately finds nothing (the common case today)', async () => {
+      // Only ~29% of the corpus is embedded (806/2761, counted 2026-08-01), so an empty
+      // vector arm is normal.
+      const { tool, findSimilar } = buildTool({ mem0: [LEX_STRONG, LEX_WEAK], similar: [] })
+      const res = await tool.search({ query: QUERY })
+      expect(findSimilar).toHaveBeenCalledTimes(1)
+      expect(res.results.map(r => r.id)).toEqual(['lex-strong', 'lex-weak'])
+      expect(res.sources.vector).toBe(0)
+    })
+
+    // ── filter plumbing ─────────────────────────────────────────────────────
+
+    it('pushes single-valued filters down and post-filters multi-valued ones', async () => {
+      const { tool, findSimilar } = buildTool({
+        similar: [
+          vectorHit({ id: 'a', contentType: 'insight' }),
+          vectorHit({ id: 'b', contentType: 'procedure' }),
+        ],
+      })
+
+      await tool.search({
+        query: QUERY,
+        filters: { userId: 'richard_yaker', contentType: ['insight'], subject: 'KMS.retrieval' },
+      })
+      expect(findSimilar.mock.calls[0][1]).toMatchObject({
+        userId: 'richard_yaker',
+        contentType: 'insight',
+        subject: 'KMS.retrieval',
+        includeFlagged: false,
+      })
+
+      const res = await tool.search({
+        query: QUERY,
+        filters: { userId: 'richard_yaker', contentType: ['insight', 'fact'] },
+      })
+      // Two values cannot be pushed into findSimilar's single-valued option…
+      expect(findSimilar.mock.calls[1][1].contentType).toBeUndefined()
+      // …so the discard happens here instead: 'procedure' is not in the allowed set.
+      expect(res.results.map(r => r.id)).toEqual(['a'])
+    })
+
+    it('propagates includeFlagged to the vector arm', async () => {
+      const { tool, findSimilar } = buildTool({ similar: [] })
+      await tool.search({ query: QUERY, options: { includeFlagged: true } })
+      expect(findSimilar.mock.calls[0][1].includeFlagged).toBe(true)
+    })
+  })
+
+  // ── cache isolation between the two modes ─────────────────────────────────
+
+  it('does not serve a lexical-mode cache entry to a hybrid-mode search', async () => {
+    const store = new Map<string, any>()
+    const cache = {
+      get: jest.fn(async (k: string) => store.get(k) ?? null),
+      set: jest.fn(async (k: string, v: any) => { store.set(k, v) }),
+      invalidate: jest.fn().mockResolvedValue(undefined),
+    }
+    const graph: any = {
+      search: jest.fn().mockResolvedValue([]),
+      getEntitySummary: jest.fn().mockResolvedValue(null),
+      getOperationalNodes: jest.fn().mockResolvedValue([]),
+      findById: jest.fn(() => SEMANTIC_ONLY),
+      findSimilar: jest.fn().mockResolvedValue([vectorHit({ id: SEMANTIC_ONLY.id })]),
+    }
+    const mem0 = { search: jest.fn().mockResolvedValue([LEX_STRONG]) }
+    const tool = new UnifiedSearchTool(
+      { mongodb: { search: jest.fn().mockResolvedValue([]) }, graph, mem0 } as any,
+      cache as any,
+      stubEmbedder()
+    )
+
+    delete process.env[FLAG]
+    const lexical = await tool.search({ query: QUERY })
+    expect(lexical.fromCache).toBe(false)
+    expect(lexical.results).toHaveLength(1)
+
+    process.env[FLAG] = '1'
+    const hybrid = await tool.search({ query: QUERY })
+    // Same cache key (it hashes only query+filters+options) — must NOT be a hit, or an
+    // A/B of the two rankers would be comparing one against a cached copy of the other.
+    expect(hybrid.fromCache).toBe(false)
+    expect(hybrid.results).toHaveLength(2)
+
+    // And the hybrid entry round-trips its own marker back out.
+    const again = await tool.search({ query: QUERY })
+    expect(again.fromCache).toBe(true)
+    expect((again as any)._hybridRetrieval).toBe(true)
+  })
+})

--- a/src/__tests__/retrieval-hybrid.test.ts
+++ b/src/__tests__/retrieval-hybrid.test.ts
@@ -141,6 +141,20 @@ describe('fuseWithRRF', () => {
     expect(fuseWithRRF([...tied].reverse()).map(c => c.id)).toEqual(['alpha', 'zeta'])
   })
 
+  it('breaks a full tie by plain codepoint id order, not locale-aware order', () => {
+    // 'B' (U+0042) < 'a' (U+0061) in codepoint order, but ICU locale collation treats
+    // letters case-insensitively and sorts 'a' before 'B' — `'B'.localeCompare('a')` is
+    // positive. A locale-dependent tie-break would order these ['a', 'B'] here (and
+    // differently again in another locale/ICU version), which makes an offline replay
+    // of a captured pool non-reproducible. The tie-break must not depend on locale.
+    const tied = [
+      { id: 'B', sourceSystem: 'vector', _vectorSimilarity: 0.9, _recency: 0.5, _lexicalScore: 0 },
+      { id: 'a', sourceSystem: 'mem0', _lexicalScore: 0, _recency: 0.5 },
+    ]
+    expect(fuseWithRRF(tied).map(c => c.id)).toEqual(['B', 'a'])
+    expect(fuseWithRRF([...tied].reverse()).map(c => c.id)).toEqual(['B', 'a'])
+  })
+
   it('returns an empty list unchanged', () => {
     expect(fuseWithRRF([])).toEqual([])
   })

--- a/src/__tests__/retrieval-hybrid.test.ts
+++ b/src/__tests__/retrieval-hybrid.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Unit tests for the pure fusion primitives in src/retrieval/hybrid.ts.
+ *
+ * These pin the properties the fusion is *chosen* for, not just that it runs:
+ *   - membership in a ranked list is decided by provenance, not by score
+ *   - the two arms' incomparable magnitudes never enter the fused score
+ *   - recency can break a tie and can never outrank RRF
+ *   - the result is deterministic, so an offline replay matches the live run
+ */
+
+import {
+  RRF_K,
+  RRF_WEIGHT_LEXICAL,
+  RRF_WEIGHT_VECTOR,
+  fuseWithRRF,
+  isHybridRetrievalEnabled,
+  isLexicalCandidate,
+  isVectorCandidate,
+  candidateSourceSystems,
+} from '../retrieval/hybrid.js'
+
+describe('isHybridRetrievalEnabled', () => {
+  it('is off when the flag is unset', () => {
+    expect(isHybridRetrievalEnabled({})).toBe(false)
+  })
+
+  it('is on only for the exact string "1"', () => {
+    expect(isHybridRetrievalEnabled({ KMS_HYBRID_RETRIEVAL: '1' })).toBe(true)
+    expect(isHybridRetrievalEnabled({ KMS_HYBRID_RETRIEVAL: '0' })).toBe(false)
+    // "true"/"yes" are NOT accepted: an operator disabling the feature must never be
+    // able to enable it by accident with a truthy-looking string.
+    expect(isHybridRetrievalEnabled({ KMS_HYBRID_RETRIEVAL: 'true' })).toBe(false)
+    expect(isHybridRetrievalEnabled({ KMS_HYBRID_RETRIEVAL: '' })).toBe(false)
+  })
+})
+
+describe('arm membership', () => {
+  it('uses provenance, not score, to decide lexical membership', () => {
+    // Relevance 0 but retrieved by mem0 → still a member of the lexical list.
+    expect(isLexicalCandidate({ sourceSystem: 'mem0', _lexicalScore: 0 })).toBe(true)
+    // Retrieved only by the vector arm → NOT a member, whatever its lexical score.
+    expect(isLexicalCandidate({ sourceSystem: 'vector', _lexicalScore: 0.9 })).toBe(false)
+  })
+
+  it('reads the merged _sourceSystems list when dedup produced one', () => {
+    expect(candidateSourceSystems({ _sourceSystems: ['vector', 'mongodb'] }))
+      .toEqual(['vector', 'mongodb'])
+    expect(isLexicalCandidate({ sourceSystem: 'vector', _sourceSystems: ['vector', 'mongodb'] })).toBe(true)
+  })
+
+  it('requires a finite similarity for vector membership', () => {
+    expect(isVectorCandidate({ _vectorSimilarity: 0 })).toBe(true)
+    expect(isVectorCandidate({})).toBe(false)
+    expect(isVectorCandidate({ _vectorSimilarity: NaN })).toBe(false)
+  })
+})
+
+describe('fuseWithRRF', () => {
+  it('uses k=60 and equal per-arm weights', () => {
+    expect(RRF_K).toBe(60)
+    expect(RRF_WEIGHT_LEXICAL).toBe(1)
+    expect(RRF_WEIGHT_VECTOR).toBe(1)
+  })
+
+  it('scores each candidate as the sum of 1/(k+rank) over the arms that retrieved it', () => {
+    const fused = fuseWithRRF([
+      { id: 'both', sourceSystem: 'mem0', _sourceSystems: ['mem0', 'vector'], _lexicalScore: 0.9, _vectorSimilarity: 0.8 },
+      { id: 'lex', sourceSystem: 'mem0', _lexicalScore: 0.5 },
+      { id: 'vec', sourceSystem: 'vector', _vectorSimilarity: 0.4 },
+    ])
+    const byId = Object.fromEntries(fused.map(c => [c.id, c]))
+
+    expect(byId.both._lexicalRank).toBe(1)
+    expect(byId.both._vectorRank).toBe(1)
+    expect(byId.both._rrf).toBeCloseTo(1 / 61 + 1 / 61, 6)
+
+    expect(byId.lex._lexicalRank).toBe(2)
+    expect(byId.lex._vectorRank).toBeUndefined()
+    expect(byId.lex._rrf).toBeCloseTo(1 / 62, 6)
+
+    expect(byId.vec._lexicalRank).toBeUndefined()
+    expect(byId.vec._vectorRank).toBe(2)
+    expect(byId.vec._rrf).toBeCloseTo(1 / 62, 6)
+
+    // Agreement between the arms wins.
+    expect(fused[0].id).toBe('both')
+  })
+
+  it('is scale-free: multiplying one arm\'s scores changes nothing', () => {
+    const base = [
+      { id: 'a', sourceSystem: 'mem0', _lexicalScore: 0.9 },
+      { id: 'b', sourceSystem: 'vector', _vectorSimilarity: 0.81 },
+      { id: 'c', sourceSystem: 'vector', _vectorSimilarity: 0.79 },
+    ]
+    // Cosine similarities on this corpus live in a narrow high band; a weighted sum
+    // would be extremely sensitive to that. Rank fusion is not.
+    const squashed = base.map(c =>
+      c._vectorSimilarity !== undefined ? { ...c, _vectorSimilarity: c._vectorSimilarity / 1000 } : c
+    )
+    expect(fuseWithRRF(base).map(c => c.id)).toEqual(fuseWithRRF(squashed).map(c => c.id))
+  })
+
+  it('breaks an exact RRF tie by recency, and only a tie', () => {
+    // Both are their own arm's #1 → identical RRF of 1/61.
+    const fused = fuseWithRRF([
+      { id: 'stale-vector', sourceSystem: 'vector', _vectorSimilarity: 0.95, _recency: 0.1 },
+      { id: 'fresh-lexical', sourceSystem: 'mem0', _lexicalScore: 0.3, _recency: 0.99 },
+    ])
+    expect(fused.map(c => c.id)).toEqual(['fresh-lexical', 'stale-vector'])
+    expect(fused[0]._rrf).toBe(fused[1]._rrf)
+  })
+
+  it('never lets recency overturn a genuine RRF difference', () => {
+    // The stale candidate is #1 in the vector arm; the fresh one is #2 in the lexical
+    // arm. Recency is maximal for the loser and near-zero for the winner, and it still
+    // does not move. Under the shipped lexical composite (recency at 0.25 of the score)
+    // the fresh entry would win — which is the measured meta-noise failure mode.
+    const fused = fuseWithRRF([
+      { id: 'fresh-but-second', sourceSystem: 'mem0', _lexicalScore: 0.2, _recency: 1 },
+      { id: 'stale-but-first', sourceSystem: 'mem0', _lexicalScore: 0.9, _recency: 0.001 },
+    ])
+    expect(fused.map(c => c.id)).toEqual(['stale-but-first', 'fresh-but-second'])
+  })
+
+  it('does not mutate its input', () => {
+    const input = [{ id: 'a', sourceSystem: 'mem0', _lexicalScore: 0.5 }]
+    fuseWithRRF(input)
+    expect(input[0]).not.toHaveProperty('_rrf')
+    expect(input[0]).not.toHaveProperty('_lexicalRank')
+  })
+
+  it('falls back to id order when RRF, recency and lexical score are all equal', () => {
+    // Two arm-leaders that agree on every tie-break: without a final deterministic
+    // guard their order would depend on input order, and an offline replay of the
+    // captured pool could disagree with the live run it is supposed to reproduce.
+    const tied = [
+      { id: 'zeta', sourceSystem: 'vector', _vectorSimilarity: 0.9, _recency: 0.5, _lexicalScore: 0 },
+      { id: 'alpha', sourceSystem: 'mem0', _lexicalScore: 0, _recency: 0.5 },
+    ]
+    expect(fuseWithRRF(tied).map(c => c.id)).toEqual(['alpha', 'zeta'])
+    expect(fuseWithRRF([...tied].reverse()).map(c => c.id)).toEqual(['alpha', 'zeta'])
+  })
+
+  it('returns an empty list unchanged', () => {
+    expect(fuseWithRRF([])).toEqual([])
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,7 +197,10 @@ export class UnifiedKMSServer {
     console.log('🛠️  Initializing Tools...')
     this.tools = {
       store: new UnifiedStoreTool(this.router, this.storage, this.factCache, ollamaRouter, enrichmentQueue, embeddingService, llmJudge),
-      search: new UnifiedSearchTool(this.storage, this.factCache),
+      // The search tool shares the store tool's embedder so the hybrid retrieval arm
+      // (KMS_HYBRID_RETRIEVAL=1, default off) reuses one `isAvailable()` probe cache
+      // instead of re-probing Ollama on every search.
+      search: new UnifiedSearchTool(this.storage, this.factCache, embeddingService),
       instructions: new KMSInstructionsTool(),
       documentStore: new DocumentStoreTool(this.storage.mongodb)
     }

--- a/src/retrieval/hybrid.ts
+++ b/src/retrieval/hybrid.ts
@@ -214,6 +214,11 @@ export function fuseWithRRF<T extends FusionCandidate>(
     if (lexDelta !== 0) return lexDelta
     // Final determinism guard so two otherwise-identical candidates never swap order
     // between runs (which would make an offline replay disagree with the live run).
-    return String(a.id ?? '').localeCompare(String(b.id ?? ''))
+    // Plain codepoint comparison, not `localeCompare` — locale-dependent ordering would
+    // make this non-deterministic across environments/ICU versions, which is exactly
+    // what this guard exists to prevent.
+    const idA = String(a.id ?? '')
+    const idB = String(b.id ?? '')
+    return idA < idB ? -1 : idA > idB ? 1 : 0
   })
 }

--- a/src/retrieval/hybrid.ts
+++ b/src/retrieval/hybrid.ts
@@ -1,0 +1,219 @@
+/**
+ * Hybrid retrieval — Reciprocal Rank Fusion over a lexical arm and a vector arm.
+ *
+ * Why this module exists
+ * ----------------------
+ * `UnifiedSearchTool.search()` fanned out to three backends (mem0 / graph / mongodb)
+ * that are all *lexical*: they match query terms against stored text. Meanwhile the
+ * store carries a populated HNSW vector index that only the write-side dedup gate ever
+ * touched. Adding a vector arm to the read path recovers that recall.
+ *
+ * Recall alone is not enough, and this is the crux. A semantically-retrieved candidate
+ * with zero term overlap scores ~0 on `calculateRelevance`, so the existing composite
+ * (`relevance*0.70 + recency*0.25 + confidence*0.05`) buries it beneath every incidental
+ * keyword hit. Merging the arms without changing the ordering would add candidates that
+ * can never surface.
+ *
+ * Why RRF rather than blending the scores
+ * ---------------------------------------
+ * The two arms emit incomparable quantities: the lexical composite is a bounded
+ * hand-weighted mixture in [0, 1]; the vector arm emits cosine similarity, whose useful
+ * dynamic range on this corpus sits in a narrow band near the top (the dedup gate's own
+ * calibration puts "duplicate" at >= 0.88 and "distinct" below 0.78 — a 0.10-wide
+ * decision band). Any weighted sum of the two needs a normalisation constant that is
+ * really a hidden hyper-parameter, and it has to be re-derived whenever either arm
+ * changes. RRF discards the magnitudes and fuses *ranks*, so it needs no normalisation
+ * and cannot be destabilised by one arm's scores drifting.
+ *
+ *     score(d) = Σ_i  w_i / (k + rank_i(d))
+ *
+ * `k = 60` is the constant from the original RRF paper (Cormack, Clarke & Buettcher,
+ * SIGIR 2009) and the de facto default in every hybrid-search implementation since. It
+ * is deliberately NOT tuned here: k damps the contribution of top ranks so that a single
+ * arm cannot dominate on its #1 alone, and picking a bespoke value on reasoning rather
+ * than measurement is exactly the mistake this whole change is gated against.
+ *
+ * Weights are 1.0 / 1.0 — equal. Two reasons. First, unequal weights are a tuned
+ * parameter and nothing here has been measured yet. Second, only ~29% of the corpus is
+ * embedded today (806 of 2761 entries in the live store carry an embedder id, counted
+ * 2026-08-01), so the vector arm's *coverage* is the binding constraint, not its weight;
+ * up-weighting a mostly-absent arm would measure the backfill's progress rather than the
+ * fusion's value. Revisit after the harness reports.
+ *
+ * Recency is a strict tie-break, never a term
+ * -------------------------------------------
+ * The lexical composite gives recency 0.25 of the total, and a measured consequence is
+ * that recency *raises* the meta-noise share of the top-k: freshly written
+ * session-extract entries are both recent and keyword-dense, so they park at the top of
+ * queries they have nothing to do with. Folding recency into the fused score would carry
+ * that defect straight through the fusion. Here it only ever breaks an exact RRF tie —
+ * which is common, because a candidate ranked #1 by one arm alone and a candidate ranked
+ * #1 by the other arm alone score identically (1/(k+1)).
+ *
+ * Everything in this module is a pure function so the fusion can be replayed offline
+ * over a frozen candidate pool (see `src/eval/rankers.ts` and `KMS_EVAL_CAPTURE`).
+ */
+
+/** Environment flag that turns hybrid retrieval on. Default OFF. */
+export const HYBRID_RETRIEVAL_FLAG = 'KMS_HYBRID_RETRIEVAL'
+
+/**
+ * RRF damping constant. 60 is the published default (Cormack et al. 2009). Exported so
+ * the eval harness fuses with the identical constant the service used.
+ */
+export const RRF_K = 60
+
+/** Per-arm RRF weights. Equal by design — see the module header. */
+export const RRF_WEIGHT_LEXICAL = 1
+export const RRF_WEIGHT_VECTOR = 1
+
+/**
+ * Backends whose hits count as "retrieved by the lexical arm". The vector arm tags its
+ * hits `vector`, so membership of each ranked list is decided by provenance rather than
+ * by whether a score happens to be non-zero.
+ */
+export const LEXICAL_SOURCE_SYSTEMS: ReadonlySet<string> = new Set(['mem0', 'graph', 'mongodb'])
+
+/** Sentinel `sourceSystem` for candidates produced by the vector arm. */
+export const VECTOR_SOURCE_SYSTEM = 'vector'
+
+/**
+ * Is hybrid retrieval enabled?
+ *
+ * Strictly `'1'`. Not "any truthy string" — an operator who exports
+ * `KMS_HYBRID_RETRIEVAL=0` to turn the feature *off* must not accidentally turn it on.
+ */
+export function isHybridRetrievalEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env[HYBRID_RETRIEVAL_FLAG] === '1'
+}
+
+/** The fields fusion reads off a deduplicated candidate. */
+export interface FusionCandidate {
+  id?: string
+  /** Set when the candidate came from exactly one backend. */
+  sourceSystem?: string
+  /** Set by `deduplicateResults` when the same item arrived from several backends. */
+  _sourceSystems?: string[]
+  /** The pre-existing lexical composite (relevance/recency/confidence), if lexical. */
+  _lexicalScore?: number
+  /** Recency weight in [0, 1] — tie-break only. */
+  _recency?: number
+  /** Cosine similarity from the vector arm, if the vector arm retrieved this. */
+  _vectorSimilarity?: number
+  [k: string]: unknown
+}
+
+/** A candidate after fusion — the signals are attached, not hidden. */
+export interface FusedCandidate extends FusionCandidate {
+  /** 1-based position within the lexical arm's ranked list. Absent if not retrieved by it. */
+  _lexicalRank?: number
+  /** 1-based position within the vector arm's ranked list. Absent if not retrieved by it. */
+  _vectorRank?: number
+  /** Σ w_i / (k + rank_i). */
+  _rrf: number
+}
+
+/** Every backend this candidate was seen in. */
+export function candidateSourceSystems(c: FusionCandidate): string[] {
+  if (Array.isArray(c._sourceSystems) && c._sourceSystems.length > 0) {
+    return c._sourceSystems.filter((s): s is string => typeof s === 'string')
+  }
+  return typeof c.sourceSystem === 'string' ? [c.sourceSystem] : []
+}
+
+/**
+ * Did the lexical arm retrieve this candidate?
+ *
+ * Provenance, not score. A lexical hit whose relevance rounds to 0 (a stopword-only
+ * overlap, say) is still a member of the lexical result list and gets a rank; a
+ * vector-only hit is not a member no matter what its lexical score computes to. That
+ * distinction is what makes this RRF rather than a disguised score blend.
+ */
+export function isLexicalCandidate(c: FusionCandidate): boolean {
+  return candidateSourceSystems(c).some(s => LEXICAL_SOURCE_SYSTEMS.has(s))
+}
+
+/** Did the vector arm retrieve this candidate? */
+export function isVectorCandidate(c: FusionCandidate): boolean {
+  return typeof c._vectorSimilarity === 'number' && Number.isFinite(c._vectorSimilarity)
+}
+
+/**
+ * Assign 1-based ranks over `members`, ordered by `score` descending.
+ *
+ * `Array.prototype.sort` is stable (ES2019), so equal scores keep their incoming order —
+ * which is the fixed backend fan-out order, hence deterministic across runs.
+ */
+function rankBy<T extends FusionCandidate>(
+  members: T[],
+  score: (c: T) => number
+): Map<T, number> {
+  const ordered = [...members].sort((a, b) => score(b) - score(a))
+  const ranks = new Map<T, number>()
+  ordered.forEach((c, i) => ranks.set(c, i + 1))
+  return ranks
+}
+
+export interface FuseOptions {
+  k?: number
+  lexicalWeight?: number
+  vectorWeight?: number
+}
+
+/**
+ * Fuse the lexical and vector arms with Reciprocal Rank Fusion.
+ *
+ * Input is the *deduplicated* pool: an item found by both arms is one candidate that
+ * appears in both ranked lists and therefore accrues both terms — which is precisely the
+ * agreement bonus RRF is meant to give.
+ *
+ * Returns new objects (the inputs are not mutated) ordered by `_rrf` descending, with
+ * recency, then lexical score, then id as strictly subordinate tie-breaks.
+ */
+export function fuseWithRRF<T extends FusionCandidate>(
+  candidates: T[],
+  options: FuseOptions = {}
+): Array<T & FusedCandidate> {
+  const k = options.k ?? RRF_K
+  const wLex = options.lexicalWeight ?? RRF_WEIGHT_LEXICAL
+  const wVec = options.vectorWeight ?? RRF_WEIGHT_VECTOR
+
+  const lexicalRanks = rankBy(
+    candidates.filter(isLexicalCandidate),
+    c => (typeof c._lexicalScore === 'number' ? c._lexicalScore : 0)
+  )
+  const vectorRanks = rankBy(
+    candidates.filter(isVectorCandidate),
+    c => (typeof c._vectorSimilarity === 'number' ? c._vectorSimilarity : 0)
+  )
+
+  const fused = candidates.map(c => {
+    const lexicalRank = lexicalRanks.get(c)
+    const vectorRank = vectorRanks.get(c)
+    const rrf =
+      (lexicalRank !== undefined ? wLex / (k + lexicalRank) : 0) +
+      (vectorRank !== undefined ? wVec / (k + vectorRank) : 0)
+
+    return {
+      ...c,
+      ...(lexicalRank !== undefined ? { _lexicalRank: lexicalRank } : {}),
+      ...(vectorRank !== undefined ? { _vectorRank: vectorRank } : {}),
+      // 6 dp: adjacent RRF values differ by ~2.7e-4 at the head of the list and stay
+      // above 1e-6 for any pool this system will ever hold, so rounding here cannot
+      // manufacture ties that the raw values did not have.
+      _rrf: Number(rrf.toFixed(6)),
+    } as T & FusedCandidate
+  })
+
+  return fused.sort((a, b) => {
+    if (b._rrf !== a._rrf) return b._rrf - a._rrf
+    // --- strictly subordinate tie-breaks below; none of these can outrank RRF ---
+    const recencyDelta = (b._recency ?? 0) - (a._recency ?? 0)
+    if (recencyDelta !== 0) return recencyDelta
+    const lexDelta = (b._lexicalScore ?? 0) - (a._lexicalScore ?? 0)
+    if (lexDelta !== 0) return lexDelta
+    // Final determinism guard so two otherwise-identical candidates never swap order
+    // between runs (which would make an offline replay disagree with the live run).
+    return String(a.id ?? '').localeCompare(String(b.id ?? ''))
+  })
+}

--- a/src/tools/UnifiedSearchTool.ts
+++ b/src/tools/UnifiedSearchTool.ts
@@ -645,6 +645,13 @@ export class UnifiedSearchTool {
       const subjects = typeof filters.subject === 'string'
         ? [filters.subject]
         : Array.isArray(filters.subject) ? filters.subject : undefined
+      // `findSimilar` has no `source` parameter at all (unlike contentType/subject, it
+      // cannot be pushed down even in the single-valued case), so this is always a
+      // post-filter. Without it a caller filtering on `source` would get vector hits from
+      // sources it explicitly excluded — the lexical arms already honour this filter
+      // (MongoDBStorage/Mem0Storage/SparrowDBStorage.search all do `$in`/equality checks
+      // on `filters.source`), so the vector arm must match rather than silently ignore it.
+      const sources = Array.isArray(filters.source) && filters.source.length > 0 ? filters.source : undefined
 
       const maxResults = query.options?.maxResults ?? 10
       // Over-fetch relative to the returned window: fusion needs enough of the vector
@@ -678,6 +685,7 @@ export class UnifiedSearchTool {
         if (!hit || typeof hit.id !== 'string') continue
         if (contentTypes && contentTypes.length > 1 && !contentTypes.includes(hit.contentType)) continue
         if (subjects && subjects.length > 1 && !subjects.includes(hit.subject ?? '')) continue
+        if (sources && !sources.includes(hit.source)) continue
 
         // `findSimilar` returns a 200-char preview, not the entry. Rehydrate through the
         // backend's own index so a vector-only hit is a first-class result rather than a

--- a/src/tools/UnifiedSearchTool.ts
+++ b/src/tools/UnifiedSearchTool.ts
@@ -8,6 +8,12 @@ import { FACTCache } from '../cache/FACTCache.js'
 import { MongoDBStorage, Mem0Storage } from '../storage/index.js'
 import type { GraphStorage } from '../types/index.js'
 import type { EvalCandidate } from '../eval/rankers.js'
+import { OllamaEmbeddingService, type EmbeddingService } from '../embedding/EmbeddingService.js'
+import {
+  fuseWithRRF,
+  isHybridRetrievalEnabled,
+  VECTOR_SOURCE_SYSTEM,
+} from '../retrieval/hybrid.js'
 
 /** Shape of the KMS_EVAL_CAPTURE payload — the deduplicated, ranked pool captured
  *  before `maxResults` slicing so a ranker can be replayed offline over the same set. */
@@ -26,13 +32,41 @@ export class UnifiedSearchTool {
     mem0: Mem0Storage
   }
   private cache: FACTCache
+  /** Injected embedder for the vector arm. Only ever touched when the hybrid flag is on. */
+  private embeddingService: EmbeddingService | null
+  /** Memoised lazy fallback embedder — see `getEmbeddingService()`. */
+  private lazyEmbeddingService: EmbeddingService | null = null
 
   constructor(
     storage: { mongodb: MongoDBStorage, graph: GraphStorage, mem0: Mem0Storage },
-    cache: FACTCache | null
+    cache: FACTCache | null,
+    embeddingService?: EmbeddingService | null
   ) {
     this.storage = storage
     this.cache = cache as FACTCache // Now using real cache
+    this.embeddingService = embeddingService ?? null
+  }
+
+  /**
+   * The embedder for the vector arm.
+   *
+   * Prefers the injected instance — sharing one instance with `UnifiedStoreTool` also
+   * shares its `isAvailable()` cache, so a search does not re-probe Ollama that a store
+   * just probed. Construction is otherwise deferred to first use so that every call site
+   * that never enables hybrid retrieval (the CLI, every existing test) pays nothing and
+   * never opens a socket.
+   */
+  private getEmbeddingService(): EmbeddingService | null {
+    if (this.embeddingService) return this.embeddingService
+    if (!this.lazyEmbeddingService) {
+      try {
+        this.lazyEmbeddingService = new OllamaEmbeddingService()
+      } catch (e) {
+        debug(`⚠️ hybrid: could not construct fallback embedder: ${e instanceof Error ? e.message : String(e)}`)
+        return null
+      }
+    }
+    return this.lazyEmbeddingService
   }
 
   /**
@@ -66,6 +100,11 @@ export class UnifiedSearchTool {
       mem0: number
       graph: number
       mongodb: number
+      // Present only when KMS_HYBRID_RETRIEVAL=1 — how many candidates the vector arm
+      // contributed. Expect this to be small or zero today: ~29% of the corpus is
+      // embedded (806/2761 entries in the live store, counted 2026-08-01), so an empty
+      // vector arm is the normal case, not a fault.
+      vector?: number
     }
     performance: {
       cacheCheckTime: number
@@ -83,6 +122,9 @@ export class UnifiedSearchTool {
     }>
     // Present only when KMS_EVAL_CAPTURE=1 — the deduplicated pool pre-slicing.
     _evalCapture?: EvalCapture
+    // Present (and true) only when KMS_HYBRID_RETRIEVAL=1. Also persisted into the cache
+    // entry so a response produced under one retrieval mode is never served to the other.
+    _hybridRetrieval?: true
   }> {
     const startTime = Date.now()
     
@@ -115,17 +157,32 @@ export class UnifiedSearchTool {
     const cached = this.cache ? await this.cache.get<{
       results: any[]
       totalFound: number
-      sources: { mem0: number, graph: number, mongodb: number }
+      sources: { mem0: number, graph: number, mongodb: number, vector?: number }
       _evalCapture?: EvalCapture
+      _hybridRetrieval?: true
     }>(cacheKey) : null
     const cacheCheckTime = Date.now() - cacheCheckStart
     const wantsEvalCapture = process.env.KMS_EVAL_CAPTURE === '1'
+    const hybridEnabled = isHybridRetrievalEnabled()
 
     // A cache entry written before KMS_EVAL_CAPTURE was set (or by a run with it off)
     // has no _evalCapture. Serving it as a hit would silently hand the harness a
     // response with no candidate pool. Treat that case as a miss so the full search
     // path runs and captures fresh.
-    if (cached && query.options?.cacheStrategy !== 'realtime' && (!wantsEvalCapture || cached._evalCapture)) {
+    //
+    // The same argument applies to the hybrid flag, and more sharply: the cache key is a
+    // hash of query+filters+options only, so a lexical-only response and a fused response
+    // collide on it. Serving one for the other would make an A/B measurement of the two
+    // rankers silently compare a ranker against a cached copy of its rival. Treat a
+    // mode mismatch as a miss. (Entries written before this field existed have it
+    // undefined, which correctly reads as "lexical".)
+    const cachedIsHybrid = cached?._hybridRetrieval === true
+    if (
+      cached &&
+      query.options?.cacheStrategy !== 'realtime' &&
+      (!wantsEvalCapture || cached._evalCapture) &&
+      cachedIsHybrid === hybridEnabled
+    ) {
       debug(`⚡ CACHE HIT - Returning cached results`)
 
       return {
@@ -141,7 +198,8 @@ export class UnifiedSearchTool {
           mergingTime: 0,
           totalTime: Date.now() - startTime
         },
-        ...(cached._evalCapture ? { _evalCapture: cached._evalCapture } : {})
+        ...(cached._evalCapture ? { _evalCapture: cached._evalCapture } : {}),
+        ...(cached._hybridRetrieval ? { _hybridRetrieval: true as const } : {})
       }
     }
 
@@ -150,10 +208,13 @@ export class UnifiedSearchTool {
     // Step 2: Search across all systems in parallel
     const searchStart = Date.now()
 
-    const [mem0Results, graphResults, mongoResults] = await Promise.allSettled([
+    // The fourth (vector) arm is appended only when the flag is on, so with the flag off
+    // this is the same three-way allSettled it has always been.
+    const [mem0Results, graphResults, mongoResults, vectorSettled] = await Promise.allSettled([
       this.searchMem0(query),
       this.searchGraph(query),
-      this.searchMongoDB(query)
+      this.searchMongoDB(query),
+      ...(hybridEnabled ? [this.searchVector(query)] : [])
     ])
 
     const searchTime = Date.now() - searchStart
@@ -164,19 +225,28 @@ export class UnifiedSearchTool {
     const processedResults = {
       mem0: mem0Results.status === 'fulfilled' ? mem0Results.value : [],
       graph: graphResults.status === 'fulfilled' ? graphResults.value : [],
-      mongodb: mongoResults.status === 'fulfilled' ? mongoResults.value : []
+      mongodb: mongoResults.status === 'fulfilled' ? mongoResults.value : [],
+      // `searchVector` already swallows its own failures and returns []; this second
+      // guard covers a rejection it could not anticipate. Either way the lexical arms
+      // still produce a result set — a search that fails because the embedder is down
+      // would be far worse than one without semantic recall.
+      vector: vectorSettled?.status === 'fulfilled' ? vectorSettled.value : []
     }
 
     debug(`📊 Results found:`)
     debug(`   Mem0: ${processedResults.mem0.length}`)
     debug(`   Graph: ${processedResults.graph.length}`)
     debug(`   MongoDB: ${processedResults.mongodb.length}`)
+    if (hybridEnabled) debug(`   Vector: ${processedResults.vector.length}`)
 
-    // Merge all results
+    // Merge all results. Vector hits join the SAME pool as the lexical ones and go
+    // through deduplicateResults with them, so an item both arms found stays one
+    // candidate (and, in fusion, one that scores in both ranked lists).
     const allResults = [
       ...processedResults.mem0.map(r => ({ ...r, sourceSystem: 'mem0' })),
       ...processedResults.graph.map(r => ({ ...r, sourceSystem: 'graph' })),
-      ...processedResults.mongodb.map(r => ({ ...r, sourceSystem: 'mongodb' }))
+      ...processedResults.mongodb.map(r => ({ ...r, sourceSystem: 'mongodb' })),
+      ...processedResults.vector.map(r => ({ ...r, sourceSystem: VECTOR_SOURCE_SYSTEM }))
     ]
 
     // Remove duplicates (same ID from different systems)
@@ -184,7 +254,9 @@ export class UnifiedSearchTool {
 
     // Sort by relevance and confidence
     const maxResults = query.options?.maxResults ?? 10
-    const rankedResults = this.rankResults(uniqueResults, args.query)
+    const rankedResults = hybridEnabled
+      ? this.rankResultsHybrid(uniqueResults, args.query)
+      : this.rankResults(uniqueResults, args.query)
     const sortedResults = rankedResults.slice(0, maxResults)
 
     // Eval capture (KMS_EVAL_CAPTURE=1). Off by default and zero-cost when off.
@@ -215,6 +287,18 @@ export class UnifiedSearchTool {
             _score: r._score,
             _relevance: r._relevance,
             _recency: r._recency,
+            // Hybrid signals. Emitted only under the flag so a flag-off capture is
+            // byte-identical to what the harness recorded before this change. The
+            // eval harness replays rankers off these fields, so the fusion has to be
+            // reconstructible from the capture alone: _lexicalRank + _vectorRank + the
+            // published k are exactly enough to recompute _rrf offline.
+            ...(hybridEnabled ? {
+              _lexicalScore: r._lexicalScore,
+              _lexicalRank: r._lexicalRank,
+              _vectorRank: r._vectorRank,
+              _vectorSimilarity: r._vectorSimilarity,
+              _rrf: r._rrf,
+            } : {}),
           })),
         }
       : undefined
@@ -250,7 +334,8 @@ export class UnifiedSearchTool {
       sources: {
         mem0: processedResults.mem0.length,
         graph: processedResults.graph.length,
-        mongodb: processedResults.mongodb.length
+        mongodb: processedResults.mongodb.length,
+        ...(hybridEnabled ? { vector: processedResults.vector.length } : {})
       },
       performance: {
         cacheCheckTime,
@@ -260,7 +345,8 @@ export class UnifiedSearchTool {
       },
       entity_context,
       triggered_actions,
-      ...(evalCapture ? { _evalCapture: evalCapture } : {})
+      ...(evalCapture ? { _evalCapture: evalCapture } : {}),
+      ...(hybridEnabled ? { _hybridRetrieval: true as const } : {})
     }
 
     // Step 5: Cache the results
@@ -504,6 +590,143 @@ export class UnifiedSearchTool {
   }
 
   /**
+   * The vector arm (KMS_HYBRID_RETRIEVAL=1 only).
+   *
+   * Embeds the query and asks the graph backend's HNSW index for nearest neighbours —
+   * the index that `unified_store`'s dedup gate has been populating and maintaining all
+   * along, and that the read path never once consulted.
+   *
+   * Every failure mode here degrades to `[]`, never to a thrown error:
+   *   - no `findSimilar` on the backend (older binding, non-vector graph store)
+   *   - no embedder available at all
+   *   - Ollama down / timing out (`isAvailable()` is a short probe, cached ~30 s)
+   *   - embed throws (dim mismatch, empty query, HTTP error)
+   *   - `findSimilar` throws
+   * A search returning fewer results is a degradation; a search that 500s because the
+   * embedder is down is an outage. Only the first is acceptable.
+   *
+   * An empty return is also the *expected* case for much of the corpus right now: 806 of
+   * 2761 entries in the live store carry an embedder id (counted 2026-08-01, ~29%), so
+   * unembedded entries simply cannot be reached by this arm and will keep arriving
+   * lexically. That is a backfill gap, not a bug in this code path.
+   */
+  private async searchVector(query: KnowledgeQuery): Promise<any[]> {
+    const graph: any = this.storage.graph
+
+    // Optional on the GraphStorage interface — a backend without a vector index must
+    // leave the lexical arms completely untouched.
+    if (typeof graph?.findSimilar !== 'function') {
+      debug('🧭 hybrid: graph backend exposes no findSimilar — vector arm skipped')
+      return []
+    }
+
+    const embedder = this.getEmbeddingService()
+    if (!embedder) {
+      debug('🧭 hybrid: no embedding service — vector arm skipped')
+      return []
+    }
+
+    try {
+      if (typeof embedder.isAvailable === 'function' && !(await embedder.isAvailable())) {
+        debug('🧭 hybrid: embedder unavailable — falling back to lexical only')
+        return []
+      }
+
+      const embedding = await embedder.embed(query.query)
+
+      const filters = query.filters ?? {}
+      const userId = filters.userId || process.env.KMS_DEFAULT_USER_ID || 'personal'
+
+      // `findSimilar` takes ONE contentType and ONE subject, while the query filters are
+      // multi-valued. Push a filter down only when it is single-valued (so the HNSW
+      // post-filter does the narrowing and the over-fetch budget is spent on candidates
+      // that can actually survive); otherwise filter here, after retrieval.
+      const contentTypes = Array.isArray(filters.contentType) ? filters.contentType : undefined
+      const subjects = typeof filters.subject === 'string'
+        ? [filters.subject]
+        : Array.isArray(filters.subject) ? filters.subject : undefined
+
+      const maxResults = query.options?.maxResults ?? 10
+      // Over-fetch relative to the returned window: fusion needs enough of the vector
+      // ranking to be meaningful, and a candidate the lexical arm also found consumes a
+      // slot in both lists.
+      const topK = Math.min(50, Math.max(10, maxResults * 2))
+
+      const hits = await graph.findSimilar(embedding, {
+        userId,
+        contentType: contentTypes?.length === 1 ? contentTypes[0] : undefined,
+        subject: subjects?.length === 1 ? subjects[0] : undefined,
+        topK,
+        includeFlagged: query.options?.includeFlagged === true
+      }) as Array<{
+        id: string
+        similarity: number
+        contentType: string
+        source: string
+        subject?: string
+        created: string
+        flag?: string | null
+        content_preview: string
+      }>
+
+      if (!Array.isArray(hits) || hits.length === 0) return []
+
+      const minConfidence = typeof filters.minConfidence === 'number' ? filters.minConfidence : undefined
+
+      const out: any[] = []
+      for (const hit of hits) {
+        if (!hit || typeof hit.id !== 'string') continue
+        if (contentTypes && contentTypes.length > 1 && !contentTypes.includes(hit.contentType)) continue
+        if (subjects && subjects.length > 1 && !subjects.includes(hit.subject ?? '')) continue
+
+        // `findSimilar` returns a 200-char preview, not the entry. Rehydrate through the
+        // backend's own index so a vector-only hit is a first-class result rather than a
+        // truncated stub — and so dedup's longest-content merge is not skewed by a
+        // preview masquerading as the whole entry.
+        const full = this.hydrateFromGraph(hit.id)
+
+        const confidence = typeof full?.confidence === 'number' ? full.confidence : 0
+        if (minConfidence !== undefined && confidence < minConfidence) continue
+
+        out.push({
+          id: hit.id,
+          content: full?.content ?? hit.content_preview,
+          contentType: full?.contentType ?? hit.contentType,
+          source: full?.source ?? hit.source,
+          timestamp: full?.timestamp ?? hit.created,
+          confidence,
+          metadata: full?.metadata ?? (hit.subject ? { subject: hit.subject } : {}),
+          relationships: full?.relationships ?? [],
+          _vectorSimilarity: Number(hit.similarity.toFixed(4))
+        })
+      }
+
+      debug(`🧭 hybrid: vector arm returned ${out.length} candidate(s)`)
+      return out
+    } catch (error) {
+      console.warn('⚠️ Vector search arm failed (continuing lexical-only):', error instanceof Error ? error.message : String(error))
+      return []
+    }
+  }
+
+  /**
+   * Best-effort full-entry lookup for a vector hit. Synchronous on the SparrowDB
+   * backend (an in-memory index read); anything else — missing method, a thenable, a
+   * throw — yields null and the caller keeps the preview.
+   */
+  private hydrateFromGraph(id: string): any | null {
+    const graph: any = this.storage.graph
+    if (typeof graph?.findById !== 'function') return null
+    try {
+      const entry = graph.findById(id)
+      if (!entry || typeof (entry as any).then === 'function') return null
+      return entry
+    } catch {
+      return null
+    }
+  }
+
+  /**
    * Remove duplicate results based on content similarity
    */
   /**
@@ -613,6 +836,35 @@ export class UnifiedSearchTool {
       return { ...r, _score: Number(score.toFixed(4)), _relevance: Number(relevance.toFixed(4)), _recency: Number(recency.toFixed(4)) }
     })
     return scored.sort((a, b) => b._score - a._score)
+  }
+
+  /**
+   * Hybrid ranking (KMS_HYBRID_RETRIEVAL=1 only) — Reciprocal Rank Fusion of the lexical
+   * ordering and the vector ordering.
+   *
+   * The lexical composite is computed exactly as `rankResults` computes it, but it is no
+   * longer the final score: it becomes the lexical arm's *ranking key*, published as
+   * `_lexicalScore`. Fusion then works on ranks, because the two arms' scores are not on
+   * a comparable scale (see `src/retrieval/hybrid.ts` for the full argument).
+   *
+   * `_score` is set to the fused value so that the value the service ordered by is the
+   * value the eval harness's `shippedRanker` re-sorts by — otherwise the harness would
+   * silently replay the lexical ordering and report it as the shipped one.
+   */
+  private rankResultsHybrid(results: any[], query: string): any[] {
+    const scored = results.map(r => {
+      const relevance = this.calculateRelevance(r.content, query)
+      const recency = this.calculateRecency(r.timestamp)
+      const lexicalScore = relevance * 0.70 + recency * 0.25 + (r.confidence ?? 0) * 0.05
+      return {
+        ...r,
+        _relevance: Number(relevance.toFixed(4)),
+        _recency: Number(recency.toFixed(4)),
+        _lexicalScore: Number(lexicalScore.toFixed(4))
+      }
+    })
+
+    return fuseWithRRF(scored).map(r => ({ ...r, _score: r._rrf }))
   }
 
   /**


### PR DESCRIPTION
## What

Adds a fourth retrieval arm to `UnifiedSearchTool.search()` — the query is embedded and run against the HNSW vector index that until now only the write-side dedup gate ever touched — and fuses it with the existing lexical arms using Reciprocal Rank Fusion.

**Gated on `KMS_HYBRID_RETRIEVAL=1`, default OFF.** Not to be made default until it is measured on the eval harness. Do not merge-and-enable in one step.

## Why RRF, and why recall alone would not have worked

A semantically-retrieved candidate with no term overlap scores exactly `0` on `calculateRelevance`, so under the shipped composite (`relevance*0.70 + recency*0.25 + confidence*0.05`) it sorts below every incidental keyword hit. Merging the arms without changing the ordering would have added candidates that can never surface. There is a test that pins precisely this: the semantic hit has `_relevance === 0` and still ranks second.

RRF (`score = Σ 1/(k + rank_i)`) rather than a weighted score blend:

- The two arms emit incomparable quantities. The lexical composite is a hand-weighted mixture in [0,1]; the vector arm emits cosine similarity whose useful range on this corpus is a narrow high band (the dedup gate calls >= 0.88 duplicate and < 0.78 distinct — a 0.10-wide decision band). Any sum of the two needs a normalisation constant, which is a hidden hyper-parameter that must be re-derived whenever either arm changes.
- Rank fusion discards the magnitudes, so it needs no normalisation and cannot be destabilised by one arm's scores drifting. A test asserts scale-invariance directly.

**Constant and weights:** `k = 60`, weights `1.0 / 1.0`.

`k=60` is the published default (Cormack, Clarke & Buettcher, SIGIR 2009) and deliberately not tuned — picking a bespoke value by reasoning is the exact failure this flag exists to prevent. Weights are equal because nothing has been measured yet, and because the binding constraint today is the vector arm's *coverage*, not its weight: 806 of 2761 live entries carry an embedder id (~29%, counted 2026-08-01). Up-weighting a mostly-absent arm would measure the backfill's progress rather than the fusion's value.

**Recency is a strict comparator tie-break, never a term in the fused score.** Recency at 0.25 of the composite is a measured cause of raised meta-noise share in the top-k (recent session-extract entries are both fresh and keyword-dense). Folding it into the fusion would carry that defect straight through. It only ever separates candidates whose RRF is exactly equal — which is common, since each arm's #1 scores an identical `1/61`. Two tests pin both directions: it breaks a tie, and it cannot overturn a genuine RRF difference.

## Exposed signals

`_lexicalRank`, `_vectorRank`, `_vectorSimilarity`, `_rrf`, plus `_lexicalScore` (the old composite, now the lexical arm's ranking key). All survive into the `KMS_EVAL_CAPTURE` candidate objects, so the fusion is reconstructible offline from the capture alone. `_score` is set to the fused value so `shippedRanker` (which re-sorts by `_score`) replays the ordering the service actually served rather than silently replaying the lexical one.

`src/eval/rankers.ts` is untouched — `EvalCandidate` already has an index signature.

## Flag-off behaviour, verified rather than asserted

A temporary differential test loaded `main`'s `UnifiedSearchTool` alongside this one and compared `search()` output as **ordered JSON** across three fixtures × `KMS_EVAL_CAPTURE` on/off, with a graph mock that *does* expose `findSimilar` (so the guard is proven to come from the flag, not from a missing method). Identical key-for-key including key order. The scaffold was removed before commit; the permanent suite keeps the observable assertions (no embed call, no `findSimilar` call, no hybrid keys, `_score` still equals the lexical composite, unchanged eval-capture key set).

Cache entries also record their retrieval mode. The cache key hashes only query+filters+options, so a lexical and a fused response collide on it — serving one for the other would make an A/B of the two rankers compare a ranker against a cached copy of its rival. A mode mismatch is treated as a miss.

## Degradation

Every vector-arm failure falls back to pure lexical and still returns results — no `findSimilar` on the backend, no embedder, Ollama unavailable, embed throws, `findSimilar` throws. Each has a test. An empty vector arm is also simply the normal case for ~71% of the corpus today.

## Tests

516 → 549 (26 → 28 suites). Green with the flag **off** and **on**. `npx tsc --noEmit` clean.

New coverage: flag off = unchanged behaviour; RRF arithmetic and ordering; a zero-term-overlap vector-only hit surfacing (plus a flag-off control showing it does not even exist); embedder failure → lexical; `isAvailable()` false → lexical without paying the embed timeout; `findSimilar` absent → lexical; `findSimilar` throws → lexical; dedup of a document found by both arms into one candidate scoring in both; rehydration to full content; filter push-down vs post-filter; cache mode isolation.

## Could not verify

- **Whether this actually improves retrieval quality.** Nothing here has been run against the eval harness — no P@5, MRR, nDCG or meta-share numbers exist for the fused ranker. That is the entire reason for the flag, and it is the next step before default-on.
- **Any live end-to-end search.** No search was executed against `~/.kms-sparrowdb-v2`. A long-running backfill holds the single-writer lock and the instruction was not to open the store or restart `com.ryaker.kms-mcp`. Every vector-arm test uses a mocked `findSimilar`, so the arm is verified against `SparrowDBStorage.findSimilar`'s *declared* contract, not its live behaviour. Specifically unexercised on real data: HNSW recall quality, and whether `internalIdToUuid` resolves for the entries a query would actually hit.
- **Real embedding latency.** Ollama was never called. `isAvailable()` + `embed()` add an unmeasured serial cost to the vector arm; the arm runs in parallel with the lexical ones, so p50 search latency should be governed by `max(arms)`, but that is reasoning, not a measurement.
- **The corpus coverage figure is mine, not the ticket's.** The brief said 767/2591. Counting `content-index.json` read-only on 2026-08-01 gives 806 of 2761 entries with an `embedder_id` (~29%). Note it lives under `metadata.embedder_id` for 806 entries and at top level for only 3 — if anything queries the top-level field to decide "is this embedded", it will see 3.
- **`src/cli/kms.ts`** constructs `UnifiedSearchTool` without an embedder. With the flag on it would lazily construct an Ollama client. Left as-is (that file was outside the stated ownership) and not exercised.
- **Vector-only hits do not participate in `expandWithEntityContext`.** That pass still receives the three lexical arms only, so a vector-only hit contributes no `entity_context` and gets no `linkedEntityIds` unless a lexical arm also found it. Deliberate, to keep the flag-off path untouched — but it is a real behavioural gap, not an oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfUP35PJDzrYLpVcbWEbsk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional hybrid search combining lexical and vector retrieval for improved result relevance.
  - Added deterministic ranking that balances lexical and semantic matches.
  - Search responses now include retrieval mode, vector result counts, and ranking details when hybrid search is enabled.
  - Added graceful fallback to lexical search when vector retrieval is unavailable.

- **Bug Fixes**
  - Improved result deduplication, filtering, caching, and recovery of vector matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->