### PR TITLE
feat(storage): measure vector-index health instead of assuming it

### DIFF
--- a/src/__tests__/vectorIndexHealth.test.ts
+++ b/src/__tests__/vectorIndexHealth.test.ts
@@ -116,3 +116,36 @@ describe('probeVectorIndex — never throws, never launders silence into health'
     }
   })
 })
+
+describe('coverage signal — SparrowDB signal 4', () => {
+  it('flags an index that is internally healthy but holds a fraction of the corpus', () => {
+    // The "Succeeded: 282, actually 3" state. Invisible to every index-derived
+    // signal, because the index IS healthy — it simply never received the data.
+    const r = probeVectorIndex(withHealth(300, 300), 'Knowledge', 'embedding', 2600)
+    expect(r.status).toBe('degraded')
+    expect(r.alert).toMatch(/COVERAGE LOW/)
+    // Must name the trap, or the next person trusts the writer's own count again.
+    expect(r.alert).toMatch(/returns void/)
+  })
+
+  it('falls back to reachable when stored is unavailable, so it works on the binding we run', () => {
+    // Without this the signal would be permanently null in production — present
+    // in code, absent in reality. reachable <= stored, so it can only over-report.
+    const db = { vectorSearch: () => new Array(1306).fill(0) }
+    const r = probeVectorIndex(db, 'Knowledge', 'embedding', 2595)
+    expect(r.status).toBe('degraded')          // 50% — the actual incident state
+    expect(r.coverage).toBeCloseTo(1306 / 2595, 3)
+  })
+
+  it('stays ok at realistic imperfect coverage', () => {
+    // ~185 sidecar orphans have no graph node; some entries are too short to embed.
+    const r = probeVectorIndex(withHealth(2439, 2439), 'Knowledge', 'embedding', 2606)
+    expect(r.status).toBe('ok')
+  })
+
+  it('never fabricates coverage when the corpus count is unknown', () => {
+    const r = probeVectorIndex(withHealth(2439, 2439), 'Knowledge', 'embedding', null)
+    expect(r.coverage).toBeNull()
+    expect(r.status).toBe('ok')
+  })
+})

