### PR TITLE
fix(storage): classify vector-write failures instead of blaming sidecar-orphans

### DIFF
--- a/src/__tests__/embeddingWriteError.test.ts
+++ b/src/__tests__/embeddingWriteError.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Pins the failure classification for vector-index writes.
+ *
+ * The behaviour under test is not cosmetic. Before this existed, storeEmbedding
+ * logged every exception at debug and blamed "likely sidecar-orphan". After
+ * SparrowDB #442, a stale handle's write is refused permanently until the process
+ * restarts — so that handler would have hidden a total, ongoing write stoppage
+ * behind a debug line attributing it to the wrong cause.
+ */
+
+import { classifyEmbeddingWriteError, lostUpdateMessage } from '../storage/embeddingWriteError.js'
+
+describe('classifyEmbeddingWriteError', () => {
+  it('classifies #442\'s generation-conflict refusal as a lost update', () => {
+    expect(classifyEmbeddingWriteError(
+      'HNSW save failed: HNSW index generation conflict: on-disk 7, handle 6',
+    )).toBe('lost-update')
+  })
+
+  it('classifies the ENOENT temp-collision variant as the SAME lost update', () => {
+    // #442's temp path is a deterministic `<path>.tmp` with no pid, so two
+    // concurrent writers collide and the loser's rename fails with ENOENT.
+    // Same data loss, different text — and it does NOT match SparrowDB's own
+    // is_lost_update(), which only matches the generation-conflict prefix.
+    expect(classifyEmbeddingWriteError(
+      'HNSW save failed: No such file or directory (os error 2)',
+    )).toBe('lost-update')
+  })
+
+  it('keeps the benign missing-node case separate', () => {
+    for (const m of ['node not found for id x', 'no node with id=abc', '0 rows matched']) {
+      expect(classifyEmbeddingWriteError(m)).toBe('sidecar-orphan')
+    }
+  })
+
+  it('defaults to unclassified rather than to benign', () => {
+    // The whole point: an unrecognised failure must not inherit the quiet path.
+    expect(classifyEmbeddingWriteError('some entirely novel engine failure')).toBe('unclassified')
+    expect(classifyEmbeddingWriteError('')).toBe('unclassified')
+  })
+
+  it('does not mistake an unrelated message merely containing "conflict"', () => {
+    expect(classifyEmbeddingWriteError('merge conflict in user data')).toBe('unclassified')
+  })
+})
+
+describe('lostUpdateMessage', () => {
+  it('states that the failure is permanent and names the remedy', () => {
+    // An operator reading one line must learn that embeddings are not being
+    // indexed and that only a restart clears it. Anything vaguer gets ignored.
+    const text = lostUpdateMessage('entry-1', 'HNSW index generation conflict')
+    expect(text).toMatch(/PERMANENT/)
+    expect(text).toMatch(/restart/i)
+    expect(text).toMatch(/NOT being\s+indexed/)
+    expect(text).toContain('entry-1')
+  })
+})

--- a/src/storage/SparrowDBStorage.ts
+++ b/src/storage/SparrowDBStorage.ts
@@ -69,6 +69,7 @@
 
 import { createRequire } from 'module'
 import { logger } from '../logger.js'
+import { classifyEmbeddingWriteError, lostUpdateMessage } from './embeddingWriteError.js'
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
 import { homedir } from 'os'
 import { join, dirname } from 'path'
@@ -536,13 +537,19 @@ export class SparrowDBStorage implements StorageSystem {
         { emb: Array.from(embedding) }
       )
     } catch (e) {
-      // The most common failure is "node not found" — happens for the ~185
-      // sidecar-orphan entries that exist in the JSON sidecar but never got
-      // a graph node (pre-cutover legacy). Logged at debug, not warn.
-      logger.debug(
-        `storeEmbedding: graph SET failed for ${id} (likely sidecar-orphan): ` +
-        `${e instanceof Error ? e.message : String(e)}`
-      )
+      const msg = e instanceof Error ? e.message : String(e)
+      // Default LOUD, downgrade only what is known benign. See
+      // ./embeddingWriteError.ts for why this stopped being a debug-level concern.
+      switch (classifyEmbeddingWriteError(msg)) {
+        case 'lost-update':
+          logger.error(lostUpdateMessage(id, msg))
+          break
+        case 'sidecar-orphan':
+          logger.debug(`storeEmbedding: no graph node for ${id} (sidecar-orphan): ${msg}`)
+          break
+        default:
+          logger.warn(`storeEmbedding: graph SET failed for ${id} (unclassified): ${msg}`)
+      }
       return false
     }
 

