### PR TITLE
fix(backfill): detect a competing writer mid-run, not just at startup

### DIFF
--- a/src/__tests__/backfill-hnsw-embeddings.test.ts
+++ b/src/__tests__/backfill-hnsw-embeddings.test.ts
@@ -604,3 +604,75 @@ describe('backfill-hnsw-embeddings', () => {
     expect(report.embedFailed).toBe(1)
   })
 })
+
+describe('competing-writer detection mid-run', () => {
+  // The 2026-08-01 incident: the startup gate passed, the run reported 1721
+  // successes, and ~1150 of them were destroyed. The launchd job has
+  // KeepAlive=true and runs `node --watch dist/index.js`, so the daemon
+  // relaunched partway through, held an index snapshot from its own open(),
+  // and saved that stale view over the backfill's work on its next write.
+  // A gate that only fires at startup cannot see a writer that arrives later.
+
+  it('aborts when the daemon reappears partway through the run', async () => {
+    const tmp = makeTmpDir()
+    const sidecar: Record<string, any> = {}
+    for (let i = 0; i < 40; i++) sidecar[`id-${i}`] = { id: `id-${i}`, content: `entry ${i}`, metadata: {} }
+
+    let probeCalls = 0
+    const opts = buildOpts(tmp, sidecar, {
+      concurrency: 1,
+      writerCheckIntervalMs: 1,
+      // Clean at the startup gate, then the daemon comes back.
+      isDaemonRunning: () => ++probeCalls > 1,
+    })
+    const report = await runBackfill(opts)
+
+    expect(report.aborted?.reason).toMatch(/^competing_writer:/)
+    expect(report.aborted?.reason).toContain('com.ryaker.kms-mcp')
+    // It must stop early rather than plough through the whole candidate set.
+    expect(report.succeeded).toBeLessThan(40)
+  })
+
+  it('completes normally when no competing writer ever appears', async () => {
+    const tmp = makeTmpDir()
+    const sidecar: Record<string, any> = {}
+    for (let i = 0; i < 5; i++) sidecar[`id-${i}`] = { id: `id-${i}`, content: `entry ${i}`, metadata: {} }
+
+    const opts = buildOpts(tmp, sidecar, { writerCheckIntervalMs: 1, isDaemonRunning: () => false })
+    const report = await runBackfill(opts)
+
+    expect(report.aborted).toBeUndefined()
+    expect(report.succeeded).toBe(5)
+  })
+
+  it('does not abort on a probe that throws — an unanswerable probe is not evidence', async () => {
+    // Failing the run on a flaky launchctl would be worse than the risk it guards.
+    const tmp = makeTmpDir()
+    const sidecar: Record<string, any> = {}
+    for (let i = 0; i < 5; i++) sidecar[`id-${i}`] = { id: `id-${i}`, content: `entry ${i}`, metadata: {} }
+
+    let first = true
+    const opts = buildOpts(tmp, sidecar, {
+      writerCheckIntervalMs: 1,
+      isDaemonRunning: () => { if (first) { first = false; return false } throw new Error('launchctl unavailable') },
+    })
+    const report = await runBackfill(opts)
+
+    expect(report.aborted).toBeUndefined()
+    expect(report.succeeded).toBe(5)
+  })
+
+  it('honours writerCheckIntervalMs=0 as "startup gate only"', async () => {
+    const tmp = makeTmpDir()
+    const sidecar: Record<string, any> = { 'id-0': { id: 'id-0', content: 'x', metadata: {} } }
+    let probeCalls = 0
+    const opts = buildOpts(tmp, sidecar, {
+      writerCheckIntervalMs: 0,
+      isDaemonRunning: () => { probeCalls++; return false },
+    })
+    const report = await runBackfill(opts)
+
+    expect(report.aborted).toBeUndefined()
+    expect(probeCalls).toBe(1)   // startup gate only, no re-checks scheduled
+  })
+})

--- a/src/__tests__/backfill-hnsw-embeddings.test.ts
+++ b/src/__tests__/backfill-hnsw-embeddings.test.ts
@@ -676,3 +676,159 @@ describe('competing-writer detection mid-run', () => {
     expect(probeCalls).toBe(1)   // startup gate only, no re-checks scheduled
   })
 })
