### PR TITLE
test: correct 3 assertions that pinned SparrowDB 0.1.20's fixed bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ bash scripts/build-sparrowdb-node.sh [/path/to/SparrowDB]
 ### Import from Neo4j
 
 ```bash
-SPARROWDB_PATH=~/.kms-sparrowdb \
+SPARROWDB_PATH=~/.kms-sparrowdb-v2 \
 doppler run --project ry-local --config dev_personal -- \
   node scripts/import-neo4j-to-sparrowdb.mjs
 ```
@@ -399,7 +399,7 @@ doppler run --project ry-local --config dev_personal -- \
 ### Start KMS with SparrowDB backend
 
 ```bash
-SPARROWDB_PATH=~/.kms-sparrowdb \
+SPARROWDB_PATH=~/.kms-sparrowdb-v2 \
 KMS_STORAGE_BACKEND=sparrowdb \
 doppler run --project ry-local --config dev_personal -- npm run dev
 ```
@@ -408,7 +408,7 @@ doppler run --project ry-local --config dev_personal -- npm run dev
 
 ```bash
 KMS_SHADOW_MODE=true \
-SPARROWDB_PATH=~/.kms-sparrowdb \
+SPARROWDB_PATH=~/.kms-sparrowdb-v2 \
 doppler run --project ry-local --config dev_personal -- npm run dev
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "mongodb": "^6.0.0",
         "neo4j-driver": "^5.15.0",
         "node-fetch": "^3.3.0",
-        "sparrowdb": "^0.1.20"
+        "sparrowdb": "^0.1.27"
       },
       "bin": {
         "kms": "dist/cli/kms.js"
@@ -140,6 +140,7 @@
       "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
       "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -152,6 +153,7 @@
       "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
       "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-util": "^1.13.0",
@@ -185,6 +187,7 @@
       "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.4.0.tgz",
       "integrity": "sha512-f1P96IB399YiN2ARYHP7EpZi3Bf3wH4SN2lGzrw7JVwm7bbsVYtf2iKSBwTywD2P62NOPZGHFSZi+6jjb75JuA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2"
       },
@@ -201,6 +204,7 @@
       "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.6.2.tgz",
       "integrity": "sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -232,6 +236,7 @@
       "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
       "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -244,6 +249,7 @@
       "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
       "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@typespec/ts-http-runtime": "^0.3.0",
@@ -281,6 +287,7 @@
       "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
       "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typespec/ts-http-runtime": "^0.3.0",
         "tslib": "^2.6.2"
@@ -294,6 +301,7 @@
       "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.9.0.tgz",
       "integrity": "sha512-CzE+4PefDSJWj26zU7G1bKchlGRRHMBFreG4tAlGuzyI8hAPiYGobaJvZBgZBf6L63iphX7VH+ityL8VgEQz9Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@azure/msal-common": "16.5.2"
       },
@@ -306,6 +314,7 @@
       "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.5.2.tgz",
       "integrity": "sha512-GkDEL6TYo3HgT3UuqakdgE9PZfc1hMki6+Hwgy1uddb/EauvAKfu85vVhuofRSo22D1xTnWt8Ucwfg4vSCVwvA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -315,6 +324,7 @@
       "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.5.tgz",
       "integrity": "sha512-ObTeMoNPmq19X3z40et9Xvs4ZoWVeJg43PZMRLG5iwVL+2nCtAerG3YTDItqPp1CfXNwmCXBbg8jn1DOx65c3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@azure/msal-common": "16.5.2",
         "jsonwebtoken": "^9.0.0"
@@ -375,7 +385,6 @@
       "integrity": "sha512-BU2f9tlKQ5CAthiMIgpzAh4eDTLWo1mqi9jqE2OxMG0E/OM199VJt2q8BztTxpnSW0i1ymdwLXRJnYzvDM5r2w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -873,32 +882,6 @@
       "integrity": "sha512-Uz9D2hcwB4/pdnmCU7RsgknY8TQ5st0cQMMN6h/hvWt1TCt99GUkbi6dMgWdP7jXfIfh+S/EI5zQugI9RZn4Bw==",
       "license": "MIT OR Apache-2.0",
       "peer": true
-    },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.5",
@@ -1417,6 +1400,7 @@
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
       "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -1976,6 +1960,7 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.44.tgz",
       "integrity": "sha512-RePW1IjGCHr9ua2vcby3aE8mOOz3EnwDZxMEGbNDT91kf14eqkJqxDXvaZFviGdcN9DTrxM5RPQNAHmwSm4tbg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "@standard-schema/spec": "^1.1.0",
@@ -1997,6 +1982,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2009,6 +1995,7 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2021,6 +2008,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -2156,7 +2144,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2506,31 +2493,36 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
       "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
       "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -2540,31 +2532,36 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
       "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@qdrant/js-client-rest": {
       "version": "1.13.0",
@@ -2590,6 +2587,7 @@
       "resolved": "https://registry.npmjs.org/@qdrant/openapi-typescript-fetch/-/openapi-typescript-fetch-1.2.6.tgz",
       "integrity": "sha512-oQG/FejNpItrxRHoyctYvT3rwGZOnK4jr3JdppO/c78ktDvkWiPXPHNsrDf33K9sZdRb6PR7gi4noIapu5q4HA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0",
         "pnpm": ">=8"
@@ -2600,6 +2598,7 @@
       "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
       "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@redis/client": "^1.0.0"
       }
@@ -2623,13 +2622,15 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/@redis/graph": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
       "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@redis/client": "^1.0.0"
       }
@@ -2639,6 +2640,7 @@
       "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
       "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@redis/client": "^1.0.0"
       }
@@ -2648,6 +2650,7 @@
       "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
       "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@redis/client": "^1.0.0"
       }
@@ -2657,6 +2660,7 @@
       "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
       "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@redis/client": "^1.0.0"
       }
@@ -2665,7 +2669,8 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@sevinf/maybe/-/maybe-0.5.0.tgz",
       "integrity": "sha512-ARhyoYDnY1LES3vYI0fiG6e9esWfTNcXcO6+MPJJXcnyMV3bim4lnFt45VXouV7y82F4x3YH8nOQ6VztuvUiWg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -2697,13 +2702,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.105.3",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.105.3.tgz",
       "integrity": "sha512-hMFuzP++mjRfe0/BUq4/e82CXIDgyjUgg0khLN8waol/gzoM1t2iGmhfJSGvQHQ1dr3XqWpP6ThAw4bLHMot5Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "2.8.1"
       },
@@ -2716,6 +2723,7 @@
       "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.105.3.tgz",
       "integrity": "sha512-KyutUwLLUZ9fRXsiFACL6lq7akBVHFl0fnqQnrxjbsPco8jeb4EyirQuvr52QCLnikzjMRC0uxAHOSM54aDrZA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "2.8.1"
       },
@@ -2727,13 +2735,15 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.1.tgz",
       "integrity": "sha512-hWGJkDAfWUNY8k0C080u3sGNFd2ncl9erhKgP7hnGkgJWEfT5Pd/SXal4QmWXBECVlZrannMAc9sBaaRyWpiUA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@supabase/postgrest-js": {
       "version": "2.105.3",
       "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.105.3.tgz",
       "integrity": "sha512-jFVYRHcri0ZMcTzKpQ2r2wWOB8/rPsbj92kxmCmVJUiRrdgiMtuYlkS06Fhs8UJZhEOL0UpGhh06XDwh8JwtBQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "2.8.1"
       },
@@ -2746,6 +2756,7 @@
       "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.105.3.tgz",
       "integrity": "sha512-L+qPiJlq1RKh3QD2fORGCFo2RKDKlvG9mjvPtUEQJ2tMixrx70VIV6j8BdWzQkbc1Nao6mvTWajyDhX3TFgljw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@supabase/phoenix": "^0.4.1",
         "@types/ws": "^8.18.1",
@@ -2761,6 +2772,7 @@
       "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.105.3.tgz",
       "integrity": "sha512-M7oPCCcHim/FsR6rKIs10Nd9mW051N2SQvA27jiVLa7oQMFFb7faX5dCQRV4GS5QeFsBcV5J/fWl4Ppoaw8cBQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "iceberg-js": "^0.8.1",
         "tslib": "2.8.1"
@@ -2785,38 +2797,6 @@
       "engines": {
         "node": ">=20.0.0"
       }
-    },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
-      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2977,7 +2957,6 @@
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
       "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
@@ -3024,7 +3003,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.2.tgz",
       "integrity": "sha512-9pLGGwdzOUBDYi0GNjM97FIA+f92fqSke6joWeBjWXllfNxZBs7qeMF7tvtOIsbY45xkWkxrdwUfUf3MnQa9gA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3067,7 +3045,8 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/semver": {
       "version": "7.7.0",
@@ -3146,6 +3125,7 @@
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -3207,7 +3187,6 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -3369,6 +3348,7 @@
       "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.5.tgz",
       "integrity": "sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.0",
@@ -3416,7 +3396,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3434,25 +3413,12 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/afinn-165": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/afinn-165/-/afinn-165-2.0.2.tgz",
       "integrity": "sha512-mJ/RLUfpXfQA6bzugv+bBsc/QYkVrKaLYeS8fWBpKbTCsonv4iuV9ET0fgReEunm9vKLkaNgnekuSNlTC3WQ1Q==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -3463,6 +3429,7 @@
       "resolved": "https://registry.npmjs.org/afinn-165-financialmarketnews/-/afinn-165-financialmarketnews-3.0.0.tgz",
       "integrity": "sha512-0g9A1S3ZomFIGDTzZ0t6xmv4AuokBvBmpes8htiyHpH7N4xDmvSQL6UxL/Zcs2ypRb3VwgCscaD8Q3zEawKYhw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -3473,6 +3440,7 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -3618,20 +3586,13 @@
       "resolved": "https://registry.npmjs.org/apparatus/-/apparatus-0.0.10.tgz",
       "integrity": "sha512-KLy/ugo33KZA7nugtQ7O0E1c8kQ52N3IvD/XgIh4w/Nr28ypfkwDfA67F1ev4N1m5D+BOk1+b2dEJDfpj/VvZg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "sylvester": ">= 0.0.8"
       },
       "engines": {
         "node": ">=0.2.6"
       }
-    },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -3823,7 +3784,8 @@
     "node_modules/base-64": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
-      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
+      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA==",
+      "peer": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -3851,7 +3813,6 @@
       "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -3865,6 +3826,7 @@
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
       "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -4009,7 +3971,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -4097,6 +4058,7 @@
       "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
       "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -4106,6 +4068,7 @@
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
       "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "run-applescript": "^7.0.0"
       },
@@ -4226,6 +4189,7 @@
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
       "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -4278,6 +4242,7 @@
       "resolved": "https://registry.npmjs.org/cloudflare/-/cloudflare-4.5.0.tgz",
       "integrity": "sha512-fPcbPKx4zF45jBvQ0z7PCdgejVAPBBCZxwqk1k7krQNfpM07Cfj97/Q6wBzvYqlWXx/zt1S9+m8vnfCe06umbQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -4293,6 +4258,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
       "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -4302,6 +4268,7 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -4321,25 +4288,29 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cloudflare/node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cloudflare/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/cloudflare/node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -4519,14 +4490,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4546,6 +4509,7 @@
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
       "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -4581,6 +4545,7 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4646,6 +4611,7 @@
       "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
       "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bundle-name": "^4.1.0",
         "default-browser-id": "^5.0.0"
@@ -4662,6 +4628,7 @@
       "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
       "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -4674,6 +4641,7 @@
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
       "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4748,17 +4716,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
@@ -4773,6 +4730,7 @@
       "resolved": "https://registry.npmjs.org/digest-fetch/-/digest-fetch-1.3.0.tgz",
       "integrity": "sha512-CGJuv6iKNM7QyZlM2T3sPAdZWd/p9zQiRNS9G+9COUCwzWFTs0Xp8NF5iePx7wtvhDykReiRRrSeNb4oMmB8lA==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "base-64": "^0.1.0",
         "md5": "^2.3.0"
@@ -4809,6 +4767,7 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
       "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4850,6 +4809,7 @@
       "resolved": "https://registry.npmjs.org/efrt/-/efrt-2.7.0.tgz",
       "integrity": "sha512-/RInbCy1d4P6Zdfa+TMVsf/ufZVotat5hCw3QXmWtjU+3pFEOvOQ7ibo3aIxyCJw2leIeAMjmPj+1SLJiCpdrQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -5047,7 +5007,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5252,13 +5211,15 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -5422,7 +5383,8 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -5818,6 +5780,7 @@
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
       "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
@@ -5833,6 +5796,7 @@
       "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "gaxios": "^5.0.0",
         "json-bigint": "^1.0.0"
@@ -5847,6 +5811,7 @@
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "debug": "4"
       },
@@ -5860,6 +5825,7 @@
       "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^5.0.0",
@@ -5876,6 +5842,7 @@
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -5890,6 +5857,7 @@
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -5910,14 +5878,16 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/gcp-metadata/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/gcp-metadata/node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -5925,6 +5895,7 @@
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -5935,6 +5906,7 @@
       "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
       "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -6139,6 +6111,7 @@
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
       "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
@@ -6156,6 +6129,7 @@
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
       "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "gaxios": "^7.0.0",
         "google-logging-utils": "^1.0.0",
@@ -6170,6 +6144,7 @@
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
       "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -6181,6 +6156,7 @@
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
       "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -6191,6 +6167,7 @@
       "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
       "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -6218,6 +6195,7 @@
       "resolved": "https://registry.npmjs.org/grad-school/-/grad-school-0.0.5.tgz",
       "integrity": "sha512-rXunEHF9M9EkMydTBux7+IryYXEZinRk6g8OBOGDBzo/qWJjhTxy86i5q7lQYpCLHN8Sqv1XX3OIOc7ka2gtvQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -6234,6 +6212,7 @@
       "resolved": "https://registry.npmjs.org/groq-sdk/-/groq-sdk-0.3.0.tgz",
       "integrity": "sha512-Cdgjh4YoSBE2X4S9sxPGXaAy1dlN4bRtAaDZ3cnq+XsxhhN9WSBeHF64l7LWwuD5ntmw7YC5Vf4Ff1oHCg1LOg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -6251,6 +6230,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
       "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -6260,6 +6240,7 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -6279,25 +6260,29 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/groq-sdk/node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/groq-sdk/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/groq-sdk/node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -6365,7 +6350,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.17.tgz",
       "integrity": "sha512-FbJJNb/XgX7YW0hX/V8w5oYLztKEsRLykCMZWt1WdLtsfjzMvmoqWBA4H4t5norinq8/rh20oiZYr+WSl4UzAQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -6398,6 +6382,7 @@
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -6411,6 +6396,7 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -6443,6 +6429,7 @@
       "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
       "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -6613,7 +6600,8 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
@@ -6636,6 +6624,7 @@
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
       "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "is-docker": "cli.js"
       },
@@ -6694,6 +6683,7 @@
       "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
       "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-docker": "^3.0.0"
       },
@@ -6750,6 +6740,7 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
       "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-inside-container": "^1.0.0"
       },
@@ -6886,7 +6877,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -7473,6 +7463,7 @@
       "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
       "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.5.1"
       }
@@ -7514,6 +7505,7 @@
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
@@ -7630,6 +7622,7 @@
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-3.3.0.tgz",
       "integrity": "sha512-kpSuLD3/7RenBnjnJdOHXCKC8dTd1JzeOiJhN0necWWci6cC+qX+VuwPnMVgb+a4+KNJSfgqahpnfWaeDXCimw==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       }
@@ -7659,6 +7652,7 @@
       "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.6.1.tgz",
       "integrity": "sha512-qNBNPRFqScIlGaPGfMrxhw/GTOL4GJKMp1P4jeA3xuI+Gkj5Ei3wvOtxpYaZMTeBbXTW3yi4n4Wf3nCgogvttg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-queue": "6.6.2"
       },
@@ -7817,7 +7811,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -7904,6 +7899,7 @@
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
       "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "charenc": "0.0.2",
         "crypt": "0.0.2",
@@ -7960,6 +7956,7 @@
       "resolved": "https://registry.npmjs.org/memjs/-/memjs-1.3.2.tgz",
       "integrity": "sha512-qUEg2g8vxPe+zPn09KidjIStHPtoBO8Cttm8bgJFWWabbsjQ9Av9Ky+6UcvKx6ue0LLb/LEhtcyQpRyKfzeXcg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8165,6 +8162,7 @@
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-9.6.1.tgz",
       "integrity": "sha512-3T8/b0plM3ZJPW3WjlzVMIGJEYYTjgDPQ05Qzru3xu3/wOPSFKWYxdwUF2dl8h3NG5dVkzIuOkZdLacnlLf/sA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "kareem": "3.3.0",
         "mongodb": "~7.2",
@@ -8186,6 +8184,7 @@
       "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
       "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/webidl-conversions": "*"
       }
@@ -8195,8 +8194,25 @@
       "resolved": "https://registry.npmjs.org/bson/-/bson-7.2.0.tgz",
       "integrity": "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/mongoose/node_modules/gcp-metadata": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
+      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/mongoose/node_modules/mongodb": {
@@ -8204,6 +8220,7 @@
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.2.0.tgz",
       "integrity": "sha512-F/2+BMZtLVhY30ioZp0dAmZ+IRZMBqI+nrv6t5+9/1AIwCa8sMRC3jBf81lpxMhnZgqq8CoUD503Z1oZWq1/sw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@mongodb-js/saslprep": "^1.3.0",
         "bson": "^7.2.0",
@@ -8250,6 +8267,7 @@
       "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz",
       "integrity": "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@types/whatwg-url": "^13.0.0",
         "whatwg-url": "^14.1.0"
@@ -8263,6 +8281,7 @@
       "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
       "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -8272,6 +8291,7 @@
       "resolved": "https://registry.npmjs.org/mquery/-/mquery-6.0.0.tgz",
       "integrity": "sha512-b2KQNsmgtkscfeDgkYMcWGn9vZI9YoXh802VDEwE6qc50zxBFQ0Oo8ROkawbPAsXCY1/Z1yp0MagqsZStPWJjw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -8287,6 +8307,7 @@
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
       "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "mustache": "bin/mustache"
       }
@@ -8302,6 +8323,7 @@
       "resolved": "https://registry.npmjs.org/natural/-/natural-8.1.1.tgz",
       "integrity": "sha512-Ucb+lsUcGxUqu3rn8cwHjT6gJQosO63nIX/aBQXB3+IDkNbFV7PuviysO+Rzz3aKn7PZhPj3bNF4PS9gDVjYCQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "afinn-165": "^2.0.2",
         "afinn-165-financialmarketnews": "^3.0.0",
@@ -8334,6 +8356,7 @@
       "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.12.1.tgz",
       "integrity": "sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 18.19.0"
       },
@@ -8371,6 +8394,7 @@
       "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.12.1.tgz",
       "integrity": "sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 18.19.0"
       },
@@ -8383,6 +8407,7 @@
       "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.12.1.tgz",
       "integrity": "sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 18.19.0"
       },
@@ -8395,6 +8420,7 @@
       "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.12.1.tgz",
       "integrity": "sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 18.19.0"
       },
@@ -8407,6 +8433,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -8434,6 +8461,7 @@
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
       "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-int8": "1.0.1",
         "postgres-array": "~2.0.0",
@@ -8450,6 +8478,7 @@
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
       "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -8459,6 +8488,7 @@
       "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
       "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8468,6 +8498,7 @@
       "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
       "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8477,6 +8508,7 @@
       "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
       "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "xtend": "^4.0.0"
       },
@@ -8489,6 +8521,7 @@
       "resolved": "https://registry.npmjs.org/redis/-/redis-5.12.1.tgz",
       "integrity": "sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@redis/bloom": "5.12.1",
         "@redis/client": "5.12.1",
@@ -8509,6 +8542,7 @@
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
+      "peer": true,
       "bin": {
         "uuid": "dist-node/bin/uuid"
       }
@@ -8662,7 +8696,8 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ollama": {
       "version": "0.5.18",
@@ -8716,6 +8751,7 @@
       "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
       "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "default-browser": "^5.2.1",
         "define-lazy-prop": "^3.0.0",
@@ -8734,7 +8770,6 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
       "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -8840,6 +8875,7 @@
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -8881,6 +8917,7 @@
       "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
       "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eventemitter3": "^4.0.4",
         "p-timeout": "^3.2.0"
@@ -8897,6 +8934,7 @@
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
       "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/retry": "0.12.0",
         "retry": "^0.13.1"
@@ -8910,6 +8948,7 @@
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
       "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-finally": "^1.0.0"
       },
@@ -8931,7 +8970,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
       "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -9061,19 +9101,22 @@
       "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
       "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/pg-connection-string": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
       "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -9083,6 +9126,7 @@
       "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
       "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -9092,6 +9136,7 @@
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
       "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "pg": ">=8.0"
       }
@@ -9100,13 +9145,15 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
       "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/pg-types": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.1.0.tgz",
       "integrity": "sha512-o2XFanIMy/3+mThw69O8d4n1E5zsLhdO+OPqswezu7Z5ekP4hYDqlDjlmOpYMbzY2Br0ufCwJLdDIXeNVwcWFg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-int8": "1.0.1",
         "pg-numeric": "1.0.2",
@@ -9125,6 +9172,7 @@
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
       "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-int8": "1.0.1",
         "postgres-array": "~2.0.0",
@@ -9141,6 +9189,7 @@
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
       "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -9150,6 +9199,7 @@
       "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
       "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9159,6 +9209,7 @@
       "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
       "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9168,6 +9219,7 @@
       "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
       "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "xtend": "^4.0.0"
       },
@@ -9180,6 +9232,7 @@
       "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
       "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "split2": "^4.1.0"
       }
@@ -9295,6 +9348,7 @@
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.4.tgz",
       "integrity": "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9304,6 +9358,7 @@
       "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
       "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "obuf": "~1.1.2"
       },
@@ -9316,6 +9371,7 @@
       "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.1.0.tgz",
       "integrity": "sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9325,6 +9381,7 @@
       "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
       "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9333,7 +9390,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.4.tgz",
       "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
@@ -9417,6 +9475,7 @@
       "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -9776,6 +9835,7 @@
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -9839,6 +9899,7 @@
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
       "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -9904,6 +9965,7 @@
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
       "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -10092,7 +10154,8 @@
       "version": "17.1.3",
       "resolved": "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz",
       "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
@@ -10184,35 +10247,13 @@
       }
     },
     "node_modules/sparrowdb": {
-      "version": "0.1.20",
-      "resolved": "https://registry.npmjs.org/sparrowdb/-/sparrowdb-0.1.20.tgz",
-      "integrity": "sha512-cC9BK8ASmL+VStCv8+qVbpdRIQ+LIYiDifrzugsaKhDLEpr511NxaZg3wJyxB1Bs2xhiiRyuzJ9jFyM8t+OOsw==",
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/sparrowdb/-/sparrowdb-0.1.27.tgz",
+      "integrity": "sha512-orOoWjIAOgaAFmE+GFxBJ9I5xYyGOM5fz0d82tzdeM/BQIwA51EQ5NLdrU8djn7YnU6b2PF2dxDqHIb4BrgG2g==",
       "license": "MIT OR Apache-2.0",
       "engines": {
         "node": ">= 18"
-      },
-      "optionalDependencies": {
-        "@sparrowdb/darwin-arm64": "0.1.20",
-        "@sparrowdb/darwin-x64": "0.1.20",
-        "@sparrowdb/linux-arm64-gnu": "0.1.20",
-        "@sparrowdb/linux-x64-gnu": "0.1.20",
-        "@sparrowdb/win32-x64-msvc": "0.1.20"
       }
-    },
-    "node_modules/sparrowdb/node_modules/@sparrowdb/darwin-arm64": {
-      "optional": true
-    },
-    "node_modules/sparrowdb/node_modules/@sparrowdb/darwin-x64": {
-      "optional": true
-    },
-    "node_modules/sparrowdb/node_modules/@sparrowdb/linux-arm64-gnu": {
-      "optional": true
-    },
-    "node_modules/sparrowdb/node_modules/@sparrowdb/linux-x64-gnu": {
-      "optional": true
-    },
-    "node_modules/sparrowdb/node_modules/@sparrowdb/win32-x64-msvc": {
-      "optional": true
     },
     "node_modules/sparse-bitfield": {
       "version": "3.0.3",
@@ -10228,6 +10269,7 @@
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">= 10.x"
       }
@@ -10280,6 +10322,7 @@
       "resolved": "https://registry.npmjs.org/stopwords-iso/-/stopwords-iso-1.1.0.tgz",
       "integrity": "sha512-I6GPS/E0zyieHehMRPQcqkiBMJKGgLta+1hREixhoLPqEA0AlVFiC43dl8uPpmkkeRdDMzYRWFWk5/l9x7nmNg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10372,7 +10415,8 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/suffix-thumb/-/suffix-thumb-5.0.2.tgz",
       "integrity": "sha512-I5PWXAFKx3FYnI9a+dQMWNqTxoRt6vdBdb0O+BJ1sxXCWtSoQCusc13E58f+9p4MYx/qCnEMkD5jac6K2j3dgA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/superagent": {
       "version": "8.1.2",
@@ -10453,6 +10497,7 @@
       "version": "0.0.21",
       "resolved": "https://registry.npmjs.org/sylvester/-/sylvester-0.0.21.tgz",
       "integrity": "sha512-yUT0ukFkFEt4nb+NY+n2ag51aS/u9UHXoZw+A4jgD77/jzZsBoSDHuqysrVCBC4CYR4TYvUJq54ONpXgDBH8tA==",
+      "peer": true,
       "engines": {
         "node": ">=0.2.6"
       }
@@ -10742,7 +10787,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10755,13 +10799,15 @@
       "version": "1.13.8",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
       "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/undici": {
       "version": "5.28.5",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
       "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },
@@ -10854,14 +10900,6 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -10918,7 +10956,8 @@
       "version": "3.6.20",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
       "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/whatwg-url": {
       "version": "14.2.0",
@@ -10963,6 +11002,7 @@
       "resolved": "https://registry.npmjs.org/wordnet-db/-/wordnet-db-3.1.14.tgz",
       "integrity": "sha512-zVyFsvE+mq9MCmwXUWHIcpfbrHHClZWZiVOzKSxNJruIcFn2RbY55zkhiAMMxM8zCVSmtNiViq8FsAZSFpMYag==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.6.0"
       }
@@ -11010,6 +11050,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -11031,6 +11072,7 @@
       "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
       "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-wsl": "^3.1.0"
       },
@@ -11046,6 +11088,7 @@
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.4"
       }
@@ -11096,17 +11139,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -11125,7 +11157,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
       "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "mongodb": "^6.0.0",
     "neo4j-driver": "^5.15.0",
     "node-fetch": "^3.3.0",
-    "sparrowdb": "^0.1.20"
+    "sparrowdb": "^0.1.27"
   },
   "devDependencies": {
     "@types/cors": "^2.8.0",

--- a/src/__tests__/SparrowDBBinding.reads.test.ts
+++ b/src/__tests__/SparrowDBBinding.reads.test.ts
@@ -17,12 +17,24 @@
  *      saw nulls, another could not reproduce them, and the reason is the real
  *      defect covered below — it is about the RETURN *alias*, not about id().
  *
- * The real defect: in a node-scan projection the engine resolves a property
- * column by its OUTPUT NAME rather than by the projected expression. So
- * `RETURN k.id AS zzz` reads a property named `zzz` (null), and
- * `RETURN k.id AS contentType` silently hands back k.contentType. Projecting
- * anything that materialises the node (`id(k)`, `labels(k)`, the variable `k`)
- * restores correct resolution, which is why `_ensureInternalIdMap` is immune.
+ * The real defect (as of 2026-07-31, sparrowdb npm 0.1.20): in a node-scan
+ * projection the engine resolves a property column by its OUTPUT NAME rather
+ * than by the projected expression. So `RETURN k.id AS zzz` read a property
+ * named `zzz` (null), and `RETURN k.id AS contentType` silently handed back
+ * k.contentType. Projecting anything that materialises the node (`id(k)`,
+ * `labels(k)`, the variable `k`) restored correct resolution, which is why
+ * `_ensureInternalIdMap` was immune.
+ *
+ * UPDATE 2026-08-17: that defect is FIXED upstream as of sparrowdb npm
+ * >=0.1.26 (SparrowDB #514, "projection resolves RETURN columns by AST expr,
+ * not display name"). This describe block's `SparrowDB = require_('sparrowdb')`
+ * had been silently `describe.skip`'d this whole time — no working native
+ * binding ever resolved locally on this machine before now — so bumping the
+ * dependency to 0.1.27 (see cli/kms.ts's native-loader fix, same PR) is what
+ * ran it for the first time. The three tests that asserted the old broken
+ * behaviour as "expected" failed as a result; their assertions were updated
+ * below to the correct, current behaviour. See inline comments for what used
+ * to happen — do not re-derive this from a test that passed on 0.1.20.
  */
 
 import { createRequire } from 'module'
@@ -156,24 +168,31 @@ describeIfBinding('sparrowdb binding — read behaviour', () => {
   })
 
   // -------------------------------------------------------------------------
-  // The defect that actually exists: RETURN aliases resolve by output name
+  // The defect that used to exist: RETURN aliases resolved by output name
+  // instead of by expression. Fixed upstream in SparrowDB #514 (sparrowdb
+  // npm >=0.1.26) — see the UPDATE note in the file header.
   // -------------------------------------------------------------------------
 
-  describe('RETURN aliases on a node scan resolve by output name, not by expression', () => {
-    it('an alias that names no property reads null', () => {
-      const rows = db.execute('MATCH (k:Knowledge) RETURN k.id AS zzz').rows
-      expect(rows).toHaveLength(2)
-      expect(rows.every(r => r['zzz'] === null)).toBe(true)
+  describe('RETURN aliases on a node scan resolve by expression, not by output name (fixed — SparrowDB #514)', () => {
+    it('an alias that names no property still resolves the projected expression', () => {
+      // Used to read null (the alias "zzz" names no real property, and
+      // resolution used to be keyed on the alias string). Now resolves k.id
+      // regardless of what the alias is spelled.
+      const rows = db.execute('MATCH (k:Knowledge) RETURN k.id AS zzz').rows.map(r => r['zzz'])
+      expect(rows.sort()).toEqual([UUID_A, UUID_B].sort())
     })
 
-    it('an alias naming a DIFFERENT property silently returns that other property', () => {
-      // The dangerous shape: this reads like "give me the id" and returns the
-      // contentType. Not an error, not a null — wrong data.
+    it('an alias naming a DIFFERENT property resolves the aliased expression, not the name it collides with', () => {
+      // Used to read like "give me the id" and silently return contentType
+      // instead — not an error, not a null, just wrong data, because
+      // resolution used to look up a property literally named "contentType".
+      // Now resolves k.id correctly no matter which property name the alias
+      // collides with.
       const row = db.execute(
         `MATCH (k:Knowledge {id: '${UUID_A}'}) RETURN k.id AS contentType`
       ).rows[0]
-      expect(row['contentType']).toBe('insight')
-      expect(row['contentType']).not.toBe(UUID_A)
+      expect(row['contentType']).toBe(UUID_A)
+      expect(row['contentType']).not.toBe('insight')
     })
 
     it('an alias equal to the property name is correct', () => {
@@ -195,7 +214,7 @@ describeIfBinding('sparrowdb binding — read behaviour', () => {
       expect(rows.sort()).toEqual([UUID_A, UUID_B].sort())
     })
 
-    it('_ensureInternalIdMap survives only because it projects id(k)', () => {
+    it('_ensureInternalIdMap no longer needs id(k) alongside it to resolve node_id correctly', () => {
       // Verbatim shape from SparrowDBStorage._ensureInternalIdMap().
       const rows = db.execute('MATCH (k:Knowledge) RETURN id(k) AS nid, k.id AS node_id').rows
       expect(rows).toHaveLength(2)
@@ -203,9 +222,11 @@ describeIfBinding('sparrowdb binding — read behaviour', () => {
         expect(typeof row['nid']).toBe('number')
         expect([UUID_A, UUID_B]).toContain(row['node_id'])
       }
-      // Drop the id(k) column and the same alias goes null.
+      // Used to go null once id(k) was dropped — that used to be the whole
+      // reason _ensureInternalIdMap carried the otherwise-unused id(k)
+      // column. Now resolves correctly with or without it.
       const stripped = db.execute('MATCH (k:Knowledge) RETURN k.id AS node_id').rows
-      expect(stripped.every(r => r['node_id'] === null)).toBe(true)
+      expect(stripped.map(r => r['node_id']).sort()).toEqual([UUID_A, UUID_B].sort())
     })
 
     it('relationship-expansion projections are unaffected by the alias defect', () => {

--- a/src/__tests__/SparrowDBStorage.resolveSparrowDBPath.test.ts
+++ b/src/__tests__/SparrowDBStorage.resolveSparrowDBPath.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Guards the single-canonical-default fix for the dual-root bug: two
+ * different defaults (`~/.kms-sparrowdb` and `~/.kms-sparrowdb-v2`) existed
+ * side by side, so `kms export`/`kms import` silently operated on a stale,
+ * five-month-old snapshot while the MCP server read/wrote the live one.
+ *
+ * Every call site that needs a SparrowDB root now goes through
+ * `resolveSparrowDBPath()` in storage/sparrowDbPath.ts instead of inlining
+ * its own `join(homedir(), '.kms-sparrowdb...')`. Three things are asserted:
+ *
+ *   1. resolveSparrowDBPath()'s precedence (explicit > $SPARROWDB_PATH >
+ *      canonical default).
+ *   2. SparrowDBStorage's constructor is wired through the SAME function —
+ *      not a second, independently-typed default. Checked by source
+ *      inspection rather than by instantiating the class: SparrowDBStorage.ts
+ *      has an unrelated, pre-existing `const __dirname =
+ *      dirname(fileURLToPath(import.meta.url))` at module scope that this
+ *      project's Jest config (CJS-executed despite the ESM preset — no
+ *      `--experimental-vm-modules`, see jest.config.js) cannot parse, so the
+ *      class itself cannot be `require`d/imported from a test today. That is
+ *      a real, separate gap this fix does not attempt to close; extracting
+ *      the resolver into the dependency-free storage/sparrowDbPath.ts (no
+ *      `import.meta.url`) is what makes THIS function testable at all.
+ *   3. A source scan: no file other than storage/sparrowDbPath.ts may
+ *      contain a hardcoded `.kms-sparrowdb` path literal. That is what
+ *      actually prevents regression — a test asserting behaviour only in
+ *      the one file that already agrees with itself proves nothing about
+ *      the other places the string used to live.
+ *
+ * Uses only temp directories / an in-memory env var — never the real
+ * ~/.kms-sparrowdb or ~/.kms-sparrowdb-v2 roots, which are live data.
+ */
+
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { DEFAULT_SPARROWDB_DIRNAME, resolveSparrowDBPath } from '../storage/sparrowDbPath.js'
+
+const ORIGINAL_SPARROWDB_PATH = process.env.SPARROWDB_PATH
+
+afterEach(() => {
+  if (ORIGINAL_SPARROWDB_PATH === undefined) delete process.env.SPARROWDB_PATH
+  else process.env.SPARROWDB_PATH = ORIGINAL_SPARROWDB_PATH
+})
+
+describe('resolveSparrowDBPath', () => {
+  it('defaults to the canonical ~/.kms-sparrowdb-v2 root when nothing else is set', () => {
+    delete process.env.SPARROWDB_PATH
+    expect(resolveSparrowDBPath()).toBe(join(homedir(), '.kms-sparrowdb-v2'))
+    expect(DEFAULT_SPARROWDB_DIRNAME).toBe('.kms-sparrowdb-v2')
+  })
+
+  it('lets $SPARROWDB_PATH override the default', () => {
+    process.env.SPARROWDB_PATH = '/tmp/kms-test-env-override'
+    expect(resolveSparrowDBPath()).toBe('/tmp/kms-test-env-override')
+  })
+
+  it('lets an explicit argument override both the env var and the default', () => {
+    process.env.SPARROWDB_PATH = '/tmp/kms-test-env-override'
+    expect(resolveSparrowDBPath('/tmp/kms-test-explicit')).toBe('/tmp/kms-test-explicit')
+  })
+
+  it('ignores an empty-string explicit argument and falls through to env/default', () => {
+    delete process.env.SPARROWDB_PATH
+    expect(resolveSparrowDBPath('')).toBe(join(homedir(), '.kms-sparrowdb-v2'))
+  })
+})
+
+describe('SparrowDBStorage constructor is wired to the shared resolver', () => {
+  // Cannot `new SparrowDBStorage()` here — see file header: the class module
+  // has an unrelated pre-existing import.meta.url usage this Jest config
+  // can't load. Assert the wiring by source inspection instead: the
+  // constructor must call resolveSparrowDBPath(config?.dbPath) and must NOT
+  // contain its own inline '.kms-sparrowdb' fallback (that inline fallback,
+  // missing the '-v2', was the actual bug).
+  const SOURCE = readFileSync(join(__dirname, '..', 'storage', 'SparrowDBStorage.ts'), 'utf8')
+
+  it('constructor delegates to resolveSparrowDBPath(config?.dbPath)', () => {
+    const ctorMatch = SOURCE.match(/constructor\(config\?: SparrowDBConfig\) \{([\s\S]*?)\n  \}/)
+    expect(ctorMatch).not.toBeNull()
+    const ctorBody = ctorMatch![1]
+    expect(ctorBody).toMatch(/resolveSparrowDBPath\(config\?\.dbPath\)/)
+    expect(ctorBody).not.toMatch(/['"`]\.kms-sparrowdb['"`]/)
+  })
+
+  it('imports resolveSparrowDBPath from the shared sparrowDbPath module', () => {
+    expect(SOURCE).toMatch(/import \{[^}]*resolveSparrowDBPath[^}]*\} from '\.\/sparrowDbPath\.js'/)
+  })
+})
+
+describe('single canonical default — no duplicated path literal anywhere else', () => {
+  // Walk src/, excluding the one file allowed to define the literal
+  // (storage/sparrowDbPath.ts) and test files, and fail if any other file
+  // hardcodes a `.kms-sparrowdb` / `.kms-sparrowdb-v2` string literal.
+  // This is the regression guard: before the fix, index.ts, cli/kms.ts
+  // (x4), scripts/backfill-hnsw-embeddings.ts, and SparrowDBStorage.ts's
+  // own constructor each carried their own copy — two different values —
+  // instead of importing a shared one.
+
+  // The test runner compiles this file to CommonJS, where `__dirname` is
+  // available (unlike `import.meta.url`, a parse error there — see
+  // SparrowDBBinding.reads.test.ts for the same workaround).
+  const SRC_ROOT = join(__dirname, '..')
+  const ALLOWED_FILE = join(SRC_ROOT, 'storage', 'sparrowDbPath.ts')
+  const LITERAL_RE = /['"`]\/?\.kms-sparrowdb(-v2)?['"`]/
+
+  function walk(dir: string, out: string[] = []): string[] {
+    for (const entry of readdirSync(dir)) {
+      const p = join(dir, entry)
+      const st = statSync(p)
+      if (st.isDirectory()) {
+        if (entry === 'node_modules' || entry === '__tests__') continue
+        walk(p, out)
+      } else if (entry.endsWith('.ts') && !entry.endsWith('.test.ts')) {
+        out.push(p)
+      }
+    }
+    return out
+  }
+
+  it('has zero hardcoded .kms-sparrowdb path literals outside sparrowDbPath.ts', () => {
+    const offenders: string[] = []
+    for (const file of walk(SRC_ROOT)) {
+      if (file === ALLOWED_FILE) continue
+      const contents = readFileSync(file, 'utf8')
+      const lines = contents.split('\n')
+      lines.forEach((line, i) => {
+        if (LITERAL_RE.test(line)) offenders.push(`${file}:${i + 1}: ${line.trim()}`)
+      })
+    }
+    expect(offenders).toEqual([])
+  })
+})

--- a/src/__tests__/kms.loadSparrowDBNative.test.ts
+++ b/src/__tests__/kms.loadSparrowDBNative.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Guards the CLI native-loader fix: `loadSparrowDBNative()` in cli/kms.ts
+ * used to resolve the native binding from three hardcoded paths inside a
+ * `~/Dev/SparrowDB` source checkout, and NEVER looked at the installed
+ * `sparrowdb` npm dependency at all. On a machine where that source-tree
+ * path happened to contain a stale build (e.g. one that predates #524's
+ * process lock), `kms export`/`kms import` would silently load it instead
+ * of the correct, installed package version — walking straight past a
+ * lock a newer binary would have respected.
+ *
+ * The fix: try the installed npm package first (a plain `require('sparrowdb')`,
+ * letting Node + the package's own platform resolution pick the right
+ * prebuilt binary), and only fall back to the source-tree dev-build paths
+ * if that fails.
+ *
+ * Uses only source inspection — cli/kms.ts has a top-level
+ * `createRequire(import.meta.url)` (same shape as SparrowDBStorage.ts's
+ * `import.meta.url` usage), which this project's Jest config (CJS-executed
+ * despite the ESM preset) cannot parse. See
+ * SparrowDBStorage.resolveSparrowDBPath.test.ts for the same precedent/
+ * workaround. Never opens a real SparrowDB database.
+ */
+
+import { join } from 'node:path'
+import { readFileSync } from 'node:fs'
+
+const SOURCE = readFileSync(join(__dirname, '..', 'cli', 'kms.ts'), 'utf8')
+
+function extractFunctionBody(source: string, name: string): string {
+  const start = source.indexOf(`async function ${name}(`)
+  expect(start).toBeGreaterThan(-1)
+  // Grab from the function's opening brace to its closing `}` at column 0,
+  // which matches this file's existing top-level-function formatting.
+  const braceIdx = source.indexOf('{', start)
+  const endMarker = source.indexOf('\n}', braceIdx)
+  expect(endMarker).toBeGreaterThan(-1)
+  return source.slice(braceIdx, endMarker)
+}
+
+describe('loadSparrowDBNative prefers the installed npm dependency', () => {
+  const body = extractFunctionBody(SOURCE, 'loadSparrowDBNative')
+
+  it('calls require(\'sparrowdb\') — not a reconstructed node_modules path or a hardcoded platform filename', () => {
+    expect(body).toMatch(/require\(\s*['"]sparrowdb['"]\s*\)/)
+    // Regression guard scoped to the npm-preferring section only (up to the
+    // source-tree fallback's `candidatePaths` array, which legitimately
+    // still names a local dev-build file `sparrowdb.node` — that generic
+    // name was removed only from the *published* package, not from the
+    // documented local `cargo build` convenience path). The npm attempt
+    // itself must never reconstruct a path into node_modules or hardcode a
+    // platform-specific filename — that would defeat the package's own
+    // platform selection (platforms.js).
+    const npmSection = body.slice(0, body.indexOf('candidatePaths'))
+    expect(npmSection).not.toMatch(/node_modules.*sparrowdb/)
+    expect(npmSection).not.toMatch(/sparrowdb\.node/)
+  })
+
+  it('tries the npm dependency before the source-tree fallback paths', () => {
+    const npmIdx = body.search(/require\(\s*['"]sparrowdb['"]\s*\)/)
+    const fallbackIdx = body.indexOf('candidatePaths')
+    expect(npmIdx).toBeGreaterThan(-1)
+    expect(fallbackIdx).toBeGreaterThan(-1)
+    expect(npmIdx).toBeLessThan(fallbackIdx)
+  })
+
+  it('keeps the source-tree paths only as a fallback (inside a try or after the npm attempt), never unconditionally', () => {
+    // The npm attempt must be inside its own try/catch so a load failure
+    // there falls through instead of throwing past the fallback logic.
+    const tryIdx = body.indexOf('try {')
+    const npmIdx = body.search(/require\(\s*['"]sparrowdb['"]\s*\)/)
+    expect(tryIdx).toBeGreaterThan(-1)
+    expect(tryIdx).toBeLessThan(npmIdx)
+  })
+
+  it('does not silently swallow the failure — some diagnostic naming what was tried precedes the null return', () => {
+    // Not asserting exact wording, only that a failure to resolve anything
+    // is reported somewhere (console.error/console.warn) before returning,
+    // rather than returning null with zero trace of what was attempted.
+    const nullReturnIdx = body.lastIndexOf('return null')
+    expect(nullReturnIdx).toBeGreaterThan(-1)
+    const beforeReturn = body.slice(0, nullReturnIdx)
+    expect(beforeReturn).toMatch(/console\.(error|warn)\(/)
+  })
+})

--- a/src/cli/kms.ts
+++ b/src/cli/kms.ts
@@ -308,6 +308,24 @@ async function cmdRoute(args: string[]) {
 // ── Shared helper: load SparrowDB native binding ──────────────────────────────
 
 async function loadSparrowDBNative(): Promise<any> {
+  // Prefer the installed npm dependency. Node's own resolution + the
+  // package's own index.js/platforms.js pick the correct prebuilt binary
+  // for this platform+arch — do not reconstruct a path into node_modules
+  // or hardcode a platform-specific filename here. Same precedent as
+  // SparrowDBStorage.ts's loadNativeBinding().
+  const attempted: string[] = []
+  try {
+    return require('sparrowdb')
+  } catch (err) {
+    attempted.push(`sparrowdb (node_modules): ${(err as Error).message.split('\n')[0]}`)
+  }
+
+  // Fall back to a local SparrowDB source-tree dev build. These paths only
+  // matter when the npm dependency isn't installed at all — they must
+  // never win over it, since an on-disk source checkout can silently be a
+  // stale build (see #524: an old binary here predates the process lock
+  // and can open a live database SparrowDB itself would refuse to touch
+  // concurrently).
   const { existsSync } = await import('node:fs')
   const candidatePaths = [
     join(homedir(), 'Dev', 'SparrowDB', 'npm', 'sparrowdb', 'sparrowdb.node'),
@@ -315,8 +333,21 @@ async function loadSparrowDBNative(): Promise<any> {
     join(homedir(), 'Dev', 'SparrowDB', 'target', 'debug', 'sparrowdb.node'),
   ]
   for (const p of candidatePaths) {
-    if (existsSync(p)) return require(p)
+    attempted.push(p)
+    if (existsSync(p)) {
+      try {
+        return require(p)
+      } catch (err) {
+        attempted.push(`  ${p}: ${(err as Error).message.split('\n')[0]}`)
+      }
+    }
   }
+
+  console.error(
+    `sparrowdb native module not found. Tried:\n${attempted.map((a) => `  - ${a}`).join('\n')}\n` +
+    `Install: npm install sparrowdb\n` +
+    `Or build locally: cargo build --release -p sparrowdb-node  in ~/Dev/SparrowDB`
+  )
   return null
 }
 

--- a/src/cli/kms.ts
+++ b/src/cli/kms.ts
@@ -31,6 +31,7 @@ const require = createRequire(import.meta.url)
 import { MongoDBStorage } from '../storage/MongoDBStorage.js'
 import type { GraphStorage } from '../types/index.js'
 import { SparrowDBStorage } from '../storage/SparrowDBStorage.js'
+import { resolveSparrowDBPath } from '../storage/sparrowDbPath.js'
 import { Mem0Storage } from '../storage/Mem0Storage.js'
 import { IntelligentStorageRouter } from '../routing/IntelligentStorageRouter.js'
 import { OllamaStorageRouter } from '../routing/OllamaStorageRouter.js'
@@ -126,7 +127,7 @@ async function getTools() {
   // Graph backend: SparrowDB (default — embedded, no Aura latency).
   // KMS_STORAGE_BACKEND env var is now a no-op kept for backwards compat;
   // SparrowDB is the only graph backend after the cutover.
-  const sparrowPath = process.env.SPARROWDB_PATH || join(homedir(), '.kms-sparrowdb-v2')
+  const sparrowPath = resolveSparrowDBPath()
   console.error(`⚡ CLI graph backend: SparrowDB (path: ${sparrowPath})`)
   const graphBackend: GraphStorage = new SparrowDBStorage({ dbPath: sparrowPath }) as GraphStorage
 
@@ -239,7 +240,7 @@ async function cmdSearch(args: string[]) {
 async function cmdPing() {
   const cfg = buildConfig()
 
-  const sparrowPath = process.env.SPARROWDB_PATH || join(homedir(), '.kms-sparrowdb-v2')
+  const sparrowPath = resolveSparrowDBPath()
 
   const checks = await Promise.allSettled([
     (async () => {
@@ -331,9 +332,7 @@ async function cmdExport(args: string[]) {
     strict: false
   })
 
-  const dbPath = (values.path as string | undefined)
-    || process.env.SPARROWDB_PATH
-    || homedir() + '/.kms-sparrowdb'
+  const dbPath = resolveSparrowDBPath(values.path as string | undefined)
 
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)
   const backupDir = homedir() + '/.kms-backups'
@@ -441,9 +440,7 @@ async function cmdImport(args: string[]) {
     strict: false
   })
 
-  const dbPath = (values.path as string | undefined)
-    || process.env.SPARROWDB_PATH
-    || homedir() + '/.kms-sparrowdb'
+  const dbPath = resolveSparrowDBPath(values.path as string | undefined)
 
   const { existsSync, mkdirSync, createReadStream, writeFileSync } = await import('node:fs')
   const readline = await import('node:readline')

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,6 @@
  * Orchestrates all components into a single, powerful MCP server
  */
 
-import { homedir } from 'node:os'
-import { join } from 'node:path'
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import {
   CallToolRequestSchema,
@@ -29,7 +27,7 @@ import { EntityLinker } from './inference/EntityLinker.js'
 import { OllamaEmbeddingService } from './embedding/EmbeddingService.js'
 import { AnthropicHaikuJudge } from './embedding/AnthropicHaikuJudge.js'
 import type { LLMJudgeService } from './embedding/LLMJudgeService.js'
-import { MongoDBStorage, Mem0Storage, SparrowDBStorage } from './storage/index.js'
+import { MongoDBStorage, Mem0Storage, SparrowDBStorage, resolveSparrowDBPath } from './storage/index.js'
 import { UnifiedStoreTool, UnifiedSearchTool, KMSInstructionsTool, DocumentStoreTool } from './tools/index.js'
 
 export class UnifiedKMSServer {
@@ -119,7 +117,7 @@ export class UnifiedKMSServer {
     // Graph backend: SparrowDB (default — embedded, ~5ms read latency).
     // Legacy Neo4j and Shadow modes were removed in the SparrowDB cutover;
     // the env vars KMS_STORAGE_BACKEND / KMS_SHADOW_MODE are now no-ops.
-    const sparrowPath = process.env.SPARROWDB_PATH || join(homedir(), '.kms-sparrowdb-v2')
+    const sparrowPath = resolveSparrowDBPath()
     console.log(`⚡ Graph backend: SparrowDB (path: ${sparrowPath})`)
     const graphBackend: GraphStorage = new SparrowDBStorage({ dbPath: sparrowPath })
     const graphBackendName = 'SparrowDB'

--- a/src/scripts/backfill-hnsw-embeddings.ts
+++ b/src/scripts/backfill-hnsw-embeddings.ts
@@ -117,6 +117,7 @@ import { join, dirname } from 'path'
 import { execSync } from 'child_process'
 
 import { OllamaEmbeddingService, type EmbeddingService } from '../embedding/EmbeddingService.js'
+import { resolveSparrowDBPath } from '../storage/sparrowDbPath.js'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -825,7 +826,7 @@ function defaultIsDaemonRunning(): boolean {
 async function main(argv: string[]): Promise<number> {
   const dryRun = argv.includes('--dry-run')
 
-  const sparrowdbPath = process.env.SPARROWDB_PATH || join(homedir(), '.kms-sparrowdb-v2')
+  const sparrowdbPath = resolveSparrowDBPath()
   const sidecarPath = join(sparrowdbPath, 'content-index.json')
   const statePath = process.env.KMS_BACKFILL_STATE_FILE || join(homedir(), '.kms-backfill-state.json')
 

--- a/src/storage/SparrowDBStorage.ts
+++ b/src/storage/SparrowDBStorage.ts
@@ -64,7 +64,7 @@
  *
  * Environment variables:
  *   KMS_STORAGE_BACKEND=sparrowdb   (switches graph backend from Neo4j to SparrowDB)
- *   SPARROWDB_PATH=/path/to/kms.db  (default: ~/.kms-sparrowdb)
+ *   SPARROWDB_PATH=/path/to/kms.db  (default: ~/.kms-sparrowdb-v2)
  */
 
 import { createRequire } from 'module'
@@ -80,6 +80,12 @@ import { PENDING_EMBEDDING_KEY, PENDING_EMBEDDER_ID_KEY } from '../embedding/Emb
 import { computeFingerprint } from '../dedup/Fingerprint.js'
 import { GraphEdgeIndex } from './GraphEdgeIndex.js'
 import { StorageSystem, UnifiedKnowledge, KnowledgeQuery, KnownPersonEntry, KnownPeopleConfig, KnowledgeFlag } from '../types/index.js'
+import { resolveSparrowDBPath, DEFAULT_SPARROWDB_DIRNAME } from './sparrowDbPath.js'
+
+// Re-exported for backward compatibility — the canonical definitions now
+// live in sparrowDbPath.ts (see that file's header for why), which has no
+// `import.meta.url` dependency and can be unit tested on its own.
+export { resolveSparrowDBPath, DEFAULT_SPARROWDB_DIRNAME }
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -130,7 +136,7 @@ interface SparrowDBModule {
 
 export interface SparrowDBConfig {
   /** Filesystem path to the database directory.
-   *  Default: $SPARROWDB_PATH env var, or ~/.kms-sparrowdb */
+   *  Default: $SPARROWDB_PATH env var, or ~/.kms-sparrowdb-v2 */
   dbPath?: string
 }
 
@@ -243,10 +249,7 @@ export class SparrowDBStorage implements StorageSystem {
   private edgeIndex: GraphEdgeIndex | null = null
 
   constructor(config?: SparrowDBConfig) {
-    this.dbPath =
-      config?.dbPath ||
-      process.env.SPARROWDB_PATH ||
-      join(homedir(), '.kms-sparrowdb')
+    this.dbPath = resolveSparrowDBPath(config?.dbPath)
     this.sidecarPath = join(this.dbPath, 'content-index.json')
   }
 

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -5,5 +5,6 @@
 export { MongoDBStorage } from './MongoDBStorage.js'
 export { Mem0Storage } from './Mem0Storage.js'
 export { SparrowDBStorage } from './SparrowDBStorage.js'
+export { resolveSparrowDBPath, DEFAULT_SPARROWDB_DIRNAME } from './sparrowDbPath.js'
 
 export type { StorageSystem } from '../types/index.js'

--- a/src/storage/sparrowDbPath.ts
+++ b/src/storage/sparrowDbPath.ts
@@ -1,0 +1,35 @@
+/**
+ * Canonical SparrowDB root-path resolution.
+ *
+ * There is exactly ONE default SparrowDB root for this codebase. Every call
+ * site that needs a path — the MCP server (index.ts), the CLI (cli/kms.ts,
+ * including `kms export`/`kms import`), the backfill script, and
+ * SparrowDBStorage's own constructor — MUST resolve it through
+ * `resolveSparrowDBPath()` rather than inlining its own
+ * `join(homedir(), '.kms-sparrowdb...')`. A second copy of the string is how
+ * a stale root silently comes back into use: before this file existed,
+ * `kms export`/`kms import` and SparrowDBStorage's own constructor default
+ * disagreed with the MCP server's default (`.kms-sparrowdb` vs
+ * `.kms-sparrowdb-v2`), so `kms export` was quietly backing up a five-month
+ * stale snapshot instead of the live database.
+ *
+ * Deliberately dependency-free (no native binding, no `import.meta.url`) so
+ * it can be imported — and unit tested — on its own without pulling in the
+ * rest of SparrowDBStorage.ts.
+ */
+
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+/** Directory name (under $HOME) of the live SparrowDB root. */
+export const DEFAULT_SPARROWDB_DIRNAME = '.kms-sparrowdb-v2'
+
+/**
+ * Resolve the SparrowDB root path with the canonical precedence:
+ *   1. an explicit path passed by the caller (e.g. a CLI --path flag)
+ *   2. $SPARROWDB_PATH
+ *   3. the canonical default, ~/.kms-sparrowdb-v2
+ */
+export function resolveSparrowDBPath(explicitPath?: string): string {
+  return explicitPath || process.env.SPARROWDB_PATH || join(homedir(), DEFAULT_SPARROWDB_DIRNAME)
+}


### PR DESCRIPTION
Follow-on to #96. **The split is my sequencing error, not a change of plan** — I merged #96 while its author was still working, so this commit landed on the branch after the PR had already closed. Opening a replacement rather than leaving it orphaned.

## What this is

`src/__tests__/SparrowDBBinding.reads.test.ts` contains a `describe` block written 2026-07-31 to *characterise* a SparrowDB bug that existed in 0.1.20: `RETURN k.id AS zzz` returned `null` because projection resolved the stored column from the **display name** rather than the AST expression.

That bug is fixed upstream — SparrowDB **#514**, shipped in 0.1.26. So with #96 raising the floor to `^0.1.27`, these assertions now fail **because the engine is correct**.

Expected values were re-derived **by hand from the fixture**, not captured from 0.1.27's output — the historical bug description is preserved in comments, matching this file's stated purpose as a record of past false claims.

**593/593 passing** after this change (was 590/593).

## Why it looked like something else first

The initial diagnosis was a *new* SparrowDB bug — `RETURN id(k), k.id` returning wrong values — and a repro was filed on SparrowDB#530. **It did not reproduce**: I ran it verbatim against published 0.1.27 and every query returned correct values. That comment has been retracted.

Root cause of the misdiagnosis is worth recording: **Jest printed mismatched code-frame snippets** — correct test titles, but the source shown beside them belonged to different, passing tests. The repro was derived from code that was not the failing assertion. Reading the test file directly rather than Jest's rendered output gave the real answer.

The general form, which this repo has now hit twice in a day: **a test failing after a dependency upgrade is not evidence of a regression until you check whether it was asserting a bug.** Six silent-wrong-answer defects were fixed between SparrowDB 0.1.20 and 0.1.27 (#444, #459, #467, #472/#479, #515, #521), so tests written against the old output *should* be expected to fail.

## Verification

Full suite 593/593. Lint remains broken on `main` (no committed ESLint config) and there is one pre-existing typecheck error in an untouched file — both predate this branch and are noted in #96.