--- a/src/storage/embeddingWriteError.ts
+++ b/src/storage/embeddingWriteError.ts
@@ -1,0 +1,72 @@
+/**
+ * Classification of failures from the vector-index write path.
+ *
+ * Extracted into its own module for two reasons. It is the kind of logic that
+ * must not regress silently, and `SparrowDBStorage.ts` uses `import.meta.url`,
+ * which Jest's CommonJS transform cannot load — so nothing in that file has ever
+ * been unit-testable. Keeping this pure and dependency-free makes it so.
+ *
+ * WHY IT EXISTS AT ALL. `storeEmbedding` used to catch every exception, log it at
+ * debug, and attribute it to "likely sidecar-orphan". Reasonable when the only
+ * realistic failure was a missing graph node.
+ *
+ * SparrowDB #442 invalidated that. A stale handle's vector write is now REFUSED
+ * with "HNSW index generation conflict", and because `load_vector_indexes` runs
+ * only inside `GraphDb::open()` with no in-process refresh, the refusal is
+ * permanent until the process restarts. Our daemon is long-lived under launchd,
+ * so the first time any other process writes the index, every subsequent
+ * embedding write fails forever — and the old handler made that invisible.
+ *
+ * #442 exists to turn silent data loss into a loud, catchable refusal. Swallowing
+ * it one layer up is worse than the bug it replaced: silent TOTAL write stoppage
+ * rather than silent partial loss.
+ */
+
+export type EmbeddingWriteFailure =
+  /** Stale handle — the index was written by another process. Permanent until restart. */
+  | 'lost-update'
+  /** No graph node for this id. Expected for pre-cutover sidecar orphans. */
+  | 'sidecar-orphan'
+  /** Unrecognised. Treated as suspicious on purpose. */
+  | 'unclassified'
+
+/**
+ * Classify a vector-index write failure by its message.
+ *
+ * Defaults to `unclassified` rather than to the benign case. An unknown failure
+ * mode being invisible is precisely how the generation-conflict problem would
+ * have survived unnoticed.
+ */
+export function classifyEmbeddingWriteError(message: string): EmbeddingWriteFailure {
+  // Two distinct texts, one meaning. "generation conflict" is #442's own refusal.
+  // The ENOENT variant is the same lost update wearing different clothes: #442's
+  // temp path is a deterministic `<path>.tmp` with no pid, so two concurrent
+  // writers collide and the loser's rename fails with "No such file or
+  // directory". Notably that one does NOT match SparrowDB's own is_lost_update()
+  // helper, which string-matches the generation-conflict prefix — so a caller
+  // relying on the upstream helper alone would misread it as a disk fault.
+  if (/generation conflict|no such file or directory|os error 2/i.test(message)) {
+    return 'lost-update'
+  }
+
+  // ~185 sidecar entries exist in the JSON sidecar but never got a graph node
+  // (pre-cutover legacy), so the MATCH finds nothing. High volume and expected;
+  // promoting these would bury the failures that matter.
+  if (/not found|no node|0 rows|does not exist/i.test(message)) {
+    return 'sidecar-orphan'
+  }
+
+  return 'unclassified'
+}
+
+/** Operator-facing text for a lost-update refusal. Must state that it is permanent. */
+export function lostUpdateMessage(id: string, detail: string): string {
+  return (
+    `storeEmbedding: VECTOR INDEX WRITES ARE FAILING for ${id}: ${detail}\n` +
+    `  This process's HNSW handle is stale — another process wrote the index.\n` +
+    `  The refusal is PERMANENT for this process: SparrowDB loads the index only\n` +
+    `  at open() and exposes no refresh. Every further embedding write will fail\n` +
+    `  until this daemon is restarted. Embeddings are NOT being indexed; semantic\n` +
+    `  dedup and vector retrieval are degraded until then.`
+  )
+}


### PR DESCRIPTION
## What was wrong

`storeEmbedding` caught **every** exception, logged it at `debug`, and attributed it to "likely sidecar-orphan":

```ts
} catch (e) {
  logger.debug(`storeEmbedding: graph SET failed for ${id} (likely sidecar-orphan): ...`)
  return false
}
```

Defensible when the only realistic failure was a missing graph node. SparrowDB #442 invalidated it.

A stale handle's vector write is now **refused** with `HNSW index generation conflict` — and because `load_vector_indexes` runs only inside `GraphDb::open()` with no in-process refresh, **that refusal is permanent until the process restarts.** Our daemon is long-lived under launchd, so the first time any other process writes the index — a backfill, a health check, an ad-hoc script — every subsequent embedding write fails forever.

The old handler rendered that invisible: debug level, wrong cause, no signal above debug anywhere. #442 exists to turn silent data loss into a loud refusal; we were undoing it one layer up. That is **worse** than the bug it replaced — silent *total* write stoppage instead of silent partial loss.

Found by adversarial review of the merged SparrowDB PRs, demonstrated with two independent handles: handle A is fenced out, fails identically forever, and a fresh `open()` works immediately.

## Change

Default **loud**, downgrade only what is known benign.

| failure | level | why |
|---|---|---|
| generation conflict / ENOENT | `error` | names the cause, that it is permanent, and that restart is the remedy |
| missing graph node | `debug` | ~185 sidecar orphans; high-volume and genuinely uninteresting |
| anything else | `warn` | an unknown failure mode being invisible is how this one would have survived |

The ENOENT case is classified as the same lost update deliberately. #442's temp path is a deterministic `<path>.tmp` with no pid, so two concurrent writers collide and the loser's rename fails with "No such file or directory" — same data loss, different text, and it does **not** match SparrowDB's own `is_lost_update()` helper, which string-matches the generation-conflict prefix. A consumer trusting the upstream helper alone reads it as a disk fault.

Logic lives in a new dependency-free module because `SparrowDBStorage.ts` uses `import.meta.url`, which Jest's CommonJS transform cannot load — nothing in that file has ever been unit-testable.

## Verified both ways, because either alone would have lied

Six unit tests on the classifier — and separately a wiring check through the **real compiled** `storeEmbedding`, confirming all four cases reach the right log level and leak to no other.

That second check mattered: it first came back **0/4** and I nearly reported the code broken. The harness was wrong — `vectorIndexAvailable` was unset on a bare prototype, so the method returned before reaching the `try`. Corrected, 4/4. The unit tests passing told me nothing about whether anything called the classifier.

Tests 520 → 526.