+
+// ---------------------------------------------------------------------------
+// PR #93 CodeRabbit review fixes
+// ---------------------------------------------------------------------------
+
+describe('PR #93 review fixes', () => {
+  // CRITICAL: checkForCompetingWriter() at the top of the task proves the
+  // daemon was down when the task STARTED. embedWithRetry is a real network
+  // round-trip (380-480ms measured against the Ollama host); a daemon that
+  // reappears during that window is invisible until the NEXT entry's top-of-
+  // task check. Re-check immediately before the write, not only at the top.
+  it('re-checks contention after the embed and before the write — a writer detected during the embed window must not be written', async () => {
+    const tmp = makeTmpDir()
+    const sidecar = makeSidecar([makeEntry('a')])
+    const dbCalls: Array<{ id: string; vec: Float32Array }> = []
+    // Flipped by a real timer mid-embed, not counted probe calls:
+    // checkForCompetingWriter()'s throttle means the exact number of real
+    // (non-throttled) probe invocations before a given check is a race (an
+    // ordinal-counting stub was flaky here — see the sibling test's comment).
+    // A wall-clock flip well inside the 30ms embed window is deterministic:
+    // the top-of-task check runs at ~t=0 (always sees `false`, timer not due
+    // yet); the post-embed check this fix adds runs at ~t=30ms, long after
+    // the 5ms flip (always sees `true`).
+    let daemonReappeared = false
+    setTimeout(() => { daemonReappeared = true }, 5)
+
+    const opts = buildOpts(tmp, sidecar, {
+      concurrency: 1,
+      writerCheckIntervalMs: 1,
+      embeddingService: makeMockEmbedder({ delayMs: 30 }),
+      openSparrowDB: () => makeMockDb({ recorded: dbCalls }),
+      isDaemonRunning: () => daemonReappeared,
+    })
+
+    const report = await runBackfill(opts)
+
+    expect(report.aborted?.reason).toMatch(/^competing_writer:/)
+    expect(dbCalls).toHaveLength(0) // must NOT have written — contention was known before the write
+    expect(report.succeeded).toBe(0)
+    try { rmSync(tmp, { recursive: true, force: true }) } catch { /* noop */ }
+  })
+
+  // CRITICAL: everything this run wrote is unsafe once a competing writer is
+  // detected — SparrowDB rewrites the WHOLE file on every insert, so the other
+  // process's next save overwrites this run's entire contribution with its
+  // own stale open()-time snapshot, not just entries written after detection.
+  // Persisting those ids as `completed` makes the next resume SKIP vectors
+  // that no longer exist. On abort: revert state.completed/failed to the
+  // pre-run snapshot, do not persist the sidecar, and do not checkpoint.
+  it('does NOT persist unsafe writes as completed — a resume after a competing-writer abort must re-embed everything this run wrote', async () => {
+    const tmp = makeTmpDir()
+    const sidecar = makeSidecar([
+      makeEntry('id-0'), makeEntry('id-1'), makeEntry('id-2'),
+    ])
+    const dbCalls: Array<{ id: string; vec: Float32Array }> = []
+    let checkpointCalls = 0
+    // Tied to a real EVENT (the first genuine write), not a probe-call
+    // ordinal — checkForCompetingWriter()'s throttle window means the exact
+    // number of real (non-throttled) probe invocations per task is a race
+    // (sub-1ms scheduling decides whether a given check's probe call lands
+    // before or after another task's), so counting calls is not
+    // deterministic. Flipping a flag inside the write itself is: task 1's own
+    // checks (top-of-task, and the post-embed one this PR adds) always run
+    // BEFORE task 1's own write, so they always see `false` and task 1 always
+    // completes; every check task 2 makes runs strictly after that write, so
+    // it always sees `true` — regardless of which of its checks (if any got
+    // throttled) is the one that actually re-probes.
+    let daemonReappeared = false
+
+    const db: SparrowDBLike = {
+      addToVectorIndex: (_label, _prop, nodeId, vec) => {
+        dbCalls.push({ id: nodeId, vec })
+        daemonReappeared = true
+      },
+      checkpoint: () => { checkpointCalls++ },
+    }
+
+    const opts = buildOpts(tmp, sidecar, {
+      concurrency: 1,
+      writerCheckIntervalMs: 1,
+      // Delay long enough that a post-embed check is never itself throttled
+      // (it always fires >= 1ms after the previous real check).
+      embeddingService: makeMockEmbedder({ delayMs: 20 }),
+      openSparrowDB: () => db,
+      isDaemonRunning: () => daemonReappeared,
+    })
+
+    const report = await runBackfill(opts)
+
+    expect(report.aborted?.reason).toMatch(/^competing_writer:/)
+    // The write to the vector index genuinely happened this run (unsafe, but real).
+    expect(dbCalls.map(c => c.id)).toEqual(['id-0'])
+    expect(report.succeeded).toBe(1)
+
+    // Yet the persisted state file must NOT record 'id-0' as completed — a
+    // resumed run has to re-embed and re-write it, not silently skip it.
+    const state = JSON.parse(readFileSync(opts.statePath, 'utf8'))
+    expect(state.completed).toEqual([])
+
+    // The sidecar on disk must not carry this run's embedder_id stamp either.
+    const persisted = JSON.parse(readFileSync(opts.sidecarPath, 'utf8')) as Record<string, SidecarEntry>
+    expect(persisted['id-0'].metadata?.embedder_id).toBeUndefined()
+
+    // No checkpoint on the way out of a competing-writer abort.
+    expect(checkpointCalls).toBe(0)
+
+    try { rmSync(tmp, { recursive: true, force: true }) } catch { /* noop */ }
+  })
+
+  // MAJOR: the startup gate has done zero work when it runs, so refusing to
+  // begin on an unanswerable probe costs nothing. This is the opposite of the
+  // mid-run check, which stays lenient because aborting a long-running
+  // backfill on a flaky launchctl is worse than the (small) risk it guards.
+  it('fails CLOSED when the startup probe throws — refuses to start, never opens SparrowDB', async () => {
+    const tmp = makeTmpDir()
+    const sidecar = makeSidecar([makeEntry('a')])
+    let openerCalled = false
+
+    const opts = buildOpts(tmp, sidecar, {
+      isDaemonRunning: () => { throw new Error('launchctl unavailable') },
+      openSparrowDB: () => { openerCalled = true; return makeMockDb() },
+    })
+
+    const report = await runBackfill(opts)
+
+    expect(report.aborted).toBeDefined()
+    expect(report.aborted?.reason).toMatch(/lock_contention/)
+    expect(openerCalled).toBe(false)
+    expect(report.succeeded).toBe(0)
+  })
+
+  // MAJOR: operator instructions must use the launchd domain for the account
+  // actually running the script, not a hardcoded gui/501 — consistent with
+  // defaultIsDaemonRunning(), which already derives the domain from the
+  // current process uid.
+  it('operator instructions use the current UID, not a hardcoded gui/501', async () => {
+    const tmp = makeTmpDir()
+    const sidecar = makeSidecar([makeEntry('a')])
+    const lines: string[] = []
+    const getuidSpy = jest.spyOn(process, 'getuid' as any).mockReturnValue(777 as any)
+
+    try {
+      const opts = buildOpts(tmp, sidecar, {
+        log: m => lines.push(m),
+        isDaemonRunning: () => true, // trigger the "STOP THE LAUNCHD DAEMON" instructions
+      })
+      await runBackfill(opts)
+    } finally {
+      getuidSpy.mockRestore()
+    }
+
+    const text = lines.join('\n')
+    expect(text).toContain('gui/777/')
+    expect(text).not.toContain('gui/501')
+  })
+})