--- a/src/__tests__/vectorIndexHealth.test.ts
+++ b/src/__tests__/vectorIndexHealth.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Pins the vector-index health probe.
+ *
+ * The case that matters most is MISSING. SparrowDB #451: a damaged index is
+ * quarantined on the first open(), after which the file is absent, the next
+ * open() succeeds, and the store looks perfectly healthy while silently
+ * discarding every embedding write. Our daemon restarts on any rebuild of dist/,
+ * so it would pass through that sequence unattended.
+ *
+ * A probe that returns "ok" or "unknown" in that state is worse than no probe,
+ * because it launders silence into reassurance.
+ */
+
+import {
+  probeVectorIndex,
+  UNREACHABLE_ALERT_FRACTION,
+  type VectorIndexProbeTarget,
+} from '../storage/vectorIndexHealth.js'
+
+const withHealth = (stored: number, reachable: number): VectorIndexProbeTarget => ({
+  vectorIndexHealth: () => ({ stored, reachable, unreachable: stored - reachable }),
+})
+
+describe('probeVectorIndex — precise path (vectorIndexHealth available)', () => {
+  it('reports ok on a healthy index', () => {
+    const r = probeVectorIndex(withHealth(2494, 2494), 'Knowledge', 'embedding')
+    expect(r.status).toBe('ok')
+    expect(r.precise).toBe(true)
+    expect(r.alert).toBeUndefined()
+  })
+
+  it('tolerates a small unreachable set instead of crying wolf', () => {
+    // Our live store sat at 56/2494 (2.2%) while functioning, and SparrowDB #448
+    // is still open. Alerting at zero would get muted, which is worse than silence.
+    const r = probeVectorIndex(withHealth(2494, 2438), 'Knowledge', 'embedding')
+    expect(r.status).toBe('ok')
+    expect(r.unreachable).toBe(56)
+  })
+
+  it('reports degraded once unreachable passes the threshold', () => {
+    const stored = 1000
+    const unreachable = Math.ceil(stored * UNREACHABLE_ALERT_FRACTION) + 1
+    const r = probeVectorIndex(withHealth(stored, stored - unreachable), 'Knowledge', 'embedding')
+    expect(r.status).toBe('degraded')
+    expect(r.alert).toMatch(/DEGRADED/)
+    // The alert has to say what to do, and the constraint that makes it fail.
+    expect(r.alert).toMatch(/repairVectorIndex/)
+    expect(r.alert).toMatch(/sole writer/)
+  })
+
+  it('treats stored=0 as MISSING, not as an empty-but-healthy index', () => {
+    const r = probeVectorIndex(withHealth(0, 0), 'Knowledge', 'embedding')
+    expect(r.status).toBe('missing')
+    expect(r.alert).toMatch(/IS MISSING/)
+    expect(r.alert).toMatch(/#451/)
+  })
+
+  it('maps SparrowDB\'s "no vector index" throw to MISSING', () => {
+    const db: VectorIndexProbeTarget = {
+      vectorIndexHealth: () => { throw new Error('no vector index on (Knowledge, embedding); call createVectorIndex first') },
+    }
+    const r = probeVectorIndex(db, 'Knowledge', 'embedding')
+    expect(r.status).toBe('missing')
+    expect(r.alert).toMatch(/silently dropped/)
+  })
+
+  it('reports unknown — never ok — when the probe itself fails', () => {
+    const db: VectorIndexProbeTarget = {
+      vectorIndexHealth: () => { throw new Error('lock poisoned') },
+    }
+    expect(probeVectorIndex(db, 'Knowledge', 'embedding').status).toBe('unknown')
+  })
+})
+
+describe('probeVectorIndex — fallback path (old binding, no vectorIndexHealth)', () => {
+  // The binding we run today predates vectorIndexHealth, and we are deliberately
+  // not upgrading yet. The fallback must still catch the missing-index case.
+  it('derives reachability from vectorSearch and marks itself imprecise', () => {
+    const db: VectorIndexProbeTarget = { vectorSearch: () => new Array(2438).fill(0) }
+    const r = probeVectorIndex(db, 'Knowledge', 'embedding')
+    expect(r.status).toBe('ok')
+    expect(r.reachable).toBe(2438)
+    expect(r.precise).toBe(false)
+    expect(r.stored).toBeNull()      // cannot know; must not guess
+    expect(r.unreachable).toBeNull()
+  })
+
+  it('still catches MISSING when search returns nothing', () => {
+    const db: VectorIndexProbeTarget = { vectorSearch: () => [] }
+    expect(probeVectorIndex(db, 'Knowledge', 'embedding').status).toBe('missing')
+  })
+
+  it('still catches MISSING when search throws "no vector index"', () => {
+    const db: VectorIndexProbeTarget = {
+      vectorSearch: () => { throw new Error('no vector index on (Knowledge, embedding)') },
+    }
+    expect(probeVectorIndex(db, 'Knowledge', 'embedding').status).toBe('missing')
+  })
+})
+
+describe('probeVectorIndex — never throws, never launders silence into health', () => {
+  it('handles a null handle', () => {
+    expect(probeVectorIndex(null, 'Knowledge', 'embedding').status).toBe('unknown')
+  })
+
+  it('handles a binding exposing neither method', () => {
+    const r = probeVectorIndex({}, 'Knowledge', 'embedding')
+    expect(r.status).toBe('unknown')
+    expect(r.alert).toMatch(/neither vectorIndexHealth nor vectorSearch/)
+  })
+
+  it('never reports ok without evidence', () => {
+    // The whole point: an unusable probe must not look like a passing one.
+    for (const db of [null, undefined, {} as VectorIndexProbeTarget]) {
+      expect(probeVectorIndex(db, 'Knowledge', 'embedding').status).not.toBe('ok')
+    }
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1027,6 +1027,27 @@ export class UnifiedKMSServer {
     // neo4j fallback, shadow) is reported via storage.<impl>.name when needed.
     const graphKey = 'graph'
 
+    // Vector-index health. Not part of the original analytics because nothing
+    // ever measured it — which is how ~1150 vectors were lost on 2026-08-01
+    // without anyone noticing. Reported unconditionally so a MISSING index shows
+    // up on any analytics call rather than only when someone goes looking.
+    let vectorIndex: unknown = { status: 'unknown', reason: 'graph backend exposes no probe' }
+    try {
+      const graph = this.storage.graph as any
+      if (typeof graph?.getVectorIndexHealth === 'function') {
+        const report = graph.getVectorIndexHealth()
+        vectorIndex = report
+        // Escalate rather than bury. A degraded or missing index is silent by
+        // nature: writes keep returning success and searches just come back thin.
+        if (report.status === 'missing') console.error(`🚨 ${report.alert}`)
+        else if (report.status === 'degraded') console.warn(`⚠️  ${report.alert}`)
+        else if (report.status === 'unknown' && report.alert) console.warn(`⚠️  ${report.alert}`)
+      }
+    } catch (e) {
+      // A monitoring probe must never break the thing it monitors.
+      vectorIndex = { status: 'unknown', reason: e instanceof Error ? e.message : String(e) }
+    }
+
     const analytics = {
       timestamp: new Date().toISOString(),
       cache: cacheStats.status === 'fulfilled' ? cacheStats.value : { error: cacheStats.reason },
@@ -1035,6 +1056,7 @@ export class UnifiedKMSServer {
         [graphKey]: graphStats.status === 'fulfilled' ? graphStats.value : { error: graphStats.reason },
         mem0: mem0Stats.status === 'fulfilled' ? mem0Stats.value : { error: mem0Stats.reason }
       },
+      vectorIndex,
       routing: this.tools.store.getRoutingStats(),
       overall: {
         systemsHealthy: [mongoStats, graphStats, mem0Stats].filter(s => s.status === 'fulfilled').length,

--- a/src/storage/SparrowDBStorage.ts
+++ b/src/storage/SparrowDBStorage.ts
@@ -295,10 +295,26 @@ export class SparrowDBStorage implements StorageSystem {
    * so it cannot quarantine the index it is measuring. Verified by execution.
    */
   getVectorIndexHealth(): VectorIndexHealthReport {
+    // Count the nodes that SHOULD carry a vector, from the GRAPH not the index.
+    // This is the only signal that catches embeddings which never reached the
+    // index at all — every other signal is index-derived, so an index that simply
+    // never received the data looks perfectly healthy to all of them.
+    let expected: number | null = null
+    try {
+      const rows = (this.db as any).execute(
+        `MATCH (k:${SparrowDBStorage.VECTOR_LABEL}) RETURN count(k)`
+      )?.rows
+      const v = rows?.[0] && Object.values(rows[0])[0]
+      if (typeof v === 'number') expected = v
+    } catch {
+      // Corpus count is best-effort; its absence must not break the probe.
+    }
+
     return probeVectorIndex(
       this.db as any,
       SparrowDBStorage.VECTOR_LABEL,
       SparrowDBStorage.VECTOR_PROPERTY,
+      expected,
     )
   }
 

--- a/src/storage/SparrowDBStorage.ts
+++ b/src/storage/SparrowDBStorage.ts
@@ -69,6 +69,8 @@
 
 import { createRequire } from 'module'
 import { logger } from '../logger.js'
+import { probeVectorIndex } from './vectorIndexHealth.js'
+import type { VectorIndexHealthReport } from './vectorIndexHealth.js'
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
 import { homedir } from 'os'
 import { join, dirname } from 'path'
@@ -277,6 +279,26 @@ export class SparrowDBStorage implements StorageSystem {
     logger.debug(
       `✅ SparrowDB opened — ${this.contentIndex.size} content entries in sidecar, ` +
       `vectorIndex=${this.vectorIndexAvailable ? 'ready' : 'unavailable'}`
+    )
+  }
+
+  /**
+   * Report whether the HNSW vector index is actually usable.
+   *
+   * Nothing measured this before; the 2026-08-01 loss of ~1150 vectors went
+   * unnoticed until a retrieval investigation stumbled on it, and the repair that
+   * followed was a manual one-off. See ./vectorIndexHealth.ts for why the MISSING
+   * case is treated as critical rather than as "no data".
+   *
+   * Safe against the live store: on bindings that expose it, vectorIndexHealth()
+   * routes through get_vector_index(), a pure in-memory RwLock read with zero I/O,
+   * so it cannot quarantine the index it is measuring. Verified by execution.
+   */
+  getVectorIndexHealth(): VectorIndexHealthReport {
+    return probeVectorIndex(
+      this.db as any,
+      SparrowDBStorage.VECTOR_LABEL,
+      SparrowDBStorage.VECTOR_PROPERTY,
     )
   }
 

--- a/src/storage/vectorIndexHealth.ts
+++ b/src/storage/vectorIndexHealth.ts
@@ -1,0 +1,170 @@
+/**
+ * Vector-index health probe.
+ *
+ * WHY THIS EXISTS. On 2026-08-01 KMS lost ~1150 embedding vectors and nobody
+ * noticed until a retrieval investigation went looking. Nothing in this codebase
+ * has ever measured whether the HNSW index is actually usable — the one repair we
+ * ran (56 unreachable -> 0) was a manual one-off, so any regression accumulates
+ * silently and indefinitely.
+ *
+ * It became urgent with SparrowDB #451, a residual hole that survives all four of
+ * their merged fixes:
+ *
+ *   1. index becomes damaged
+ *   2. FIRST open() -> loud Err(Corruption), bytes quarantined to .corrupt.<millis>
+ *   3. SECOND open() -> the .bin no longer exists, so this is now the ABSENT case.
+ *      open() SUCCEEDS with no index registered.
+ *   4. every vector write is silently dropped, every search returns nothing
+ *
+ * Our daemon runs under launchd with KeepAlive=true and `node --watch dist/index.js`,
+ * so it restarts on any rebuild. It would hit step 2 once, log a crash, relaunch,
+ * and sail straight into step 3 — a healthy-looking store quietly discarding every
+ * embedding. Same loss as the original incident, reached by a different route.
+ *
+ * SparrowDB's own guidance: until #451 lands, a periodic health check is the only
+ * thing standing between a quarantine event and unbounded silent loss. Step 3 is
+ * the dangerous one precisely because the store looks perfectly healthy by every
+ * other measure — which is why MISSING is treated as critical here, not as "no
+ * data". An absent index is indistinguishable from a healthy one unless you are
+ * specifically looking for it.
+ *
+ * DEGRADES BY DESIGN. `vectorIndexHealth()` only exists in SparrowDB >= 1d5cec1,
+ * and we are deliberately NOT on that build yet (four unfixed criticals live on
+ * their main). So this feature-detects and falls back to a reachability count
+ * derived from vectorSearch, which works on the binding we run today. The
+ * fallback cannot see `stored`, so it cannot compute unreachable — but it CAN
+ * still detect the missing-index case, which is the one that matters most.
+ */
+
+/** What the probe could determine. Ordered by severity, worst first. */
+export type VectorIndexStatus =
+  /** No index registered for (label, prop). SparrowDB #451 step 3 — writes are being dropped. */
+  | 'missing'
+  /** Index present, but a meaningful share of stored vectors are unreachable. */
+  | 'degraded'
+  /** Index present and healthy. */
+  | 'ok'
+  /** Binding too old, or the probe itself failed. Absence of evidence, not evidence of health. */
+  | 'unknown'
+
+export interface VectorIndexHealthReport {
+  status: VectorIndexStatus
+  /** Vectors the index holds. Null when only the fallback probe was available. */
+  stored: number | null
+  /** Vectors greedy search can actually reach. */
+  reachable: number | null
+  /** stored - reachable. Null unless the full accessor was available. */
+  unreachable: number | null
+  /** True when the numbers came from vectorIndexHealth() rather than the fallback. */
+  precise: boolean
+  /** Present when status is not 'ok'. Written for a human reading one line at 3am. */
+  alert?: string
+}
+
+/** Minimal surface this probe needs. Everything optional — old bindings lack most of it. */
+export interface VectorIndexProbeTarget {
+  vectorIndexHealth?(label: string, property: string): { stored: number; reachable: number; unreachable: number }
+  vectorSearch?(label: string, property: string, query: Float32Array, k: number): unknown[]
+}
+
+/**
+ * Fraction of stored vectors allowed to be unreachable before reporting 'degraded'.
+ *
+ * 0.05 rather than 0. A small unreachable set is a known, tolerated property of
+ * this HNSW implementation — SparrowDB #443's reciprocal-link fix reduces it but
+ * #448 is still open, and our own store sat at 56/2494 (2.2%) while functioning.
+ * Alerting at zero would cry wolf permanently and get muted, which is worse than
+ * not alerting at all.
+ */
+export const UNREACHABLE_ALERT_FRACTION = 0.05
+
+const PROBE_DIMENSIONS = 768
+const PROBE_TOP_K = 100_000
+
+/**
+ * Probe one (label, property) vector index.
+ *
+ * Never throws: a monitoring probe that can take down its caller is worse than no
+ * probe. Every failure path resolves to a report, and an unusable probe reports
+ * 'unknown' rather than 'ok' — silence must never be mistaken for health.
+ */
+export function probeVectorIndex(
+  db: VectorIndexProbeTarget | null | undefined,
+  label: string,
+  property: string,
+): VectorIndexHealthReport {
+  if (!db) {
+    return { status: 'unknown', stored: null, reachable: null, unreachable: null, precise: false,
+      alert: 'vector index probe skipped: no graph handle' }
+  }
+
+  // Preferred path — SparrowDB >= 1d5cec1. Verified safe against a live store:
+  // it routes through get_vector_index(), a pure RwLock read with zero I/O, so it
+  // cannot quarantine or otherwise mutate the index it is measuring.
+  if (typeof db.vectorIndexHealth === 'function') {
+    try {
+      const h = db.vectorIndexHealth(label, property)
+      const { stored, reachable } = h
+      const unreachable = h.unreachable ?? stored - reachable
+      if (stored === 0) {
+        return { status: 'missing', stored, reachable, unreachable, precise: true,
+          alert: missingAlert(label, property) }
+      }
+      if (unreachable / stored > UNREACHABLE_ALERT_FRACTION) {
+        return { status: 'degraded', stored, reachable, unreachable, precise: true,
+          alert:
+            `vector index (${label}, ${property}) DEGRADED: ${unreachable} of ${stored} vectors ` +
+            `(${((unreachable / stored) * 100).toFixed(1)}%) are stored but unreachable by search. ` +
+            `Run repairVectorIndex('${label}','${property}') with the daemon stopped — it must be ` +
+            `the sole writer, or SparrowDB's generation check will refuse its save.` }
+      }
+      return { status: 'ok', stored, reachable, unreachable, precise: true }
+    } catch (e) {
+      // SparrowDB throws "no vector index on (L, p); call createVectorIndex first"
+      // when nothing is registered — which is exactly #451 step 3.
+      const msg = e instanceof Error ? e.message : String(e)
+      if (/no vector index/i.test(msg)) {
+        return { status: 'missing', stored: 0, reachable: 0, unreachable: 0, precise: true,
+          alert: missingAlert(label, property) }
+      }
+      return { status: 'unknown', stored: null, reachable: null, unreachable: null, precise: false,
+        alert: `vector index probe failed for (${label}, ${property}): ${msg}` }
+    }
+  }
+
+  // Fallback for the binding we actually run today. It cannot see `stored`, so it
+  // cannot compute unreachable — but it still catches the missing-index case,
+  // which is the one that silently eats writes.
+  if (typeof db.vectorSearch === 'function') {
+    try {
+      const hits = db.vectorSearch(label, property, new Float32Array(PROBE_DIMENSIONS).fill(0.01), PROBE_TOP_K)
+      const reachable = Array.isArray(hits) ? hits.length : 0
+      if (reachable === 0) {
+        return { status: 'missing', stored: null, reachable: 0, unreachable: null, precise: false,
+          alert: missingAlert(label, property) }
+      }
+      return { status: 'ok', stored: null, reachable, unreachable: null, precise: false }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e)
+      if (/no vector index/i.test(msg)) {
+        return { status: 'missing', stored: null, reachable: null, unreachable: null, precise: false,
+          alert: missingAlert(label, property) }
+      }
+      return { status: 'unknown', stored: null, reachable: null, unreachable: null, precise: false,
+        alert: `vector index probe failed for (${label}, ${property}): ${msg}` }
+    }
+  }
+
+  return { status: 'unknown', stored: null, reachable: null, unreachable: null, precise: false,
+    alert: 'vector index probe unavailable: binding exposes neither vectorIndexHealth nor vectorSearch' }
+}
+
+function missingAlert(label: string, property: string): string {
+  return (
+    `vector index (${label}, ${property}) IS MISSING — embedding writes are being silently dropped. ` +
+    `This is SparrowDB #451: a damaged index is quarantined on the first open(), after which the ` +
+    `file is absent, the next open() succeeds, and the store looks healthy while discarding every ` +
+    `vector. Check for hnsw_${label}_${property}.bin.corrupt.* artifacts in the store's ` +
+    `vector_indexes/ directory, then restore or rebuild the index.`
+  )
+}

--- a/src/storage/vectorIndexHealth.ts
+++ b/src/storage/vectorIndexHealth.ts
@@ -49,6 +49,18 @@ export type VectorIndexStatus =
 
 export interface VectorIndexHealthReport {
   status: VectorIndexStatus
+  /**
+   * Nodes that SHOULD carry a vector, counted from the graph rather than the index.
+   *
+   * SparrowDB's signal 4, and the only one that catches writes which never reached
+   * the index at all — the "Succeeded: 282, actually 3" class, where the backfill
+   * reported success because addToVectorIndex returns void. Every other signal is
+   * derived from the index, so an index that simply never received the data looks
+   * perfectly healthy to all of them. Null when the node count is unavailable.
+   */
+  expected?: number | null
+  /** stored / expected. Null unless both are known. */
+  coverage?: number | null
   /** Vectors the index holds. Null when only the fallback probe was available. */
   stored: number | null
   /** Vectors greedy search can actually reach. */
@@ -78,6 +90,15 @@ export interface VectorIndexProbeTarget {
  */
 export const UNREACHABLE_ALERT_FRACTION = 0.05
 
+/**
+ * Minimum stored/expected ratio before reporting 'degraded'.
+ *
+ * 0.80 because coverage is legitimately imperfect — ~185 sidecar orphans have no
+ * graph node, some entries are too short to embed, and a backfill in progress is
+ * transiently low. Below 80% something is systematically not landing.
+ */
+export const COVERAGE_ALERT_FRACTION = 0.80
+
 const PROBE_DIMENSIONS = 768
 const PROBE_TOP_K = 100_000
 
@@ -92,24 +113,62 @@ export function probeVectorIndex(
   db: VectorIndexProbeTarget | null | undefined,
   label: string,
   property: string,
+  /** Nodes that should have a vector. Counted from the graph, not the index. */
+  expected?: number | null,
 ): VectorIndexHealthReport {
-  if (!db) {
-    return { status: 'unknown', stored: null, reachable: null, unreachable: null, precise: false,
-      alert: 'vector index probe skipped: no graph handle' }
-  }
+  const base = rawProbe(db, label, property)
+  const exp = expected ?? null
+  // Prefer `stored`; fall back to `reachable`. On the binding we run today
+  // `stored` is unavailable, and without a fallback the coverage signal would be
+  // permanently null in production — i.e. present in the code and absent in
+  // reality, which is the failure this whole file exists to prevent. `reachable`
+  // is a strictly conservative proxy: it is <= stored, so it can only over-report
+  // a problem, never hide one. It would have caught the actual incident, where
+  // 1306 of 2595 nodes were retrievable.
+  const counted = base.stored ?? base.reachable
+  const coverage = exp && exp > 0 && counted != null ? counted / exp : null
+  const out: VectorIndexHealthReport = { ...base, expected: exp, coverage }
 
-  // Preferred path — SparrowDB >= 1d5cec1. Verified safe against a live store:
-  // it routes through get_vector_index(), a pure RwLock read with zero I/O, so it
+  // Coverage can only downgrade a report, never upgrade one. An index that is
+  // present and internally consistent but holds a fraction of the corpus is the
+  // "Succeeded: 282, actually 3" state — invisible to every index-derived signal,
+  // because the index is perfectly healthy; it simply never received the data.
+  if (out.status === 'ok' && coverage != null && coverage < COVERAGE_ALERT_FRACTION) {
+    out.status = 'degraded'
+    out.alert =
+      `vector index (${label}, ${property}) COVERAGE LOW: ${counted} ` +
+      `${base.stored != null ? 'stored' : 'reachable'} vectors for ${exp} nodes ` +
+      `(${(coverage * 100).toFixed(1)}%). Embeddings are not reaching the index. Note that ` +
+      `addToVectorIndex returns void, so a writer can report success while storing nothing — ` +
+      `always verify against the index, never against the writer's own success count.`
+  }
+  return out
+}
+
+/** The index-derived half of the probe, before coverage is folded in. */
+function rawProbe(
+  db: VectorIndexProbeTarget | null | undefined,
+  label: string,
+  property: string,
+): VectorIndexHealthReport {
+  const unknown = (alert: string): VectorIndexHealthReport =>
+    ({ status: 'unknown', stored: null, reachable: null, unreachable: null, precise: false, alert })
+  const missing = (stored: number | null, precise: boolean): VectorIndexHealthReport =>
+    ({ status: 'missing', stored, reachable: stored === null ? null : 0, unreachable: null,
+       precise, alert: missingAlert(label, property) })
+
+  if (!db) return unknown('vector index probe skipped: no graph handle')
+
+  // Preferred path — SparrowDB >= 1d5cec1. Verified safe against a live store: it
+  // routes through get_vector_index(), a pure RwLock read with zero I/O, so it
   // cannot quarantine or otherwise mutate the index it is measuring.
   if (typeof db.vectorIndexHealth === 'function') {
     try {
       const h = db.vectorIndexHealth(label, property)
-      const { stored, reachable } = h
+      const stored = h.stored
+      const reachable = h.reachable
       const unreachable = h.unreachable ?? stored - reachable
-      if (stored === 0) {
-        return { status: 'missing', stored, reachable, unreachable, precise: true,
-          alert: missingAlert(label, property) }
-      }
+      if (stored === 0) return missing(0, true)
       if (unreachable / stored > UNREACHABLE_ALERT_FRACTION) {
         return { status: 'degraded', stored, reachable, unreachable, precise: true,
           alert:
@@ -120,43 +179,31 @@ export function probeVectorIndex(
       }
       return { status: 'ok', stored, reachable, unreachable, precise: true }
     } catch (e) {
-      // SparrowDB throws "no vector index on (L, p); call createVectorIndex first"
-      // when nothing is registered — which is exactly #451 step 3.
       const msg = e instanceof Error ? e.message : String(e)
-      if (/no vector index/i.test(msg)) {
-        return { status: 'missing', stored: 0, reachable: 0, unreachable: 0, precise: true,
-          alert: missingAlert(label, property) }
-      }
-      return { status: 'unknown', stored: null, reachable: null, unreachable: null, precise: false,
-        alert: `vector index probe failed for (${label}, ${property}): ${msg}` }
+      // SparrowDB throws "no vector index on (L, p); call createVectorIndex first"
+      // when nothing is registered — exactly #451 step 3.
+      if (/no vector index/i.test(msg)) return missing(0, true)
+      return unknown(`vector index probe failed for (${label}, ${property}): ${msg}`)
     }
   }
 
-  // Fallback for the binding we actually run today. It cannot see `stored`, so it
-  // cannot compute unreachable — but it still catches the missing-index case,
+  // Fallback for the binding we run today. It cannot see `stored`, so it cannot
+  // compute unreachable or coverage — but it still catches the missing case,
   // which is the one that silently eats writes.
   if (typeof db.vectorSearch === 'function') {
     try {
       const hits = db.vectorSearch(label, property, new Float32Array(PROBE_DIMENSIONS).fill(0.01), PROBE_TOP_K)
       const reachable = Array.isArray(hits) ? hits.length : 0
-      if (reachable === 0) {
-        return { status: 'missing', stored: null, reachable: 0, unreachable: null, precise: false,
-          alert: missingAlert(label, property) }
-      }
+      if (reachable === 0) return missing(null, false)
       return { status: 'ok', stored: null, reachable, unreachable: null, precise: false }
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e)
-      if (/no vector index/i.test(msg)) {
-        return { status: 'missing', stored: null, reachable: null, unreachable: null, precise: false,
-          alert: missingAlert(label, property) }
-      }
-      return { status: 'unknown', stored: null, reachable: null, unreachable: null, precise: false,
-        alert: `vector index probe failed for (${label}, ${property}): ${msg}` }
+      if (/no vector index/i.test(msg)) return missing(null, false)
+      return unknown(`vector index probe failed for (${label}, ${property}): ${msg}`)
     }
   }
 
-  return { status: 'unknown', stored: null, reachable: null, unreachable: null, precise: false,
-    alert: 'vector index probe unavailable: binding exposes neither vectorIndexHealth nor vectorSearch' }
+  return unknown('vector index probe unavailable: binding exposes neither vectorIndexHealth nor vectorSearch')
 }
 
 function missingAlert(label: string, property: string): string {


### PR DESCRIPTION
## The gap

Nothing in this codebase has ever checked whether the HNSW index is usable. That is how ~1150 embedding vectors were lost on 2026-08-01 without anyone noticing, and the repair that followed (56 unreachable → 0) was a manual one-off — so any regression since would have accumulated silently and indefinitely.

It became urgent with **SparrowDB #451**, a hole that survives all four of their merged fixes:

1. index becomes damaged
2. **first** `open()` → loud `Err(Corruption)`, bytes quarantined to `.corrupt.<millis>`
3. **second** `open()` → the `.bin` is gone, so this is now the *absent* case. `open()` succeeds, no index registered.
4. every vector write silently dropped, every search returns nothing

Our daemon runs under launchd with `KeepAlive=true` and `node --watch dist/index.js`, so it restarts on any rebuild. It would hit step 2 once, log a crash, relaunch, and sail straight into step 3 — a healthy-looking store quietly discarding every embedding. Same loss as the original incident, different route.

SparrowDB's own guidance: until #451 lands, a periodic health check is the only thing between a quarantine event and unbounded silent loss.

## Change

`getKMSAnalytics` now reports `{status, stored, reachable, unreachable, precise}` and escalates — `MISSING` to `console.error`, `DEGRADED` to `console.warn` — rather than burying it in a return value nobody reads.

Design decisions that carry the reasoning:

- **`MISSING` is critical, not "no data."** An absent index is indistinguishable from a healthy one unless you look for it specifically. That is precisely what makes #451 step 3 dangerous.
- **An unusable probe reports `unknown`, never `ok`.** Silence must not be laundered into reassurance.
- **Threshold is 5%, not 0.** Our store ran at 2.2% unreachable while functioning fine, and SparrowDB #448 is still open. Alerting at zero gets muted, which is worse than not alerting.
- **Feature-detects.** `vectorIndexHealth()` exists only in SparrowDB ≥ `1d5cec1`, and we are deliberately *not* on that build — four unfixed criticals are live on their main. So it falls back to a reachability count from `vectorSearch`, which works on the binding we run today. The fallback cannot see `stored`, so it returns `null` rather than guessing — but it still catches `MISSING`, the case that eats writes.
- **Never throws.** A monitoring probe that can break its caller is worse than no probe.

## Safe against production

On bindings that expose it, `vectorIndexHealth()` routes through `get_vector_index()` — a pure in-memory `RwLock` read with zero I/O — so it cannot quarantine the index it measures. Verified by execution against a truncated index, not by reading source. This was an open question earlier and is now settled.

## Verified both ways

12 unit tests, plus an end-to-end call to the real `get_kms_analytics` MCP tool against the live store:

```json
{"status":"ok","stored":null,"reachable":2439,"unreachable":null,"precise":false}
```

Correct numbers, correct fallback path for the binding we actually run.

Tests 522 → 534.

## Known limitation

`vector_index_load_failures()` — the accessor that reports quarantine artifacts, and the only way to learn a quarantine *ever happened* given only the first boot errors — **has no napi binding**, so it is unreachable from Node. That is SparrowDB's third recommended alert and it cannot be implemented here yet. Raised with them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added vector-index health monitoring with clear healthy, degraded, missing, and unknown statuses.
  * Analytics now includes vector-index health reports.
  * Added coverage and reachability checks with actionable alerts.
  * Health checks continue safely when index probing or graph counts fail.

* **Tests**
  * Added comprehensive coverage for index statuses, fallback checks, alerts, thresholds, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->