--- a/src/scripts/backfill-hnsw-embeddings.ts
+++ b/src/scripts/backfill-hnsw-embeddings.ts
@@ -53,13 +53,13 @@
  * dist/ by any process restarts it mid-run. Disable the job:
  *
  *   BEFORE running:
- *     launchctl disable gui/501/com.ryaker.kms-mcp
- *     launchctl bootout  gui/501/com.ryaker.kms-mcp
+ *     launchctl disable gui/$(id -u)/com.ryaker.kms-mcp
+ *     launchctl bootout  gui/$(id -u)/com.ryaker.kms-mcp
  *     sleep 10 && /usr/sbin/lsof -nP -i :8180 || echo CLEAR   # wait for CLEAR
  *
  *   AFTER running:
- *     launchctl enable    gui/501/com.ryaker.kms-mcp
- *     launchctl bootstrap gui/501 ~/Library/LaunchAgents/com.ryaker.kms-mcp.plist
+ *     launchctl enable    gui/$(id -u)/com.ryaker.kms-mcp
+ *     launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.ryaker.kms-mcp.plist
  *
  * The script gates on this at startup AND re-checks every `writerCheckIntervalMs`
  * while running (default 10s), aborting the moment a competing writer appears —
@@ -67,7 +67,15 @@
  *
  * Note also that this script writes via `addToVectorIndex`, which populates the
  * HNSW index WITHOUT writing the node property. Those vectors are therefore not
- * rebuildable from column data. Prefer `SET k.embedding = $vec` if that matters.
+ * rebuildable from column data. If that matters, prefer the parameterized write
+ * `storeEmbedding()` uses (SparrowDBStorage.ts) instead — SparrowDB 0.1.22
+ * rejects list literals in SET, so the vector must go through
+ * `executeWithParams`, not an inline `SET k.embedding = [...]`:
+ *
+ *   db.executeWithParams(
+ *     `MATCH (k:Knowledge {id: ${cypherStr(id)}}) SET k.embedding = $emb`,
+ *     { emb: Array.from(embedding) }
+ *   )
  *
  * Run
  * ===
@@ -363,6 +371,10 @@ export async function runBackfill(opts: BackfillOptions): Promise<BackfillReport
   const startTime = Date.now()
   const hnswPath = join(opts.sparrowdbPath, 'vector_indexes', 'hnsw_Knowledge_embedding.bin')
   const hnswSizeBefore = fileSizeOrZero(hnswPath)
+  // Same derivation as defaultIsDaemonRunning() — the printed operator
+  // commands must target the launchd domain of the account actually running
+  // this script, not a hardcoded uid that's wrong on any other account.
+  const uid = process.getuid?.() ?? 501
 
   // ----- Lock acquisition first ------------------------------------------------
   // Two-step gate:
@@ -390,14 +402,14 @@ export async function runBackfill(opts: BackfillOptions): Promise<BackfillReport
     log('  bootout alone is not enough: the job has KeepAlive=true, so')
     log('  launchd will relaunch it. Disable it first.')
     log('')
-    log(`    launchctl disable gui/501/${DAEMON_LABEL}`)
-    log(`    launchctl bootout  gui/501/${DAEMON_LABEL}`)
+    log(`    launchctl disable gui/${uid}/${DAEMON_LABEL}`)
+    log(`    launchctl bootout  gui/${uid}/${DAEMON_LABEL}`)
     log('    sleep 10 && /usr/sbin/lsof -nP -i :8180 || echo CLEAR')
     log('')
     log('  Wait for CLEAR, then re-run this script. Afterwards:')
     log('')
-    log(`    launchctl enable    gui/501/${DAEMON_LABEL}`)
-    log('    launchctl bootstrap gui/501 \\')
+    log(`    launchctl enable    gui/${uid}/${DAEMON_LABEL}`)
+    log(`    launchctl bootstrap gui/${uid} \\`)
     log(`      ~/Library/LaunchAgents/${DAEMON_LABEL}.plist`)
     log('')
     return {
@@ -414,9 +426,26 @@ export async function runBackfill(opts: BackfillOptions): Promise<BackfillReport
   }
 
   // OS-level daemon check. Skip in dry-run since we don't write.
+  //
+  // Fail CLOSED here, not open — the opposite of checkForCompetingWriter()
+  // below, which deliberately treats a throwing probe as "no evidence" and
+  // keeps going. That asymmetry is intentional: at startup we have not done
+  // any work yet, so refusing to begin costs nothing, while failing a
+  // long-running backfill on a flaky launchctl mid-run costs everything
+  // already in flight. Starting blind on an unanswerable probe risks writing
+  // straight into the exact contention this script exists to prevent.
   const daemonProbe = opts.isDaemonRunning ?? defaultIsDaemonRunning
-  if (!opts.dryRun && daemonProbe()) {
-    return failOpen(`Daemon (${DAEMON_LABEL}) is currently running:`, 'launchctl reports active state')
+  if (!opts.dryRun) {
+    let daemonIsRunning: boolean
+    try {
+      daemonIsRunning = daemonProbe()
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e)
+      return failOpen('Could not determine daemon state before starting:', `daemon probe threw: ${msg}`)
+    }
+    if (daemonIsRunning) {
+      return failOpen(`Daemon (${DAEMON_LABEL}) is currently running:`, 'launchctl reports active state')
+    }
   }
 
   let db: SparrowDBLike
@@ -434,6 +463,18 @@ export async function runBackfill(opts: BackfillOptions): Promise<BackfillReport
   const state = loadState(opts.statePath)
   const completedSet = new Set(state.completed)
   log(`📁 State file: ${state.completed.length} previously completed, ${state.failed.length} previously failed`)
+
+  // Snapshot of what was known-safe BEFORE this run touched anything. If a
+  // competing writer is detected mid-run, every vector THIS RUN wrote is
+  // unsafe — SparrowDB rewrites the whole index file on every insert, so the
+  // other process's next save overwrites this run's entire contribution with
+  // its own stale open()-time snapshot, not just entries written after
+  // detection. On that abort path we revert to exactly this snapshot rather
+  // than persisting any of this run's completions, so a resume re-embeds and
+  // re-writes everything instead of silently skipping vectors that no longer
+  // exist.
+  const preRunCompleted = [...state.completed]
+  const preRunFailed = [...state.failed]
 
   // ----- Build work list ------------------------------------------------------
   const candidates: SidecarEntry[] = []
@@ -540,7 +581,15 @@ export async function runBackfill(opts: BackfillOptions): Promise<BackfillReport
         return
       }
 
-      // 2. Insert into HNSW.
+      // 2. Re-check contention. embedWithRetry is a real network round-trip to
+      // Ollama (380-480ms measured) — the guard's answer from step 0 is stale
+      // by the time we get here. A daemon that reappears during the embed
+      // window must be caught NOW, before the write, not only at the next
+      // entry's top-of-task check.
+      checkForCompetingWriter()
+      if (fatalError || competingWriter) return
+
+      // 3. Insert into HNSW.
       try {
         db.addToVectorIndex('Knowledge', 'embedding', entry.id, embedResult.vec)
       } catch (e) {
@@ -566,7 +615,7 @@ export async function runBackfill(opts: BackfillOptions): Promise<BackfillReport
         return
       }
 
-      // 3. Stamp metadata + persist progress (in-memory only).
+      // 4. Stamp metadata + persist progress (in-memory only).
       const e = sidecar.get(entry.id)
       if (e) {
         e.metadata = {
@@ -580,7 +629,7 @@ export async function runBackfill(opts: BackfillOptions): Promise<BackfillReport
       succeeded++
       processedSinceFlush++
 
-      // 4. Periodic state flush + progress log.
+      // 5. Periodic state flush + progress log.
       if (processedSinceFlush >= flushEvery) {
         processedSinceFlush = 0
         saveState(opts.statePath, state)
@@ -598,9 +647,23 @@ export async function runBackfill(opts: BackfillOptions): Promise<BackfillReport
 
   // A competing writer means everything above is provisional: the other process
   // holds an index snapshot from its own open() and will overwrite this run's
-  // work on its next vector write. Say so loudly — the 2026-08-01 incident looked
-  // like a clean success right up until the daemon's next save.
+  // ENTIRE contribution on its next vector write — SparrowDB re-serialises and
+  // rewrites the whole index file on every insert, so this is not limited to
+  // entries written after detection. Say so loudly — the 2026-08-01 incident
+  // looked like a clean success right up until the daemon's next save.
+  //
+  // Do not persist any of this run's completions: revert state.completed /
+  // state.failed to the pre-run snapshot, skip the sidecar write, and skip
+  // checkpoint() (one more write we don't need to make on the way out), then
+  // return BEFORE the normal finalization below. Persisting these ids as
+  // `completed` would make the next resume SKIP vectors that the daemon is
+  // about to destroy — exactly the silent-data-loss class this PR exists to
+  // prevent, just moved one abort path over.
   if (competingWriter) {
+    state.completed = preRunCompleted
+    state.failed = preRunFailed
+    saveState(opts.statePath, state)
+
     log('')
     log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━')
     log('  ABORTED — A COMPETING WRITER APPEARED MID-RUN')
@@ -616,12 +679,27 @@ export async function runBackfill(opts: BackfillOptions): Promise<BackfillReport
     log('    ls -l "$SPARROWDB_PATH/vector_indexes/hnsw_Knowledge_embedding.bin"')
     log('')
     log('  Disable the job (not just bootout — KeepAlive relaunches it),')
-    log('  confirm port 8180 is clear, then re-run. The state file makes')
-    log('  this resumable, so completed ids are not re-embedded.')
+    log('  confirm port 8180 is clear, then re-run. This run recorded NO new')
+    log('  completions — the state file was reverted to what it was before')
+    log('  this run, so the resume re-embeds and re-writes everything in')
+    log('  this window rather than silently skipping lost vectors.')
     log('')
+
+    return {
+      total,
+      succeeded,
+      alreadyCompleted,
+      graphOrphan,
+      embedFailed,
+      hnswSizeBefore,
+      hnswSizeAfter: fileSizeOrZero(hnswPath),
+      elapsedMs: Date.now() - startTime,
+      aborted: { reason: `competing_writer: ${competingWriter}` },
+    }
   }
 
-  // ----- Final flush ----------------------------------------------------------
+  // ----- Final flush (fatalError or full completion only — competingWriter
+  // returned above) ------------------------------------------------------------
   saveState(opts.statePath, state)
 
   // Persist the sidecar ONCE — see comment in storeEmbedding (PR #69) about
@@ -659,20 +737,6 @@ export async function runBackfill(opts: BackfillOptions): Promise<BackfillReport
       hnswSizeAfter: fileSizeOrZero(hnswPath),
       elapsedMs: Date.now() - startTime,
       aborted: { reason: `fatal_typeerror: ${fatalError.message}` },
-    }
-  }
-
-  if (competingWriter) {
-    return {
-      total,
-      succeeded,
-      alreadyCompleted,
-      graphOrphan,
-      embedFailed,
-      hnswSizeBefore,
-      hnswSizeAfter: fileSizeOrZero(hnswPath),
-      elapsedMs: Date.now() - startTime,
-      aborted: { reason: `competing_writer: ${competingWriter}` },
     }
   }
 

--- a/src/scripts/backfill-hnsw-embeddings.ts
+++ b/src/scripts/backfill-hnsw-embeddings.ts
@@ -34,17 +34,40 @@
  *
  * Critical safety
  * ===============
- * SparrowDB 0.1.22 is a single-writer engine. The KMSmcp launchd daemon
- * (`com.ryaker.kms-mcp` on the build server) holds a writer handle on the
- * same database. Running this script concurrently with the daemon will fail
- * to acquire the writer lock; the script aborts with a clear instruction
- * rather than retrying.
+ * SparrowDB 0.1.22 calls itself single-writer, but that guarantee is a
+ * PROCESS-LOCAL AtomicBool with no cross-process enforcement. Two processes
+ * each get their own, so neither sees the other and `SparrowDB.open()` simply
+ * succeeds. Nothing fails, nothing warns. Every insert re-serialises the entire
+ * in-memory index and writes the whole file, so whichever process saves LAST
+ * silently overwrites everything the other one did.
+ *
+ * This is not hypothetical. On 2026-08-01 this script reported 1721 successes
+ * and grew the index 2,497,757 -> 8,084,693 bytes. The daemon then relaunched,
+ * held an index snapshot from its own open(), performed one ordinary vector
+ * write, and saved 1299 vectors over the 2433 that were there. ~1150 destroyed,
+ * no error anywhere. Recovered only because a copy of the .bin happened to
+ * survive in a scratch directory.
+ *
+ * `bootout` alone is NOT sufficient — the job carries KeepAlive=true, so launchd
+ * relaunches it. It also runs `node --watch dist/index.js`, so ANY rebuild of
+ * dist/ by any process restarts it mid-run. Disable the job:
  *
  *   BEFORE running:
- *     launchctl bootout gui/501/com.ryaker.kms-mcp
+ *     launchctl disable gui/501/com.ryaker.kms-mcp
+ *     launchctl bootout  gui/501/com.ryaker.kms-mcp
+ *     sleep 10 && /usr/sbin/lsof -nP -i :8180 || echo CLEAR   # wait for CLEAR
  *
  *   AFTER running:
+ *     launchctl enable    gui/501/com.ryaker.kms-mcp
  *     launchctl bootstrap gui/501 ~/Library/LaunchAgents/com.ryaker.kms-mcp.plist
+ *
+ * The script gates on this at startup AND re-checks every `writerCheckIntervalMs`
+ * while running (default 10s), aborting the moment a competing writer appears —
+ * a startup-only gate cannot see a daemon that returns at minute three.
+ *
+ * Note also that this script writes via `addToVectorIndex`, which populates the
+ * HNSW index WITHOUT writing the node property. Those vectors are therefore not
+ * rebuildable from column data. Prefer `SET k.embedding = $vec` if that matters.
  *
  * Run
  * ===
@@ -150,6 +173,23 @@ export interface BackfillOptions {
    * shell-out; tests inject a stub.
    */
   isDaemonRunning?: () => boolean
+  /**
+   * How often to RE-CHECK for a competing writer while the run is in flight,
+   * in milliseconds. 0 disables re-checking (startup gate only).
+   *
+   * Why this exists: on 2026-08-01 a backfill wrote 1721 vectors, the index grew
+   * 2.5MB -> 8.1MB, and roughly 1150 of them were destroyed. The startup gate had
+   * passed. The launchd job carries KeepAlive=true and runs `node --watch
+   * dist/index.js`, so the daemon relaunches on any rebuild of dist/ — and once
+   * relaunched it holds an index snapshot taken at ITS open() time. Because
+   * SparrowDB's single-writer guarantee is a process-local AtomicBool with no
+   * cross-process enforcement, and every insert re-serialises the whole in-memory
+   * index, the daemon's next vector write silently saved its stale view over the
+   * backfill's work. Last writer wins, no error, no detection.
+   *
+   * Checking once at startup cannot catch a writer that appears at minute three.
+   */
+  writerCheckIntervalMs?: number
 }
 
 /** Final report emitted at end of run. */
@@ -342,14 +382,21 @@ export async function runBackfill(opts: BackfillOptions): Promise<BackfillReport
     log(`  ${reason}`)
     log(`    ${detail}`)
     log('')
-    log('  SparrowDB 0.1.22 is single-writer. The KMSmcp daemon')
-    log('  must be stopped before this script can safely write')
-    log('  to the HNSW index. Run:')
+    log('  SparrowDB 0.1.22 is single-writer, and that guarantee is a')
+    log('  process-local AtomicBool — it is NOT enforced across processes.')
+    log('  Two writers do not conflict; the second one silently overwrites')
+    log('  the first. The daemon must be stopped, and must STAY stopped.')
     log('')
-    log('    launchctl bootout gui/501/com.ryaker.kms-mcp')
+    log('  bootout alone is not enough: the job has KeepAlive=true, so')
+    log('  launchd will relaunch it. Disable it first.')
     log('')
-    log('  …then re-run this script. After it finishes:')
+    log('    launchctl disable gui/501/com.ryaker.kms-mcp')
+    log('    launchctl bootout  gui/501/com.ryaker.kms-mcp')
+    log('    sleep 10 && /usr/sbin/lsof -nP -i :8180 || echo CLEAR')
     log('')
+    log('  Wait for CLEAR, then re-run this script. Afterwards:')
+    log('')
+    log('    launchctl enable    gui/501/com.ryaker.kms-mcp')
     log('    launchctl bootstrap gui/501 \\')
     log('      ~/Library/LaunchAgents/com.ryaker.kms-mcp.plist')
     log('')
@@ -449,9 +496,38 @@ export async function runBackfill(opts: BackfillOptions): Promise<BackfillReport
   // Abort-on-fatal hook: TypeError from addToVectorIndex (dimension mismatch).
   let fatalError: Error | null = null
 
+  // Abort-on-competing-writer hook. The startup gate proves the daemon was down
+  // when we began; it says nothing about minute three. Everything already written
+  // is at risk the moment a second writer appears, so stop immediately and tell
+  // the operator rather than continuing to pile work onto an index that is about
+  // to be overwritten by someone else's stale snapshot.
+  let competingWriter: string | null = null
+  const writerCheckMs = opts.writerCheckIntervalMs ?? 10_000
+  const writerCheckEnabled = !opts.dryRun && writerCheckMs > 0
+  let lastWriterCheck = Date.now()
+
+  // Checked INLINE rather than on a setInterval. A timer is a macrotask, so a run
+  // whose embedder resolves immediately can finish every entry without the event
+  // loop ever reaching it — the check would silently never fire, which is exactly
+  // the class of bug this whole guard exists to prevent.
+  const checkForCompetingWriter = (): void => {
+    if (!writerCheckEnabled || competingWriter) return
+    if (Date.now() - lastWriterCheck < writerCheckMs) return
+    lastWriterCheck = Date.now()
+    try {
+      if (daemonProbe()) {
+        competingWriter = 'launchd daemon com.ryaker.kms-mcp reappeared mid-run'
+      }
+    } catch {
+      // A probe that cannot answer is not evidence of a writer. Keep going —
+      // failing the run on a flaky launchctl is worse than the risk it guards.
+    }
+  }
+
   const tasks = candidates.map(entry =>
     limit(async () => {
-      if (fatalError) return // short-circuit remaining queue after abort
+      checkForCompetingWriter()
+      if (fatalError || competingWriter) return // short-circuit remaining queue after abort
 
       const t0 = Date.now()
 
@@ -517,8 +593,33 @@ export async function runBackfill(opts: BackfillOptions): Promise<BackfillReport
     }),
   )
 
-  // Wait for everything (or fatalError to propagate).
+  // Wait for everything (or fatalError / competingWriter to propagate).
   await Promise.allSettled(tasks)
+
+  // A competing writer means everything above is provisional: the other process
+  // holds an index snapshot from its own open() and will overwrite this run's
+  // work on its next vector write. Say so loudly — the 2026-08-01 incident looked
+  // like a clean success right up until the daemon's next save.
+  if (competingWriter) {
+    log('')
+    log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━')
+    log('  ABORTED — A COMPETING WRITER APPEARED MID-RUN')
+    log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━')
+    log('')
+    log(`  ${competingWriter}`)
+    log('')
+    log(`  ${succeeded} vectors were written before the abort, and they are`)
+    log('  NOT safe. The other process opened the index at its own start')
+    log('  time and will save that stale snapshot over this work on its')
+    log('  next vector write, silently. Verify before trusting them:')
+    log('')
+    log('    ls -l "$SPARROWDB_PATH/vector_indexes/hnsw_Knowledge_embedding.bin"')
+    log('')
+    log('  Disable the job (not just bootout — KeepAlive relaunches it),')
+    log('  confirm port 8180 is clear, then re-run. The state file makes')
+    log('  this resumable, so completed ids are not re-embedded.')
+    log('')
+  }
 
   // ----- Final flush ----------------------------------------------------------
   saveState(opts.statePath, state)
@@ -558,6 +659,20 @@ export async function runBackfill(opts: BackfillOptions): Promise<BackfillReport
       hnswSizeAfter: fileSizeOrZero(hnswPath),
       elapsedMs: Date.now() - startTime,
       aborted: { reason: `fatal_typeerror: ${fatalError.message}` },
+    }
+  }
+
+  if (competingWriter) {
+    return {
+      total,
+      succeeded,
+      alreadyCompleted,
+      graphOrphan,
+      embedFailed,
+      hnswSizeBefore,
+      hnswSizeAfter: fileSizeOrZero(hnswPath),
+      elapsedMs: Date.now() - startTime,
+      aborted: { reason: `competing_writer: ${competingWriter}` },
     }
   }
 

--- a/src/scripts/backfill-hnsw-embeddings.ts
+++ b/src/scripts/backfill-hnsw-embeddings.ts
@@ -390,15 +390,15 @@ export async function runBackfill(opts: BackfillOptions): Promise<BackfillReport
     log('  bootout alone is not enough: the job has KeepAlive=true, so')
     log('  launchd will relaunch it. Disable it first.')
     log('')
-    log('    launchctl disable gui/501/com.ryaker.kms-mcp')
-    log('    launchctl bootout  gui/501/com.ryaker.kms-mcp')
+    log(`    launchctl disable gui/501/${DAEMON_LABEL}`)
+    log(`    launchctl bootout  gui/501/${DAEMON_LABEL}`)
     log('    sleep 10 && /usr/sbin/lsof -nP -i :8180 || echo CLEAR')
     log('')
     log('  Wait for CLEAR, then re-run this script. Afterwards:')
     log('')
-    log('    launchctl enable    gui/501/com.ryaker.kms-mcp')
+    log(`    launchctl enable    gui/501/${DAEMON_LABEL}`)
     log('    launchctl bootstrap gui/501 \\')
-    log('      ~/Library/LaunchAgents/com.ryaker.kms-mcp.plist')
+    log(`      ~/Library/LaunchAgents/${DAEMON_LABEL}.plist`)
     log('')
     return {
       total: 0,
@@ -416,7 +416,7 @@ export async function runBackfill(opts: BackfillOptions): Promise<BackfillReport
   // OS-level daemon check. Skip in dry-run since we don't write.
   const daemonProbe = opts.isDaemonRunning ?? defaultIsDaemonRunning
   if (!opts.dryRun && daemonProbe()) {
-    return failOpen('Daemon (com.ryaker.kms-mcp) is currently running:', 'launchctl reports active state')
+    return failOpen(`Daemon (${DAEMON_LABEL}) is currently running:`, 'launchctl reports active state')
   }
 
   let db: SparrowDBLike
@@ -516,7 +516,7 @@ export async function runBackfill(opts: BackfillOptions): Promise<BackfillReport
     lastWriterCheck = Date.now()
     try {
       if (daemonProbe()) {
-        competingWriter = 'launchd daemon com.ryaker.kms-mcp reappeared mid-run'
+        competingWriter = `launchd daemon ${DAEMON_LABEL} reappeared mid-run`
       }
     } catch {
       // A probe that cannot answer is not evidence of a writer. Keep going —
@@ -729,12 +729,20 @@ async function defaultOpener(path: string): Promise<SparrowDBLike> {
  * (manual `node dist/index.js`), the operator can still pass
  * `KMS_BACKFILL_FORCE=1` to bypass.
  */
+/**
+ * launchd label of the process that competes for the SparrowDB writer.
+ * Overridable so the competing-writer path can be exercised end-to-end against a
+ * throwaway job instead of the production daemon — a stubbed probe proves the
+ * abort logic but proves nothing about whether launchctl parsing actually works.
+ */
+export const DAEMON_LABEL = process.env.KMS_DAEMON_LABEL || 'com.ryaker.kms-mcp'
+
 function defaultIsDaemonRunning(): boolean {
   if (process.env.KMS_BACKFILL_FORCE === '1') return false
   try {
     const uid = process.getuid?.() ?? 501
     const out = execSync(
-      `launchctl print "gui/${uid}/com.ryaker.kms-mcp"`,
+      `launchctl print "gui/${uid}/${DAEMON_LABEL}"`,
       { stdio: ['ignore', 'pipe', 'ignore'] }
     ).toString()
     // launchctl prints `state = running` (or `not running`). Treat anything


### PR DESCRIPTION
## The incident this prevents

On 2026-08-01 the backfill reported 1721 successes and grew the HNSW index from 2,497,757 to 8,084,693 bytes. Roughly 1150 of those vectors were then destroyed. **The startup gate had passed cleanly.**

SparrowDB's single-writer guarantee is a process-local `AtomicBool` with no cross-process enforcement — two writers never see each other and `open()` just succeeds. Every insert re-serialises the whole in-memory index and rewrites the file, so whichever process saves *last* silently overwrites the other's work. The launchd job carries `KeepAlive=true` and runs `node --watch dist/index.js`, so the daemon returns on any rebuild of `dist/`. It came back mid-run, held an index snapshot from its own `open()`, made one ordinary write, and saved 1299 vectors over 2433.

A gate that fires once at startup cannot see a writer that arrives at minute three.

## Change

Re-probe every `writerCheckIntervalMs` (default 10s) and abort on detection, reporting `competing_writer:` and telling the operator plainly that the vectors written so far are **not** safe — the other process will overwrite them on its next save. The state file makes the re-run resumable, so nothing is re-embedded.

Checked **inline rather than on a `setInterval`**: a timer is a macrotask, and a run whose embedder resolves immediately finishes every entry without the event loop ever reaching it. The first version of this fix had exactly that bug and its own test caught it.

A probe that throws is treated as "no evidence" and does not abort — failing a long backfill on a flaky `launchctl` is worse than the risk it guards.

Operator instructions corrected throughout: `bootout` alone does not hold because `KeepAlive` relaunches the job. Must `launchctl disable` first and confirm port 8180 is clear.

## Verified end to end, not just by stub

The competing-writer test injects a stubbed probe — which proves the abort logic and proves nothing about whether `launchctl` parsing works. So the launchd label became configurable (`KMS_DAEMON_LABEL`, defaulting to the production value) and the guard was exercised against a **real throwaway launchd job**:

- startup gate passed with the job unloaded
- job bootstrapped mid-run via real `launchctl`
- run aborted at 50.6s with `competing_writer: launchd daemon com.ryaker.e2e-writer-probe reappeared mid-run`
- exit code 1 confirmed separately on the startup-contention path, and the store copy's index was byte-identical afterwards

That E2E also exposed a defect no unit test could: the script reported `Succeeded: 282` while the index grew by **zero bytes** — ground truth showed 3 landed. It counts `addToVectorIndex` not throwing, and that returns `void`. So the original "1721 written" was never 1721. Not fixed here; filed separately as it needs the report to reconcile against measured index state.

Tests 516 → 520.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backfill processing now periodically checks for a competing SparrowDB daemon and safely stops if one is detected.
  * Completed work is saved with a clear warning when processing is interrupted.
  * Added configurable writer-check intervals and daemon identification.

* **Bug Fixes**
  * Improved cross-process writer coordination to prevent conflicting backfill operations.

* **Tests**
  * Added coverage for daemon reappearance, normal completion, probe errors, and disabled periodic checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->